### PR TITLE
Fix incorrect path in docker scripts

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -24,7 +24,7 @@
 set -e
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
-cd $ROOT_DIR/pulsar-client-cpp
+cd $ROOT_DIR
 
 BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-20.04}"
@@ -35,8 +35,8 @@ echo "---- Build Pulsar C++ client using image $IMAGE (pass <skip-clean> for inc
 
 docker pull $IMAGE
 
-VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
-COMMAND="cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make -j8"
+VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar-client-cpp"}
+COMMAND="cd /pulsar-client-cpp && cmake . $CMAKE_ARGS && make check-format && make -j8"
 
 DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
 

--- a/docker-format.sh
+++ b/docker-format.sh
@@ -24,7 +24,7 @@
 set -e
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
-cd $ROOT_DIR/pulsar-client-cpp
+cd $ROOT_DIR
 
 BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-20.04}"
@@ -35,8 +35,8 @@ echo "---- Build Pulsar C++ client using image $IMAGE"
 
 docker pull $IMAGE
 
-VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar"}
-COMMAND="cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make format"
+VOLUME_OPTION=${VOLUME_OPTION:-"-v $ROOT_DIR:/pulsar-client-cpp"}
+COMMAND="cd /pulsar-client-cpp && cmake . $CMAKE_ARGS && make format"
 
 DOCKER_CMD="docker run -i ${VOLUME_OPTION} ${IMAGE}"
 

--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -31,7 +31,7 @@ fi
 
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
-cd $ROOT_DIR/pulsar-client-cpp
+cd $ROOT_DIR
 
 BUILD_IMAGE_NAME="${BUILD_IMAGE_NAME:-apachepulsar/pulsar-build}"
 BUILD_IMAGE_VERSION="${BUILD_IMAGE_VERSION:-ubuntu-20.04}"

--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -44,7 +44,7 @@ docker pull $IMAGE
 
 CONTAINER_LABEL="pulsartests=$$"
 export GTEST_COLOR=${GTEST_COLOR:-no}
-DOCKER_CMD="docker run -e GTEST_COLOR -i -l $CONTAINER_LABEL -v $ROOT_DIR:/pulsar $IMAGE"
+DOCKER_CMD="docker run -e GTEST_COLOR -i -l $CONTAINER_LABEL -v $ROOT_DIR:/pulsar-client-cpp $IMAGE"
 
 
 for args in "$@"
@@ -68,7 +68,7 @@ fi
 
 # Java17 is required for CLI e.g) bin/pulsar create-token
 $DOCKER_CMD bash -c "apt-get -y install openjdk-17-jre-headless &&\
- set -o pipefail; cd /pulsar/pulsar-client-cpp && ./run-unit-tests.sh ${tests} $DISABLE_COLOR_OUTPUT"
+ set -o pipefail; cd /pulsar-client-cpp && git config --global --add safe.directory /pulsar-client-cpp && ./run-unit-tests.sh ${tests} $DISABLE_COLOR_OUTPUT"
 RES=$?
 if [ $RES -ne 0 ]; then
   (


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

Currently, the `docker-*.sh` are using the incorrect project root path. Need to fix thems.

### Modifications

* Fix the incorrect path

We need to add `git config --global --add safe.directory /pulsar-client-cpp` to the `docker-test.sh` otherwise it will throw:
```
fatal: unsafe repository ('/pulsar-client-cpp' is owned by someone else)
To add an exception for this directory, call:

        git config --global --add safe.directory /pulsar-client-cpp
```
This started appearing with the release of the Git 2.35.2 security update which fixes vulnerabilities described [here](https://github.blog/2022-04-12-git-security-vulnerability-announced/). [FYI](https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
