### PR TITLE
Add TLS transport config

### DIFF
--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -157,6 +157,30 @@ class PULSAR_PUBLIC ClientConfiguration {
     bool isUseTls() const;
 
     /**
+     * Set the path to the TLS private key file.
+     *
+     * @param tlsPrivateKeyFilePath
+     */
+    ClientConfiguration& setTlsPrivateKeyFilePath(const std::string& tlsKeyFilePath);
+
+    /**
+     * @return the path to the TLS private key file
+     */
+    const std::string& getTlsPrivateKeyFilePath() const;
+
+    /**
+     * Set the path to the TLS certificate file.
+     *
+     * @param tlsCertificateFilePath
+     */
+    ClientConfiguration& setTlsCertificateFilePath(const std::string& tlsCertificateFilePath);
+
+    /**
+     * @return the path to the TLS certificate file
+     */
+    const std::string& getTlsCertificateFilePath() const;
+
+    /**
      * Set the path to the trusted TLS certificate file.
      *
      * @param tlsTrustCertsFilePath

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -82,6 +82,22 @@ ClientConfiguration& ClientConfiguration::setValidateHostName(bool validateHostN
 
 bool ClientConfiguration::isValidateHostName() const { return impl_->validateHostName; }
 
+ClientConfiguration& ClientConfiguration::setTlsPrivateKeyFilePath(const std::string& filePath) {
+    impl_->tlsPrivateKeyFilePath = filePath;
+    return *this;
+}
+
+const std::string& ClientConfiguration::getTlsPrivateKeyFilePath() const { return impl_->tlsPrivateKeyFilePath; }
+
+ClientConfiguration& ClientConfiguration::setTlsCertificateFilePath(const std::string& filePath) {
+    impl_->tlsCertificateFilePath = filePath;
+    return *this;
+}
+
+const std::string& ClientConfiguration::getTlsCertificateFilePath() const {
+    return impl_->tlsCertificateFilePath;
+}
+
 ClientConfiguration& ClientConfiguration::setTlsTrustCertsFilePath(const std::string& filePath) {
     impl_->tlsTrustCertsFilePath = filePath;
     return *this;

--- a/lib/ClientConfigurationImpl.h
+++ b/lib/ClientConfigurationImpl.h
@@ -32,6 +32,8 @@ struct ClientConfigurationImpl {
     int concurrentLookupRequest{50000};
     std::string logConfFilePath;
     bool useTls{false};
+    std::string tlsPrivateKeyFilePath;
+    std::string tlsCertificateFilePath;
     std::string tlsTrustCertsFilePath;
     bool tlsAllowInsecureConnection{false};
     unsigned int statsIntervalInSeconds{600};  // 10 minutes

--- a/lib/HTTPLookupService.cc
+++ b/lib/HTTPLookupService.cc
@@ -55,6 +55,8 @@ HTTPLookupService::HTTPLookupService(ServiceNameResolver &serviceNameResolver,
       serviceNameResolver_(serviceNameResolver),
       authenticationPtr_(authData),
       lookupTimeoutInSeconds_(clientConfiguration.getOperationTimeoutSeconds()),
+      tlsPrivateFilePath_(clientConfiguration.getTlsPrivateKeyFilePath()),
+      tlsCertificateFilePath_(clientConfiguration.getTlsCertificateFilePath()),
       tlsTrustCertsFilePath_(clientConfiguration.getTlsTrustCertsFilePath()),
       isUseTls_(clientConfiguration.isUseTls()),
       tlsAllowInsecure_(clientConfiguration.isTlsAllowInsecureConnection()),
@@ -231,6 +233,11 @@ Result HTTPLookupService::sendHTTPRequest(std::string completeUrl, std::string &
             if (authDataContent->hasDataForTls()) {
                 curl_easy_setopt(handle, CURLOPT_SSLCERT, authDataContent->getTlsCertificates().c_str());
                 curl_easy_setopt(handle, CURLOPT_SSLKEY, authDataContent->getTlsPrivateKey().c_str());
+            } else {
+                if (!tlsPrivateFilePath_.empty() && !tlsCertificateFilePath_.empty()) {
+                    curl_easy_setopt(handle, CURLOPT_SSLCERT, tlsCertificateFilePath_.c_str());
+                    curl_easy_setopt(handle, CURLOPT_SSLKEY, tlsPrivateFilePath_.c_str());
+                }
             }
         }
 

--- a/lib/HTTPLookupService.h
+++ b/lib/HTTPLookupService.h
@@ -46,6 +46,8 @@ class HTTPLookupService : public LookupService, public std::enable_shared_from_t
     ServiceNameResolver& serviceNameResolver_;
     AuthenticationPtr authenticationPtr_;
     int lookupTimeoutInSeconds_;
+    std::string tlsPrivateFilePath_;
+    std::string tlsCertificateFilePath_;
     std::string tlsTrustCertsFilePath_;
     bool isUseTls_;
     bool tlsAllowInsecure_;

--- a/lib/c/c_ClientConfiguration.cc
+++ b/lib/c/c_ClientConfiguration.cc
@@ -119,6 +119,24 @@ int pulsar_client_configuration_is_validate_hostname(pulsar_client_configuration
     return conf->conf.isValidateHostName();
 }
 
+void pulsar_client_configuration_set_tls_private_key_file_path(pulsar_client_configuration_t *conf,
+                                                               const char *tlsPrivateKeyFilePath) {
+    conf->conf.setTlsPrivateKeyFilePath(tlsPrivateKeyFilePath);
+}
+
+const char *pulsar_client_configuration_get_tls_private_key_file_path(pulsar_client_configuration_t *conf) {
+    return conf->conf.getTlsPrivateKeyFilePath().c_str();
+}
+
+void pulsar_client_configuration_set_tls_certificate_file_path(pulsar_client_configuration_t *conf,
+                                                               const char *tlsCertificateFilePath) {
+    conf->conf.setTlsCertificateFilePath(tlsCertificateFilePath);
+}
+
+const char *pulsar_client_configuration_get_tls_certificate_file_path(pulsar_client_configuration_t *conf) {
+    return conf->conf.getTlsCertificateFilePath().c_str();
+}
+
 void pulsar_client_configuration_set_tls_trust_certs_file_path(pulsar_client_configuration_t *conf,
                                                                const char *tlsTrustCertsFilePath) {
     conf->conf.setTlsTrustCertsFilePath(tlsTrustCertsFilePath);


### PR DESCRIPTION
### Motivation

Add a TLS transport config for the client.

In the old version, we can only use the TLS authentication to config the TLS transport, so we cannot use the other authentication, which is confusing, so we need to add a TLS transport config for the client, which would resolve the issue I mentioned.

When using this config with the TLS authentication, the TLS authentication config is preferred.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
