### PR TITLE
Fix getLastMessageId method dead recursion.

### DIFF
--- a/lib/Consumer.cc
+++ b/lib/Consumer.cc
@@ -295,7 +295,8 @@ void Consumer::getLastMessageIdAsync(GetLastMessageIdCallback callback) {
         callback(ResultConsumerNotInitialized, MessageId());
         return;
     }
-    getLastMessageIdAsync([callback](Result result, const GetLastMessageIdResponse& response) {
+
+    impl_->getLastMessageIdAsync([callback](Result result, const GetLastMessageIdResponse& response) {
         callback(result, response.getLastMessageId());
     });
 }

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -1341,7 +1341,7 @@ void ConsumerImpl::getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback
     if (state == Closed || state == Closing) {
         LOG_ERROR(getName() << "Client connection already closed.");
         if (callback) {
-            callback(ResultAlreadyClosed, MessageId());
+            callback(ResultAlreadyClosed, GetLastMessageIdResponse());
         }
         return;
     }

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -44,7 +44,6 @@ class BatchAcknowledgementTracker;
 class MessageCrypto;
 class GetLastMessageIdResponse;
 typedef std::shared_ptr<MessageCrypto> MessageCryptoPtr;
-typedef std::function<void(Result, const GetLastMessageIdResponse&)> BrokerGetLastMessageIdCallback;
 typedef std::shared_ptr<Backoff> BackoffPtr;
 
 class AckGroupingTracker;
@@ -124,6 +123,7 @@ class ConsumerImpl : public ConsumerImplBase {
     const std::string& getName() const override;
     int getNumOfPrefetchedMessages() const override;
     void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback) override;
+    void getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback) override;
     void seekAsync(const MessageId& msgId, ResultCallback callback) override;
     void seekAsync(uint64_t timestamp, ResultCallback callback) override;
     void negativeAcknowledge(const MessageId& msgId) override;
@@ -139,7 +139,6 @@ class ConsumerImpl : public ConsumerImplBase {
 
     virtual bool isReadCompacted();
     virtual void hasMessageAvailableAsync(HasMessageAvailableCallback callback);
-    virtual void getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback);
     void beforeConnectionChange(ClientConnection& cnx) override;
 
    protected:

--- a/lib/ConsumerImplBase.h
+++ b/lib/ConsumerImplBase.h
@@ -25,12 +25,12 @@
 #include <set>
 
 #include "Future.h"
+#include "GetLastMessageIdResponse.h"
 #include "HandlerBase.h"
 
 namespace pulsar {
 class ConsumerImplBase;
 using ConsumerImplBaseWeakPtr = std::weak_ptr<ConsumerImplBase>;
-
 class OpBatchReceive {
    public:
     OpBatchReceive();
@@ -68,6 +68,7 @@ class ConsumerImplBase : public HandlerBase, public std::enable_shared_from_this
     virtual void redeliverUnacknowledgedMessages(const std::set<MessageId>& messageIds) = 0;
     virtual int getNumOfPrefetchedMessages() const = 0;
     virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback) = 0;
+    virtual void getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback) = 0;
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback) = 0;
     virtual void seekAsync(uint64_t timestamp, ResultCallback callback) = 0;
     virtual void negativeAcknowledge(const MessageId& msgId) = 0;

--- a/lib/GetLastMessageIdResponse.h
+++ b/lib/GetLastMessageIdResponse.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <pulsar/MessageId.h>
+#include <pulsar/Result.h>
 
 #include <iostream>
 
@@ -53,5 +54,7 @@ class GetLastMessageIdResponse {
     MessageId markDeletePosition_;
     bool hasMarkDeletePosition_;
 };
+
+typedef std::function<void(Result, const GetLastMessageIdResponse&)> BrokerGetLastMessageIdCallback;
 
 }  // namespace pulsar

--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -803,6 +803,10 @@ void MultiTopicsConsumerImpl::getBrokerConsumerStatsAsync(BrokerConsumerStatsCal
     });
 }
 
+void MultiTopicsConsumerImpl::getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback) {
+    callback(ResultOperationNotSupported, GetLastMessageIdResponse());
+}
+
 void MultiTopicsConsumerImpl::handleGetConsumerStats(Result res, BrokerConsumerStats brokerConsumerStats,
                                                      LatchPtr latchPtr,
                                                      MultiTopicsBrokerConsumerStatsPtr statsPtr, size_t index,

--- a/lib/MultiTopicsConsumerImpl.h
+++ b/lib/MultiTopicsConsumerImpl.h
@@ -82,6 +82,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
     const std::string& getName() const override;
     int getNumOfPrefetchedMessages() const override;
     void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback) override;
+    void getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback) override;
     void seekAsync(const MessageId& msgId, ResultCallback callback) override;
     void seekAsync(uint64_t timestamp, ResultCallback callback) override;
     void negativeAcknowledge(const MessageId& msgId) override;

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -841,6 +841,30 @@ TEST(ConsumerTest, testPartitionsWithCloseUnblock) {
     thread.join();
 }
 
+TEST(ConsumerTest, testGetLastMessageId) {
+    Client client(lookupUrl);
+    const std::string topic = "testGetLastMessageId-" + std::to_string(time(nullptr));
+
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, "test-sub", consumer));
+
+    MessageId msgId;
+    ASSERT_EQ(ResultOk, consumer.getLastMessageId(msgId));
+    ASSERT_EQ(msgId, MessageId(-1, -1, -1, -1));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic, producer));
+    Message msg = MessageBuilder().setContent("message").build();
+    ASSERT_EQ(ResultOk, producer.send(msg));
+
+    ASSERT_EQ(ResultOk, consumer.getLastMessageId(msgId));
+    ASSERT_TRUE(msgId != MessageId(-1, -1, -1, -1));
+
+    std::cout << msgId << std::endl;
+
+    client.close();
+}
+
 TEST(ConsumerTest, testGetLastMessageIdBlockWhenConnectionDisconnected) {
     int operationTimeout = 5;
     ClientConfiguration clientConfiguration;

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -858,9 +858,7 @@ TEST(ConsumerTest, testGetLastMessageId) {
     ASSERT_EQ(ResultOk, producer.send(msg));
 
     ASSERT_EQ(ResultOk, consumer.getLastMessageId(msgId));
-    ASSERT_TRUE(msgId != MessageId(-1, -1, -1, -1));
-
-    std::cout << msgId << std::endl;
+    ASSERT_NE(msgId, MessageId(-1, -1, -1, -1));
 
     client.close();
 }


### PR DESCRIPTION
### Motivation

There is a problem with the `getLastMessageId` method currently implemented.

It is recursively invoking itself.
https://github.com/apache/pulsar-client-cpp/blob/ad79becf0814a992ad493bc625ba0a489900451f/lib/Consumer.cc#L293-L301

### Modifications

- Let it call the actual implementation.

**Note**:  `MultiTopicConsumer.getLastMessageId()` is not supported for the time being. I will support it later. Supporting `MultiTopicConsumer` requires the implementation of [MultiMessageId](https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiMessageIdImpl.java), which requires more thought and design.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
