### PR TITLE
Send notifications to dev@ mailing list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,11 +63,3 @@ github:
 
     # The following branch protections only ensure that force pushes are not allowed
     # branch-3.xxx: {}
-
-
-notifications:
-  commits:      commits@pulsar.apache.org
-  issues:       commits@pulsar.apache.org
-  pullrequests: commits@pulsar.apache.org
-  discussions:  dev@pulsar.apache.org
-  jira_options: link label


### PR DESCRIPTION
### Motivation

In our other client repos, we do not have a notification section, and that (apparently) triggers notifications to go to the dev list. I find this particularly helpful when keeping up with our non apache/pulsar repos. If we're concerned about the volume, we can always turn it down later.

https://github.com/apache/pulsar-client-go/blob/master/.asf.yaml

### Modifications

* Remove the `notifications` section of the `.asf.yaml` so that all notifications go to dev@ pulsar
