### PR TITLE
Fixed validation of cluster/namespace names containing legal non-alpha characters

### DIFF
--- a/lib/NamedEntity.cc
+++ b/lib/NamedEntity.cc
@@ -18,19 +18,29 @@
  */
 #include "NamedEntity.h"
 
+#include <cctype>
+
+/**
+ * Allowed characters for property, namespace, cluster and topic names are
+ * alphanumeric (a-zA-Z_0-9) and these special chars -=:.
+ * @param name
+ * @return
+ */
 bool NamedEntity::checkName(const std::string& name) {
     for (char c : name) {
+        if (isalnum(c)) {
+            continue;
+        }
+
         switch (c) {
+            case '-':
             case '=':
             case ':':
-            case ' ':
-            case '!':
-            case '\t':
-            case '\r':
-            case '\n':
-                return false;
+            case '.':
+                continue;
             default:
-                break;
+                // Invalid character was found
+                return false;
         }
     }
 

--- a/tests/NamespaceNameTest.cc
+++ b/tests/NamespaceNameTest.cc
@@ -42,3 +42,11 @@ TEST(NamespaceNameTest, testNamespaceNameV2) {
     std::shared_ptr<NamespaceName> nn2 = NamespaceName::get("property", "namespace");
     ASSERT_TRUE(*nn1 == *nn2);
 }
+
+TEST(NamespaceNameTest, testNamespaceNameLegalCharacters) {
+    std::shared_ptr<NamespaceName> nn1 = NamespaceName::get("cluster-1:=.", "namespace-1:=.");
+    ASSERT_EQ("cluster-1:=.", nn1->getProperty());
+    ASSERT_TRUE(nn1->getCluster().empty());
+    ASSERT_EQ("namespace-1:=.", nn1->getLocalName());
+    ASSERT_TRUE(nn1->isV2());
+}

--- a/tests/TopicNameTest.cc
+++ b/tests/TopicNameTest.cc
@@ -141,8 +141,7 @@ TEST(TopicNameTest, testIllegalCharacters) {
 }
 
 TEST(TopicNameTest, testLegalNonAlphaCharacters) {
-    std::shared_ptr<TopicName> topicName =
-        TopicName::get("persistent://cluster-1:=./namespace-1:=./topic");
+    std::shared_ptr<TopicName> topicName = TopicName::get("persistent://cluster-1:=./namespace-1:=./topic");
     ASSERT_TRUE(topicName);
     ASSERT_EQ("cluster-1:=.", topicName->getProperty());
     ASSERT_EQ("namespace-1:=.", topicName->getNamespacePortion());

--- a/tests/TopicNameTest.cc
+++ b/tests/TopicNameTest.cc
@@ -140,6 +140,16 @@ TEST(TopicNameTest, testIllegalCharacters) {
     ASSERT_FALSE(topicName);
 }
 
+TEST(TopicNameTest, testLegalNonAlphaCharacters) {
+    std::shared_ptr<TopicName> topicName =
+        TopicName::get("persistent://cluster-1:=./namespace-1:=./topic");
+    ASSERT_TRUE(topicName);
+    ASSERT_EQ("cluster-1:=.", topicName->getProperty());
+    ASSERT_EQ("namespace-1:=.", topicName->getNamespacePortion());
+    ASSERT_EQ("persistent", topicName->getDomain());
+    ASSERT_EQ("topic", topicName->getLocalName());
+}
+
 TEST(TopicNameTest, testIllegalUrl) {
     std::shared_ptr<TopicName> topicName = TopicName::get("persistent:::/property/cluster/namespace/topic");
     ASSERT_FALSE(topicName);


### PR DESCRIPTION
### Motivation

C++ client is not allowing some characters like `:` in the cluster or namespace names. This is not consistent with Java client and the broker validations which allow such character. 

We must use the same exact logic of validation for topic names as in https://github.com/apache/pulsar/blob/master/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamedEntity.java 

