### PR TITLE
Improved the CI check completion

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,12 +49,7 @@ github:
       #   # Contexts are the names of checks that must pass.
       #   # See ./github/workflows/README.md for more documentation on this list.
         contexts:
-           - Run unit tests
-           - Build CPP Client on Windows x64
-           - Build CPP Client on Windows x86
-           - Build Debian Package
-           - Build RPM Package
-           - Build Alpine Linux APK Package
+           - Check Completion
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -264,3 +264,13 @@ jobs:
 
       - name: Build APK packages
         run: pkg/apk/docker-build-apk-x86_64.sh build-apk-x86_64:latest
+
+
+  # Job that will be required to complete and depends on all the other jobs
+  check-completion:
+    name: Check Completion
+    runs-on: ubuntu-latest
+    needs: [unit-tests, cpp-build-windows, deb-packaging, rpm-packaging, apk-packaging]
+
+    steps:
+      - run: true


### PR DESCRIPTION
### Motivation

The definition for required CI jobs is set into `.asf.yaml` file though that file is synced in background and only after a PR is committed. 

That makes it difficult to add or rename CI jobs because these PRs won't be passing the validation.

Instead, use a simple check-completion jobs that will be the only required job, though it waits for all the others to finish