### PR TITLE
Fix Ubuntu and macOS build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,36 +92,10 @@ Run unit tests:
 #### Install all dependencies:
 
 ```shell
-apt-get install -y g++ cmake libssl-dev libcurl4-openssl-dev \
-                libprotobuf-dev libboost-all-dev libgtest-dev google-mock \
+sudo apt-get install -y g++ cmake libssl-dev libcurl4-openssl-dev \
+                libprotobuf-dev libboost-all-dev libgtest-dev libgmock-dev \
                 protobuf-compiler
 ```
-
-#### Compile and install Google Test:
-
-```shell
-cd /usr/src/gtest
-sudo cmake .
-sudo make
-
-# Copy the libraries you just built to the OS library path.
-sudo cp lib/*.a /usr/lib
-```
-
-
-#### Compile and install Google Mock:
-
-```shell
-cd /usr/src/gmock
-sudo cmake .
-sudo make
-
-# Copy the gmock headers to the OS include path.
-sudo cp -r include/gmock /usr/include/
-# Copy the libraries you just built to the OS brary path.
-sudo cp lib/*.a /usr/lib
-```
-
 
 #### Compile Pulsar client library:
 
@@ -151,12 +125,17 @@ perf/perfConsumer
 ```shell
 # For openSSL
 brew install openssl
+
+# For x86_64 macOS
 export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/
 export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
 
+# For arm64 (Apple Silicon) macOS
+export OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl/include/
+export OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl/
+
 # For Protobuf
-brew install protobuf boost boost-python log4cxx jsoncpp
-// If you are using python3, you need to install boost-python3
+brew install protobuf boost boost-python3 log4cxx jsoncpp
 
 # For GoogleTest
 brew install googletest

--- a/README.md
+++ b/README.md
@@ -123,22 +123,7 @@ perf/perfConsumer
 
 #### Install all dependencies:
 ```shell
-# For openSSL
-brew install openssl
-
-# For x86_64 macOS
-export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/
-export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
-
-# For arm64 (Apple Silicon) macOS
-export OPENSSL_INCLUDE_DIR=/opt/homebrew/opt/openssl/include/
-export OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl/
-
-# For Protobuf
-brew install protobuf boost boost-python3 log4cxx jsoncpp
-
-# For GoogleTest
-brew install googletest
+brew install openssl protobuf boost boost-python3 googletest zstd snappy
 ```
 
 #### Compile Pulsar client library:
@@ -237,18 +222,16 @@ pulsar-client-cpp/build/examples/Release
 
 ## Tests
 ```shell
-# Source code
-pulsar-client-cpp/tests/
-
 # Execution
 # Start standalone broker
-pulsar-test-service-start.sh
+./pulsar-test-service-start.sh
 
 # Run the tests
-pulsar-client-cpp/tests/main
+cd tests
+./pulsar-tests
 
 # When no longer needed, stop standalone broker
-pulsar-test-service-stop.sh
+./pulsar-test-service-stop.sh
 ```
 
 ## Requirements for Contributors


### PR DESCRIPTION
### Motivation

Currently, some build guide is out-of-date. We need to update the build guide.

The first issue is when we install the dependencies for Ubuntu, we still need manually compile and install google test and google mock. 

However, we can use `libgmock-dev` to replace the `google-mock`, since the `libgmock-dev` already contains the static-link library.

```
$ dpkg -L libgmock-dev
// ...
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libgmock.a
/usr/lib/x86_64-linux-gnu/libgmock_main.a
// ...
```

Same as the `libgtest-dev`.

```
$ dpkg -L libgtest-dev
// ...
/usr/lib/x86_64-linux-gnu/libgtest.a
/usr/lib/x86_64-linux-gnu/libgtest_main.a
// ...
```

The second issue is macOS dependency. The `boost-python` has already been removed from the brew core. We should always use `boost-python3`.

```
~ brew info boost-python
Error: No available formula with the name "boost-python". Did you mean boost-python3 or gst-python?
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
```

The third one is `OPENSSL_INCLUDE_DIR` and `OPENSSL_ROOT_DIR`. 
For m1 macOS, the brew preferred prefix is `/opt/homebrew/opt`, Intel macOS is `/usr/local`.
So we set the `OPENSSL_INCLUDE_DIR, OPENSSL_ROOT_DIR`. We should consider the different platforms.


### Modifications

Fix Ubuntu and macOS build guide

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
