### PR TITLE
Generate and install pulsarStaticWithDeps into correct paths

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -141,12 +141,14 @@ if (LINK_STATIC AND BUILD_STATIC_LIB)
             endif()
         endforeach()
 
+        set(PULSAR_WITH_DEPS ${CMAKE_BINARY_DIR}/lib/libpulsarwithdeps.a)
         add_custom_target(pulsarStaticWithDeps
                 ALL
                 BYPRODUCTS merged-library
-                COMMAND ./build-support/merge_archives.sh libpulsar.a $<TARGET_FILE:pulsarStatic> ${STATIC_LIBS} && mv merged-library/libpulsar.a lib/libpulsarwithdeps.a
+                COMMAND ./build-support/merge_archives.sh libpulsar.a $<TARGET_FILE:pulsarStatic> ${STATIC_LIBS} && mv merged-library/libpulsar.a ${PULSAR_WITH_DEPS}
                 DEPENDS pulsarStatic
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+        install(PROGRAMS ${PULSAR_WITH_DEPS} DESTINATION lib)
     endif(MSVC)
 elseif(BUILD_STATIC_LIB)
     # Install regular libpulsar.a


### PR DESCRIPTION
### Motivation

Currently, the `pulsarStaticWithDeps` target (`libpulsarwithdeps.a`) is generated under the `./lib` directory relative to the project root path. However, if the cmake build directory is customized, e.g. `cmake -B build`, the `libpulsarwithdeps.a` is still generated under `lib/`, not `build/lib`.

In addition, the install target doesn't install the `libpulsarwithdeps.a` except for MSVC build.

### Modification

Modify the `lib/CMakeLists.txt` to:
- generate `libpulsarwithdeps.a` under the CMake build directory
- add `libpulsarwithdeps.a` to the install target

### Verification

Run the following commands:

```bash
cmake -DLINK_STATIC=ON -DCMAKE_INSTALL_PREFIX=/tmp/pulsar-cpp -B build
cmake --build build --target install
```

We can see the following files generated and installed:

```bash
$ ls -1 build/lib/libpulsar*
build/lib/libpulsar.a
build/lib/libpulsar.dylib
build/lib/libpulsarnossl.dylib
build/lib/libpulsarwithdeps.a
$ ls -1 /tmp/pulsar-cpp/lib
libpulsar.a
libpulsar.dylib
libpulsarnossl.dylib
libpulsarwithdeps.a
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
