### PR TITLE
Build release artifacts

### DIFF
--- a/.github/workflows/ci-build-binary-artifacts.yaml
+++ b/.github/workflows/ci-build-binary-artifacts.yaml
@@ -1,0 +1,122 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: CI - Build binary artifacts
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  deb-packaging-x86_64:
+    name: Build Debian Package - x86_64
+    runs-on: ubuntu-20.04
+    timeout-minutes: 120
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Package Pulsar source
+        run: build-support/generate-source-archive.sh
+
+      - name: Build Debian packages
+        run: pkg/deb/docker-build-deb-x86_64.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: deb-x86_64
+          path: pkg/deb/BUILD/DEB
+
+  deb-packaging-arm64:
+    name: Build Debian Package - Arm64
+    runs-on: ubuntu-20.04
+    timeout-minutes: 120
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Package Pulsar source
+        run: build-support/generate-source-archive.sh
+
+      - name: Build Debian packages
+        run: pkg/deb/docker-build-deb-arm64.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: deb-arm64
+          path: pkg/deb/BUILD/DEB
+
+  rpm-packaging-x86_64:
+    name: Build RPM Package - x86_64
+    runs-on: ubuntu-20.04
+    timeout-minutes: 120
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Package Pulsar source
+        run: build-support/generate-source-archive.sh
+
+      - name: Build RPM packages
+        run: pkg/rpm/docker-build-rpm-x86_64.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: rpm-x86_64
+          path: pkg/rpm/RPMS
+
+  rpm-packaging-arm64:
+    name: Build RPM Package - arm64
+    runs-on: ubuntu-20.04
+    timeout-minutes: 120
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Package Pulsar source
+        run: build-support/generate-source-archive.sh
+
+      - name: Build RPM packages
+        run: pkg/rpm/docker-build-rpm-arm64.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: rpm-arm64
+          path: pkg/rpm/RPMS

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Build Debian packages
         run: |
           echo "Build Debian packages"
-          BUILD_IMAGE=1 pkg/deb/docker-build-deb.sh
+          BUILD_IMAGE=1 pkg/deb/docker-build-deb-x86_64.sh
 
   rpm-packaging:
     name: Build RPM Package
@@ -181,7 +181,7 @@ jobs:
       - name: Build RPM packages
         run: |
           echo "Build RPM packages"
-          BUILD_IMAGE=1 pkg/rpm/docker-build-rpm.sh
+          BUILD_IMAGE=1 pkg/rpm/docker-build-rpm-x86_64.sh
 
 #  apk-packaging:
 #    name: Build Alpine Linux APK Package

--- a/pkg/deb/Dockerfile
+++ b/pkg/deb/Dockerfile
@@ -19,7 +19,9 @@
 
 # Build pulsar client library in Centos with tools to
 
-FROM --platform=linux/amd64 debian:9
+FROM debian:9
+
+ARG PLATFORM
 
 # perl is required to install OpenSSL
 RUN apt-get update -y && \
@@ -33,11 +35,11 @@ RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/
     ./b2 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
     rm -rf /boost_1_79_0.tar.gz /boost_1_79_0
 
