### PR TITLE
Fix macOS compilation errors caused by forward declaration

### DIFF
--- a/lib/ProducerImpl.h
+++ b/lib/ProducerImpl.h
@@ -23,8 +23,8 @@
 
 #include "Future.h"
 #include "HandlerBase.h"
-// In MSVC, the value type of a STL container cannot be forward declared
-#if defined(_MSC_VER)
+// In MSVC and macOS, the value type of STL container cannot be forward declared
+#if defined(_MSC_VER) || defined(__APPLE__)
 #include "OpSendMsg.h"
 #endif
 #include "PendingFailures.h"


### PR DESCRIPTION
### Motivation

In macOS, the value type of STL container cannot be forward declared


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
