### PR TITLE
[feat] Support WaitForExclusive producer access mode.

### DIFF
--- a/include/pulsar/ProducerConfiguration.h
+++ b/include/pulsar/ProducerConfiguration.h
@@ -89,7 +89,12 @@ class PULSAR_PUBLIC ProducerConfiguration {
         /**
          * Require exclusive access for producer. Fail immediately if there's already a producer connected.
          */
-        Exclusive = 1
+        Exclusive = 1,
+
+        /**
+         * Producer creation is pending until it can acquire exclusive access.
+         */
+        WaitForExclusive = 2
     };
 
     ProducerConfiguration();

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -172,6 +172,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     struct PendingRequestData {
         Promise<Result, ResponseData> promise;
         DeadlineTimerPtr timer;
+        std::shared_ptr<std::atomic_bool> hasGotResponse{std::make_shared<std::atomic_bool>(false)};
     };
 
     struct LookupRequestData {

--- a/lib/HandlerBase.cc
+++ b/lib/HandlerBase.cc
@@ -130,6 +130,7 @@ void HandlerBase::handleDisconnection(Result result, ClientConnectionWeakPtr con
         case NotStarted:
         case Closing:
         case Closed:
+        case Producer_Fenced:
         case Failed:
             LOG_DEBUG(handler->getName()
                       << "Ignoring connection closed event since the handler is not used anymore");

--- a/lib/HandlerBase.h
+++ b/lib/HandlerBase.h
@@ -118,7 +118,8 @@ class HandlerBase {
         Ready,
         Closing,
         Closed,
-        Failed
+        Failed,
+        Producer_Fenced
     };
 
     std::atomic<State> state_;


### PR DESCRIPTION
### Motivation
#95 

### Modifications
- Support WaitForExclusive producer access mode.
 
**Note**: `ExclusiveWithFencing` needs to depend on pulsar to release 2.11

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
