### PR TITLE
Enable required check status for unit tests job

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,6 +49,7 @@ github:
       #   # Contexts are the names of checks that must pass.
       #   # See ./github/workflows/README.md for more documentation on this list.
         contexts:
+           - Run unit tests
            - Build CPP Client on Windows x64
            - Build CPP Client on Windows x86
            - Build Debian Package


### PR DESCRIPTION
### Motivation

Currently, in workflow, the unit tests job is not required. 

### Modifications

Enable required check status for unit tests job.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
