### PR TITLE
[flaky tests] Fix flaky ShutdownTest::testDestructor

### DIFF
--- a/tests/ShutdownTest.cc
+++ b/tests/ShutdownTest.cc
@@ -23,6 +23,7 @@
 #include "lib/ClientImpl.h"
 #include "HttpHelper.h"
 #include "PulsarFriend.h"
+#include "WaitUtils.h"
 
 using namespace pulsar;
 
@@ -111,6 +112,7 @@ TEST_P(ShutdownTest, testDestructor) {
         ASSERT_EQ(ResultOk, client_.createProducer(topic, producer));
         EXPECT_EQ(producers_.size(), 1);
     }
+    waitUntil(std::chrono::seconds(2), [this] { return producers_.size() == 0; });
     EXPECT_EQ(producers_.size(), 0);
 
     {
@@ -118,6 +120,7 @@ TEST_P(ShutdownTest, testDestructor) {
         ASSERT_EQ(ResultOk, subscribe(consumer, topic));
         EXPECT_EQ(consumers_.size(), 1);
     }
+    waitUntil(std::chrono::seconds(2), [this] { return consumers_.size() == 0; });
     EXPECT_EQ(consumers_.size(), 0);
 
     assertConnectionsEmpty();

--- a/tests/WaitUtils.h
+++ b/tests/WaitUtils.h
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <thread>
+
+namespace pulsar {
+
+template <typename Rep, typename Period>
+inline void waitUntil(std::chrono::duration<Rep, Period> timeout, std::function<bool()> condition) {
+    auto timeoutMs = std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
+    while (timeoutMs > 0) {
+        auto now = std::chrono::high_resolution_clock::now();
+        if (condition()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::high_resolution_clock::now() - now)
+                           .count();
+        timeoutMs -= elapsed;
+    }
+}
+
+}  // namespace pulsar


### PR DESCRIPTION
Fixes #61

### Motivation

`testDestructor` is flaky because the destructor might not be called immediately after the `shared_ptr` object goes out of the scope. It's similar like the flaky `testReferenceCount` before in https://github.com/apache/pulsar/pull/17645.

### Modifications

Add back `WaitUtils.h`, which was removed in #55, add use `waitUntil` to wait until the assertion.

### Verifications

Run the reproduce script in #61. Even if the loop count was increased to 100, it still never failed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
