### PR TITLE
[docs] Fix compilation guidance on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Run unit tests:
 #### Install all dependencies:
 
 ```shell
-apt-get install -y g++ cmake libssl-dev libcurl4-openssl-dev liblog4cxx-dev \
-                libprotobuf-dev libboost-all-dev  libgtest-dev google-mock \
-                protobuf-compiler python3-setuptools
+apt-get install -y g++ cmake libssl-dev libcurl4-openssl-dev \
+                libprotobuf-dev libboost-all-dev libgtest-dev google-mock \
+                protobuf-compiler
 ```
 
 #### Compile and install Google Test:
@@ -105,8 +105,7 @@ sudo cmake .
 sudo make
 
 # Copy the libraries you just built to the OS library path.
-# GTEST_LIB_PATH may be `/usr/src/gtest`, `/usr/src/gtest/lib` or other path you provided when building gtest above.
-sudo cp ${GTEST_LIB_PATH}/*.a /usr/lib
+sudo cp lib/*.a /usr/lib
 ```
 
 
@@ -117,9 +116,10 @@ cd /usr/src/gmock
 sudo cmake .
 sudo make
 
-# Copy the libraries you just built to the OS library path.
-# GMOCK_LIB_PATH may be `/usr/src/gmock`, `/usr/src/gmock/lib` or other path you provided when building gmock above.
-sudo cp ${GMOCK_LIB_PATH}/*.a /usr/lib
+# Copy the gmock headers to the OS include path.
+sudo cp -r include/gmock /usr/include/
+# Copy the libraries you just built to the OS brary path.
+sudo cp lib/*.a /usr/lib
 ```
 
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/17427

### Motivation

The compilation guidance on Ubuntu is wrong, we must copy the `gmock` directory into `/usr/include` to avoid `GMOCK_INCLUDE_PATH` is not found.

### Modifications

- Copy the `gmock` directory into `/usr/include`
- Make it clear the directory of `*.a` is `lib/` because the guidance specify Ubuntu 20.04 as the OS.
- Remove unnecessary dependencies

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
