### PR TITLE
Link to OpenSSL statically when LINK_STATIC is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,45 +122,28 @@ endif(NOT LOG_CATEGORY_NAME)
 
 add_definitions(-DLOG_CATEGORY_NAME=${LOG_CATEGORY_NAME} -DBUILDING_PULSAR -DBOOST_ALL_NO_LIB -DBOOST_ALLOW_DEPRECATED_HEADERS)
 
-set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/lib64/)
-
-### This part is to find and keep SSL dynamic libs in RECORD_OPENSSL_SSL_LIBRARY and RECORD_OPENSSL_CRYPTO_LIBRARY
-### After find the libs, will unset related cache, and will not affect another same call to find_package.
-if (APPLE)
-    set(OPENSSL_INCLUDE_DIR /usr/local/opt/openssl/include/ /opt/homebrew/opt/openssl/include)
-    set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/local/opt/openssl/ /opt/homebrew/opt/openssl)
-endif ()
-
-set(OPENSSL_USE_STATIC_LIBS FALSE)
-find_package(OpenSSL REQUIRED)
-set(RECORD_OPENSSL_SSL_LIBRARY ${OPENSSL_SSL_LIBRARY})
-set(RECORD_OPENSSL_CRYPTO_LIBRARY ${OPENSSL_CRYPTO_LIBRARY})
-message("RECORD_OPENSSL_SSL_LIBRARY: " ${RECORD_OPENSSL_SSL_LIBRARY})
-message("RECORD_OPENSSL_CRYPTO_LIBRARY: " ${RECORD_OPENSSL_CRYPTO_LIBRARY})
-
-unset(OPENSSL_FOUND CACHE)
-unset(OPENSSL_INCLUDE_DIR CACHE)
-unset(OPENSSL_CRYPTO_LIBRARY CACHE)
-unset(OPENSSL_CRYPTO_LIBRARIES CACHE)
-unset(OPENSSL_SSL_LIBRARY CACHE)
-unset(OPENSSL_SSL_LIBRARIES CACHE)
-unset(OPENSSL_LIBRARIES CACHE)
-unset(OPENSSL_VERSION CACHE)
-
-find_package(OpenSSL REQUIRED)
-message("OPENSSL_INCLUDE_DIR: " ${OPENSSL_INCLUDE_DIR})
-message("OPENSSL_SSL_LIBRARY: " ${OPENSSL_SSL_LIBRARY})
-message("OPENSSL_CRYPTO_LIBRARY: " ${OPENSSL_CRYPTO_LIBRARY})
-
 # For dependencies other than OpenSSL, dynamic libraries are forbidden to link when LINK_STATIC is ON
 if (LINK_STATIC)
     if (NOT MSVC)
         set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
     endif()
+    set(Boost_USE_STATIC_LIBS TRUE)
+    set(OPENSSL_USE_STATIC_LIBS TRUE)
+else ()
+    set(Boost_USE_STATIC_LIBS FALSE)
+    set(OPENSSL_USE_STATIC_LIBS FALSE)
 endif ()
 
 find_package(Boost REQUIRED)
 message("Boost_INCLUDE_DIRS: " ${Boost_INCLUDE_DIRS})
+
+set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/lib64/)
+if (APPLE)
+    set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/local/opt/openssl/ /opt/homebrew/opt/openssl)
+endif ()
+find_package(OpenSSL REQUIRED)
+message("OPENSSL_INCLUDE_DIR: " ${OPENSSL_INCLUDE_DIR})
+message("OPENSSL_LIBRARIES: " ${OPENSSL_LIBRARIES})
 
 find_package(Protobuf REQUIRED)
 message("Protobuf_INCLUDE_DIRS: " ${Protobuf_INCLUDE_DIRS})
@@ -217,9 +200,6 @@ if (LINK_STATIC)
     if (MSVC)
         add_definitions(-DCURL_STATICLIB)
     endif()
-
-    SET(Boost_USE_STATIC_LIBS   ON)
-    SET(OPENSSL_USE_STATIC_LIBS TRUE)
 else()
     if (MSVC AND (${CMAKE_BUILD_TYPE} STREQUAL Debug))
         find_library(LIB_ZSTD zstdd HINTS "${VCPKG_DEBUG_ROOT}/lib")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -72,25 +72,6 @@ if(HAVE_AUXV_GETAUXVAL)
     add_definitions(-DPULSAR_AUXV_GETAUXVAL_PRESENT)
 endif()
 
