### PR TITLE
Fixed the release artifacts package file name

### DIFF
--- a/.github/workflows/ci-build-binary-artifacts.yaml
+++ b/.github/workflows/ci-build-binary-artifacts.yaml
@@ -75,5 +75,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{matrix.pkg.type}}-${{matrix.pkg.platform}}
+          name: ${{matrix.pkg.type}}-${{matrix.cpu.platform}}
           path: ${{matrix.pkg.path}}


### PR DESCRIPTION
### Motivation

Because of the typo in the variable name, the packages end up with the same name for both x86_64 and arm64 and GH action is merging them. It's mainly a problem for Deb packages since the files don't have the arch in the file names.