### PR TITLE
[fix] Flush no batch message when call producer.flush

### DIFF
--- a/lib/OpSendMsg.h
+++ b/lib/OpSendMsg.h
@@ -39,6 +39,7 @@ struct OpSendMsg {
     boost::posix_time::ptime timeout_;
     uint32_t messagesCount_;
     uint64_t messagesSize_;
+    std::vector<std::function<void(Result)>> trackerCallbacks_;
 
     OpSendMsg() = default;
 
@@ -59,6 +60,13 @@ struct OpSendMsg {
         if (sendCallback_) {
             sendCallback_(result, messageId);
         }
+        for (const auto& trackerCallback : trackerCallbacks_) {
+            trackerCallback(result);
+        }
+    }
+
+    void addTrackerCallback(std::function<void(Result)> trackerCallback) {
+        trackerCallbacks_.emplace_back(trackerCallback);
     }
 };
 


### PR DESCRIPTION
### Motivation

#51

### Modifications

- when calling `producer.flush`, wait for no batch message send suceese. 


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