-### pulsarSharedNossl not static link ssl, it could avoid rebuild libpulsar when ssl lib need update.
-### pulsarSharedNossl is build under condition LINK_STATIC=ON, we should replace static ssl libs with dynamic libs.
-SET(COMMON_LIBS_NOSSL ${COMMON_LIBS})
-if (NOT ${RECORD_OPENSSL_SSL_LIBRARY} MATCHES ".+\\.a$")
-    LIST(REMOVE_ITEM COMMON_LIBS_NOSSL ${OPENSSL_SSL_LIBRARY})
-    LIST(APPEND COMMON_LIBS_NOSSL ${RECORD_OPENSSL_SSL_LIBRARY})
-endif ()
-if (NOT ${RECORD_OPENSSL_CRYPTO_LIBRARY} MATCHES ".+\\.a$")
-    LIST(REMOVE_ITEM COMMON_LIBS_NOSSL  ${OPENSSL_CRYPTO_LIBRARY})
-    LIST(APPEND COMMON_LIBS_NOSSL ${RECORD_OPENSSL_CRYPTO_LIBRARY})
-endif ()
-
-if (BUILD_DYNAMIC_LIB AND LINK_STATIC)
-    add_library(pulsarSharedNossl SHARED $<TARGET_OBJECTS:PULSAR_OBJECT_LIB>)
-    set_property(TARGET pulsarSharedNossl PROPERTY OUTPUT_NAME ${LIB_NAME_SHARED}nossl)
-    set_property(TARGET pulsarSharedNossl PROPERTY VERSION ${LIBRARY_VERSION})
-    target_link_libraries(pulsarSharedNossl ${COMMON_LIBS_NOSSL} ${CMAKE_DL_LIBS})
-endif()
-
 if (BUILD_STATIC_LIB)
     add_library(pulsarStatic STATIC $<TARGET_OBJECTS:PULSAR_OBJECT_LIB>)
     if (MSVC)
@@ -136,7 +117,7 @@ if (LINK_STATIC AND BUILD_STATIC_LIB)
         # Build a list of the requird .a libs (except ssl) to merge
         SET(STATIC_LIBS "")
         foreach (LIB IN LISTS COMMON_LIBS)
-            if (${LIB} MATCHES ".+\\.a$" AND NOT ${LIB} MATCHES ${OPENSSL_SSL_LIBRARY} AND NOT ${LIB} MATCHES ${OPENSSL_CRYPTO_LIBRARY})
+            if (${LIB} MATCHES ".+\\.a$")
                 set(STATIC_LIBS "${STATIC_LIBS} ${LIB}")
             endif()
         endforeach()
@@ -162,10 +143,6 @@ endif()
 
 if (BUILD_DYNAMIC_LIB)
     install(TARGETS pulsarShared RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
-endif()
-
-if (BUILD_DYNAMIC_LIB AND LINK_STATIC)
-    install(TARGETS pulsarSharedNossl RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 endif()
 
 install(DIRECTORY "../include/pulsar" DESTINATION include)


### PR DESCRIPTION
### Motivation

See discussions here: https://github.com/apache/pulsar-client-cpp/pull/28#issuecomment-1272588627

The original purpose to not include static OpenSSL library in `libpulsarwithnossl.so` and `libpulsarwithdeps.a` is https://github.com/apache/pulsar/pull/6458. However, the ABI compatibility of OpenSSL is not good. If the Pulsar C++ library links dynamically to OpenSSL and the user only changes the OpenSSL dynamic library, some symbols might not be found.

### Modifications

Use `LINK_STATIC` option to determine whether to link to OpenSSL library statically. After that, there are only 3 libraries generated when `LINK_STATIC` is ON.
- `libpulsar.so`: the dynamic pulsar-client-cpp library.
- `libpulsar.a`: the static pulsar-client-cpp library. When it's used, users must link to all 3rd party dependencies (OpenSSL, curl, etc.)
- `libpulsarwithdeps.a`: the static pulsar-client-cpp library.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
