### PR TITLE
[feat] Expose start message id inclusive configuration to C API

### DIFF
--- a/include/pulsar/c/consumer_configuration.h
+++ b/include/pulsar/c/consumer_configuration.h
@@ -297,6 +297,12 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_auto_ack_oldest_chunked_mes
 PULSAR_PUBLIC int pulsar_consumer_configuration_is_auto_ack_oldest_chunked_message_on_queue_full(
     pulsar_consumer_configuration_t *consumer_configuration);
 
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_start_message_id_inclusive(
+    pulsar_consumer_configuration_t *consumer_configuration, int start_message_id_inclusive);
+
+PULSAR_PUBLIC int pulsar_consumer_configuration_is_start_message_id_inclusive(
+    pulsar_consumer_configuration_t *consumer_configuration);
+
 // const CryptoKeyReaderPtr getCryptoKeyReader()
 //
 // const;

--- a/lib/c/c_ConsumerConfiguration.cc
+++ b/lib/c/c_ConsumerConfiguration.cc
@@ -217,3 +217,13 @@ int pulsar_consumer_configuration_is_auto_ack_oldest_chunked_message_on_queue_fu
     pulsar_consumer_configuration_t *consumer_configuration) {
     return consumer_configuration->consumerConfiguration.isAutoAckOldestChunkedMessageOnQueueFull();
 }
+
+void pulsar_consumer_configuration_set_start_message_id_inclusive(
+    pulsar_consumer_configuration_t *consumer_configuration, int start_message_id_inclusive) {
+    consumer_configuration->consumerConfiguration.setStartMessageIdInclusive(start_message_id_inclusive);
+}
+
+int pulsar_consumer_configuration_is_start_message_id_inclusive(
+    pulsar_consumer_configuration_t *consumer_configuration) {
+    return consumer_configuration->consumerConfiguration.isStartMessageIdInclusive();
+}

--- a/tests/c/c_ConsumerConfigurationTest.cc
+++ b/tests/c/c_ConsumerConfigurationTest.cc
@@ -31,4 +31,7 @@ TEST(C_ConsumerConfigurationTest, testCApiConfig) {
     pulsar_consumer_configuration_set_auto_ack_oldest_chunked_message_on_queue_full(consumer_conf, 1);
     ASSERT_EQ(pulsar_consumer_configuration_is_auto_ack_oldest_chunked_message_on_queue_full(consumer_conf),
               1);
+
+    pulsar_consumer_configuration_set_start_message_id_inclusive(consumer_conf, 1);
+    ASSERT_EQ(pulsar_consumer_configuration_is_start_message_id_inclusive(consumer_conf), 1);
 }


### PR DESCRIPTION
### Motivation

Expose start message id inclusive configuration to C API

### Modifications

* Expose `start_message_id_inclusive` to C API.
* Add unit tests for C API of producer configuration and consumer configuration.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
