### PR TITLE
Add new interfaces to improve data consuming performance. (#65)

### DIFF
--- a/include/pulsar/Message.h
+++ b/include/pulsar/Message.h
@@ -101,6 +101,13 @@ class PULSAR_PUBLIC Message {
     KeyValue getKeyValueData() const;
 
     /**
+     * Release and return the message's payload.
+     *
+     * @return the released payload.
+     */
+    std::string releaseData();
+
+    /**
      * Move payload into the given string.
      *
      * @param data the string that receiving the payload's ownership.

--- a/include/pulsar/Message.h
+++ b/include/pulsar/Message.h
@@ -101,6 +101,13 @@ class PULSAR_PUBLIC Message {
     KeyValue getKeyValueData() const;
 
     /**
+     * Move payload into the given string.
+     *
+     * @param data the string that receiving the payload's ownership.
+     */
+    void moveDataIntoString(std::string& data);
+
+    /**
      * Get the unique message ID associated with this message.
      *
      * The message id can be used to univocally refer to a message without having to keep the entire payload

--- a/include/pulsar/Message.h
+++ b/include/pulsar/Message.h
@@ -108,13 +108,6 @@ class PULSAR_PUBLIC Message {
     std::string releaseData();
 
     /**
-     * Move payload into the given string.
-     *
-     * @param data the string that receiving the payload's ownership.
-     */
-    void moveDataIntoString(std::string& data);
-
-    /**
      * Get the unique message ID associated with this message.
      *
      * The message id can be used to univocally refer to a message without having to keep the entire payload

--- a/lib/Message.cc
+++ b/lib/Message.cc
@@ -56,7 +56,11 @@ std::size_t Message::getLength() const { return impl_->payload.readableBytes(); 
 
 std::string Message::getDataAsString() const { return std::string((const char*)getData(), getLength()); }
 
-void Message::moveDataIntoString(std::string& data) { impl_->payload.pop(data); }
+std::string Message::releaseData() {
+    std::string data;
+    impl_->payload.pop(data);
+    return data;
+}
 
 Message::Message() : impl_() {}
 

--- a/lib/Message.cc
+++ b/lib/Message.cc
@@ -56,6 +56,8 @@ std::size_t Message::getLength() const { return impl_->payload.readableBytes(); 
 
 std::string Message::getDataAsString() const { return std::string((const char*)getData(), getLength()); }
 
+void Message::moveDataIntoString(std::string& data) { return impl_->payload.pop(data); }
+
 Message::Message() : impl_() {}
 
 Message::Message(MessageImplPtr& impl) : impl_(impl) {}

--- a/lib/Message.cc
+++ b/lib/Message.cc
@@ -56,7 +56,7 @@ std::size_t Message::getLength() const { return impl_->payload.readableBytes(); 
 
 std::string Message::getDataAsString() const { return std::string((const char*)getData(), getLength()); }
 
-void Message::moveDataIntoString(std::string& data) { return impl_->payload.pop(data); }
+void Message::moveDataIntoString(std::string& data) { impl_->payload.pop(data); }
 
 Message::Message() : impl_() {}
 

--- a/lib/SharedBuffer.h
+++ b/lib/SharedBuffer.h
@@ -25,6 +25,7 @@
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/detail/socket_ops.hpp>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -205,11 +206,12 @@ class SharedBuffer {
         writeIdx_ = 0;
     }
 
-    bool pop(std::string& target) {
-        if (data_ == nullptr) return false;
+    void pop(std::string& target) {
+        if (data_ == nullptr) {
+            throw std::runtime_error("Popped on SharedBuffer object that does NOT own the data.");
+        }
         target.swap(*data_);
         *this = SharedBuffer();
-        return true;
     }
 
    private:

--- a/lib/SharedBuffer.h
+++ b/lib/SharedBuffer.h
@@ -205,6 +205,13 @@ class SharedBuffer {
         writeIdx_ = 0;
     }
 
+    bool pop(std::string& target) {
+        if (data_ == nullptr) return false;
+        target.swap(*data_);
+        *this = SharedBuffer();
+        return true;
+    }
+
    private:
     std::shared_ptr<std::string> data_;
     char* ptr_;

--- a/tests/MessageTest.cc
+++ b/tests/MessageTest.cc
@@ -61,7 +61,7 @@ TEST(MessageTest, testAllocatedContents) {
         throwed = true;
     } catch (...) {
     }
-    ASSERT_FALSE(throwed);
+    ASSERT_TRUE(throwed);
     delete[] content;
 }
 

--- a/tests/MessageTest.cc
+++ b/tests/MessageTest.cc
@@ -53,6 +53,15 @@ TEST(MessageTest, testAllocatedContents) {
     Message msg = msgBuilder.build();
     ASSERT_FALSE(strncmp("content", (char*)msg.getData(), msg.getLength()));
     ASSERT_EQ(content, (char*)msg.getData());
+
+    bool throwed = false;
+    try {
+        msg.releaseData();
+    } catch (std::runtime_error& ex) {
+        throwed = true;
+    } catch (...) {
+    }
+    ASSERT_FALSE(throwed);
     delete[] content;
 }
 

--- a/tests/MessageTest.cc
+++ b/tests/MessageTest.cc
@@ -54,14 +54,7 @@ TEST(MessageTest, testAllocatedContents) {
     ASSERT_FALSE(strncmp("content", (char*)msg.getData(), msg.getLength()));
     ASSERT_EQ(content, (char*)msg.getData());
 
-    bool throwed = false;
-    try {
-        msg.releaseData();
-    } catch (std::runtime_error& ex) {
-        throwed = true;
-    } catch (...) {
-    }
-    ASSERT_TRUE(throwed);
+    ASSERT_THROW(msg.releaseData(), std::runtime_error);
     delete[] content;
 }
 


### PR DESCRIPTION
Fixes #65

### Motivation

Improve data consuming performance by adding new interfaces on `class Message` and `class SharedBuffer`.

### Modifications

Adding two functions:

`lib/SharedBuffer.h`

```cpp
void SharedBuffer::pop(std::string &target)
```

`pulsar/Message.h`, `lib/Message.cc`

```cpp
std::string Message::release()
```

### Verifying this change

This change added tests and can be verified as follows:

Run client's unit test, it's added in `MessageTest.cc`.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [x] `doc-complete`
(Docs have been already added)
