### PR TITLE
Removed extra call of `find_package(OpenSSL)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,6 @@ add_definitions(-DLOG_CATEGORY_NAME=${LOG_CATEGORY_NAME} -DBUILDING_PULSAR -DBOO
 
 set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/lib64/)
 
-find_package(OpenSSL REQUIRED)
 ### This part is to find and keep SSL dynamic libs in RECORD_OPENSSL_SSL_LIBRARY and RECORD_OPENSSL_CRYPTO_LIBRARY
 ### After find the libs, will unset related cache, and will not affect another same call to find_package.
 if (APPLE)


### PR DESCRIPTION
### Motivation

There is an extra call to `find_package(OpenSSL)` that will make cmake to fail on MacOS since the non-standard paths are not specified yet.