-RUN curl -O -L https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-x86_64.tar.gz && \
-    tar xfz cmake-3.24.0-linux-x86_64.tar.gz && \
-    cp cmake-3.24.0-linux-x86_64/bin/* /usr/bin/ && \
-    cp -r cmake-3.24.0-linux-x86_64/share/cmake-3.24 /usr/share/ && \
-    rm -rf cmake-3.24.0-linux-x86_64 cmake-3.24.0-linux-x86_64.tar.gz
+RUN curl -O -L https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-${PLATFORM}.tar.gz && \
+    tar xfz cmake-3.24.0-linux-${PLATFORM}.tar.gz && \
+    cp cmake-3.24.0-linux-${PLATFORM}/bin/* /usr/bin/ && \
+    cp -r cmake-3.24.0-linux-${PLATFORM}/share/cmake-3.24 /usr/share/ && \
+    rm -rf cmake-3.24.0-linux-${PLATFORM} cmake-3.24.0-linux-${PLATFORM}.tar.gz
 
 # Download and copile protoubf
 RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.20.0/protobuf-cpp-3.20.0.tar.gz && \
@@ -74,7 +76,7 @@ RUN curl -O -L https://github.com/google/snappy/releases/download/1.1.3/snappy-1
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz && \
     tar xfz OpenSSL_1_1_1n.tar.gz && \
     cd openssl-OpenSSL_1_1_1n/ && \
-    ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
+    ./Configure -fPIC --prefix=/usr/local/ssl/ linux-${PLATFORM} && \
     make -j8 && make install && \
     rm -rf /OpenSSL_1_1_1n.tar.gz /openssl-OpenSSL_1_1_1n
 

--- a/pkg/deb/build-deb.sh
+++ b/pkg/deb/build-deb.sh
@@ -51,7 +51,7 @@ cat <<EOF > $DEST_DIR/DEBIAN/control
 Package: apache-pulsar-client
 Version: ${VERSION}
 Maintainer: Apache Pulsar <dev@pulsar.apache.org>
-Architecture: amd64
+Architecture: ${PLATFORM}
 Description: The Apache Pulsar client contains a C++ and C APIs to interact with Apache Pulsar brokers.
 EOF
 
@@ -61,7 +61,7 @@ cat <<EOF > $DEVEL_DEST_DIR/DEBIAN/control
 Package: apache-pulsar-client-dev
 Version: ${VERSION}
 Maintainer: Apache Pulsar <dev@pulsar.apache.org>
-Architecture: amd64
+Architecture: ${PLATFORM}
 Depends: apache-pulsar-client
 Description: The Apache Pulsar client contains a C++ and C APIs to interact with Apache Pulsar brokers.
 EOF

--- a/pkg/deb/create-images.sh
+++ b/pkg/deb/create-images.sh
@@ -18,26 +18,15 @@
 # under the License.
 #
 
-set -e
+set -e -x
 
-cd /pulsar-client-cpp
-ROOT_DIR=$(pwd)
-cd $ROOT_DIR/pkg/rpm
+ROOT_DIR=$(git rev-parse --show-toplevel)
+cd $ROOT_DIR/pkg/deb
 
-POM_VERSION=`cat $ROOT_DIR/version.txt | xargs`
+# ARM
+IMAGE=apachepulsar/pulsar-build:debian-9-2.11-arm64
+docker build --platform arm64 -t $IMAGE . --build-arg PLATFORM=aarch64
 
-# Sanitize VERSION by removing `-incubating` since it's not legal in RPM
-VERSION=`echo $POM_VERSION | awk -F-  '{print $1}'`
-
-mkdir -p BUILD RPMS SOURCES SPECS SRPMS
-
-cp $ROOT_DIR/apache-pulsar-client-cpp-$POM_VERSION.tar.gz SOURCES
-
-rpmbuild -v -bb --clean \
-        --define "version $VERSION" \
-        --define "pom_version $POM_VERSION" \
-        --define "_topdir $PWD" \
-        SPECS/pulsar-client.spec
-
-cd RPMS/${PLATFORM}
-createrepo .
+# X86_64
+IMAGE=apachepulsar/pulsar-build:debian-9-2.11-x86_64
+docker build --platform x86_64 -t $IMAGE . --build-arg PLATFORM=x86_64

--- a/pkg/deb/docker-build-deb-arm64.sh
+++ b/pkg/deb/docker-build-deb-arm64.sh
@@ -22,8 +22,10 @@ set -ex
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
-IMAGE_NAME=apachepulsar/pulsar-build:debian-9-2.11-x86_64
+IMAGE_NAME=apachepulsar/pulsar-build:debian-9-2.11-arm64
 
 docker pull $IMAGE_NAME
-docker run -v $ROOT_DIR:/pulsar-client-cpp $IMAGE_NAME \
+docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        --env PLATFORM=arm64 \
+        $IMAGE_NAME \
         /pulsar-client-cpp/pkg/deb/build-deb.sh

--- a/pkg/deb/docker-build-deb-x86_64.sh
+++ b/pkg/deb/docker-build-deb-x86_64.sh
@@ -18,26 +18,14 @@
 # under the License.
 #
 
-set -e
+set -ex
 
-cd /pulsar-client-cpp
-ROOT_DIR=$(pwd)
-cd $ROOT_DIR/pkg/rpm
+ROOT_DIR=$(git rev-parse --show-toplevel)
 
-POM_VERSION=`cat $ROOT_DIR/version.txt | xargs`
+IMAGE_NAME=apachepulsar/pulsar-build:debian-9-2.11-x86_64
 
-# Sanitize VERSION by removing `-incubating` since it's not legal in RPM
-VERSION=`echo $POM_VERSION | awk -F-  '{print $1}'`
-
-mkdir -p BUILD RPMS SOURCES SPECS SRPMS
-
-cp $ROOT_DIR/apache-pulsar-client-cpp-$POM_VERSION.tar.gz SOURCES
-
-rpmbuild -v -bb --clean \
-        --define "version $VERSION" \
-        --define "pom_version $POM_VERSION" \
-        --define "_topdir $PWD" \
-        SPECS/pulsar-client.spec
-
-cd RPMS/${PLATFORM}
-createrepo .
+docker pull $IMAGE_NAME
+docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        --env PLATFORM=amd64 \
+        $IMAGE_NAME \
+        /pulsar-client-cpp/pkg/deb/build-deb.sh

--- a/pkg/rpm/Dockerfile
+++ b/pkg/rpm/Dockerfile
@@ -21,9 +21,11 @@
 
 FROM centos:7
 
+ARG PLATFORM
+
 RUN yum update -y && \
     yum install -y gcc-c++ make rpm-build which \
-                createrepo libstdc++-static.x86_64 python3
+                createrepo libstdc++-static python3
 
 # Download and compile boost
 # GCC 4.8.2 implementation of std::regex is buggy, so we install boost::regex here
@@ -34,11 +36,11 @@ RUN curl -O -L https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/
     ./b2 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
     rm -rf /boost_1_79_0.tar.gz /boost_1_79_0
 
-RUN curl -O -L https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-x86_64.tar.gz && \
-    tar xfz cmake-3.24.0-linux-x86_64.tar.gz && \
-    cp cmake-3.24.0-linux-x86_64/bin/* /usr/bin/ && \
-    cp -r cmake-3.24.0-linux-x86_64/share/cmake-3.24 /usr/share/ && \
-    rm -rf cmake-3.24.0-linux-x86_64 cmake-3.24.0-linux-x86_64.tar.gz
+RUN curl -O -L https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-${PLATFORM}.tar.gz && \
+    tar xfz cmake-3.24.0-linux-${PLATFORM}.tar.gz && \
+    cp cmake-3.24.0-linux-${PLATFORM}/bin/* /usr/bin/ && \
+    cp -r cmake-3.24.0-linux-${PLATFORM}/share/cmake-3.24 /usr/share/ && \
+    rm -rf cmake-3.24.0-linux-${PLATFORM} cmake-3.24.0-linux-${PLATFORM}.tar.gz
 
 # Download and copile protoubf
 RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.20.0/protobuf-cpp-3.20.0.tar.gz && \
@@ -75,7 +77,7 @@ RUN curl -O -L https://github.com/google/snappy/releases/download/1.1.3/snappy-1
 RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz && \
     tar xfz OpenSSL_1_1_1n.tar.gz && \
     cd openssl-OpenSSL_1_1_1n/ && \
-    ./Configure -fPIC --prefix=/usr/local/ssl/ linux-x86_64 && \
+    ./Configure -fPIC --prefix=/usr/local/ssl/ linux-${PLATFORM} && \
     make -j8 && make install && \
     rm -rf /OpenSSL_1_1_1n.tar.gz /openssl-OpenSSL_1_1_1n
 

--- a/pkg/rpm/create-images.sh
+++ b/pkg/rpm/create-images.sh
@@ -18,26 +18,15 @@
 # under the License.
 #
 
-set -e
+set -e -x
 
-cd /pulsar-client-cpp
-ROOT_DIR=$(pwd)
+ROOT_DIR=$(git rev-parse --show-toplevel)
 cd $ROOT_DIR/pkg/rpm
 
-POM_VERSION=`cat $ROOT_DIR/version.txt | xargs`
+# ARM
+IMAGE=apachepulsar/pulsar-build:centos-7-2.11-arm64
+docker build --platform arm64 -t $IMAGE . --build-arg PLATFORM=aarch64
 
-# Sanitize VERSION by removing `-incubating` since it's not legal in RPM
-VERSION=`echo $POM_VERSION | awk -F-  '{print $1}'`
-
-mkdir -p BUILD RPMS SOURCES SPECS SRPMS
-
-cp $ROOT_DIR/apache-pulsar-client-cpp-$POM_VERSION.tar.gz SOURCES
-
-rpmbuild -v -bb --clean \
-        --define "version $VERSION" \
-        --define "pom_version $POM_VERSION" \
-        --define "_topdir $PWD" \
-        SPECS/pulsar-client.spec
-
-cd RPMS/${PLATFORM}
-createrepo .
+# X86_64
+IMAGE=apachepulsar/pulsar-build:centos-7-2.11-x86_64
+docker build --platform x86_64 -t $IMAGE . --build-arg PLATFORM=x86_64

--- a/pkg/rpm/docker-build-rpm-arm64.sh
+++ b/pkg/rpm/docker-build-rpm-arm64.sh
@@ -20,10 +20,13 @@
 
 set -ex
 
-ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. &> /dev/null && pwd )"
-IMAGE_NAME=apachepulsar/pulsar-build:centos-7-2.11-x86_64
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+IMAGE_NAME=apachepulsar/pulsar-build:centos-7-2.11-arm64
 
 docker pull $IMAGE_NAME
 
-docker run -v $ROOT_DIR:/pulsar-client-cpp $IMAGE_NAME \
+docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        --env PLATFORM=aarch64 \
+        $IMAGE_NAME \
         /pulsar-client-cpp/pkg/rpm/build-rpm.sh

--- a/pkg/rpm/docker-build-rpm-x86_64.sh
+++ b/pkg/rpm/docker-build-rpm-x86_64.sh
@@ -18,26 +18,15 @@
 # under the License.
 #
 
-set -e
+set -ex
 
-cd /pulsar-client-cpp
-ROOT_DIR=$(pwd)
-cd $ROOT_DIR/pkg/rpm
+ROOT_DIR=$(git rev-parse --show-toplevel)
 
-POM_VERSION=`cat $ROOT_DIR/version.txt | xargs`
+IMAGE_NAME=apachepulsar/pulsar-build:centos-7-2.11-x86_64
 
-# Sanitize VERSION by removing `-incubating` since it's not legal in RPM
-VERSION=`echo $POM_VERSION | awk -F-  '{print $1}'`
+docker pull $IMAGE_NAME
 
-mkdir -p BUILD RPMS SOURCES SPECS SRPMS
-
-cp $ROOT_DIR/apache-pulsar-client-cpp-$POM_VERSION.tar.gz SOURCES
-
-rpmbuild -v -bb --clean \
-        --define "version $VERSION" \
-        --define "pom_version $POM_VERSION" \
-        --define "_topdir $PWD" \
-        SPECS/pulsar-client.spec
-
-cd RPMS/${PLATFORM}
-createrepo .
+docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        --env PLATFORM=x86_64 \
+        $IMAGE_NAME \
+        /pulsar-client-cpp/pkg/rpm/build-rpm.sh


### PR DESCRIPTION
### Motivation

When we push a tag, trigger a job that builds RPM/Deb packages for both x86_64 and arm64 and uploads them as artifacts.

The release manager can then fetch the binaries when preparing a release.