### PR TITLE
Fix segmentation fault during the destruction of ConsumerImpl

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -125,11 +125,13 @@ ConsumerImpl::~ConsumerImpl() {
 
         ClientConnectionPtr cnx = getCnx().lock();
         ClientImplPtr client = client_.lock();
-        int requestId = client->newRequestId();
-        if (cnx) {
+        if (client && cnx) {
+            int requestId = client->newRequestId();
             cnx->sendRequestWithId(Commands::newCloseConsumer(consumerId_, requestId), requestId);
             cnx->removeConsumer(consumerId_);
             LOG_INFO(getName() << "Closed consumer for race condition: " << consumerId_);
+        } else {
+            LOG_WARN(getName() << "Client is destroyed and cannot send the CloseConsumer command");
         }
     }
     shutdown();


### PR DESCRIPTION
### Motivation

When I ran the tests of Python wrapper in my local env, I observed a segmentation fault. See the key stacktrace:

```
#3  0x00007ffff6d742c5 in std::unique_lock<std::mutex>::lock() () from /usr/local/lib/python3.8/dist-packages/_pulsar.cpython-38-x86_64-linux-gnu.so
#4  0x00007ffff6d72523 in std::unique_lock<std::mutex>::unique_lock(std::mutex&) ()
   from /usr/local/lib/python3.8/dist-packages/_pulsar.cpython-38-x86_64-linux-gnu.so
#5  0x00007ffff67de193 in pulsar::ClientImpl::newRequestId **(this=0x0)** at /home/xyz/github.com/apache/pulsar-client-cpp/lib/ClientImpl.cc:644
#6  0x00007ffff685d2c2 in pulsar::ConsumerImpl::~ConsumerImpl (this=0x7fff9800f9e0, __in_chrg=<optimized out>)
    at /home/xyz/github.com/apache/pulsar-client-cpp/lib/ConsumerImpl.cc:116
```

In the destructor of `ConsumerImpl`, `client->newRequestId` might be called. However, `client` might be a null pointer because it's returned by `std::weak_ptr::lock()`.

### Modifications

Add null check to avoid the segfault.