### PR TITLE
[fix] Fix consumer doesn't clear incomingMessageQueue during seek

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -1397,6 +1397,7 @@ void ConsumerImpl::seekAsyncInternal(long requestId, SharedBuffer seek, const Me
             if (result == ResultOk) {
                 LOG_INFO(getName() << "Seek successfully");
                 ackGroupingTrackerPtr_->flushAndClean();
+                incomingMessages_.clear();
                 Lock lock(mutexForMessageId_);
                 lastDequedMessageId_ = MessageId::earliest();
                 lock.unlock();

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -893,6 +893,14 @@ TEST_P(ConsumerSeekTest, testSeekForMessageId) {
     Producer producer;
     ASSERT_EQ(ResultOk, client.createProducer(topic, producerConf_, producer));
 
+    Consumer consumerExclusive;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, "sub-0", consumerExclusive));
+
+    Consumer consumerInclusive;
+    ASSERT_EQ(ResultOk,
+              client.subscribe(topic, "sub-1", ConsumerConfiguration().setStartMessageIdInclusive(true),
+                               consumerInclusive));
+
     const auto numMessages = 100;
     MessageId seekMessageId;
 
@@ -909,16 +917,10 @@ TEST_P(ConsumerSeekTest, testSeekForMessageId) {
 
     LOG_INFO("The seekMessageId is: " << seekMessageId << ", r : " << r);
 
-    Consumer consumerExclusive;
-    ASSERT_EQ(ResultOk, client.subscribe(topic, "sub-0", consumerExclusive));
     consumerExclusive.seek(seekMessageId);
     Message msg0;
     ASSERT_EQ(ResultOk, consumerExclusive.receive(msg0, 3000));
 
-    Consumer consumerInclusive;
-    ASSERT_EQ(ResultOk,
-              client.subscribe(topic, "sub-1", ConsumerConfiguration().setStartMessageIdInclusive(true),
-                               consumerInclusive));
     consumerInclusive.seek(seekMessageId);
     Message msg1;
     ASSERT_EQ(ResultOk, consumerInclusive.receive(msg1, 3000));


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Currently, the consumer will receive old messages after the seek operation. Because the consumer doesn't clear the incomingMessageQueue before reconnecting. Therefore the consumer will dispatch some old messages to the user after the seek operation.

This issue can be easily reproduced by advancing the process of creating consumers to before producing message in `testSeekForMessageId`.

### Modifications

* Clear the incomingMessageQueue after seeking complete.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *testSeekForMessageId*.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
