### PR TITLE
Add handle the authorization error

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -1130,6 +1130,7 @@ void ClientConnection::handleIncomingCommand(BaseCommand& incomingCmd) {
                             }
                         }
                     }
+                    checkServerError(error.error());
                     break;
                 }
 
@@ -1707,6 +1708,9 @@ void ClientConnection::checkServerError(ServerError error) {
         case proto::ServerError::TooManyRequests:
             // TODO: Implement maxNumberOfRejectedRequestPerConnection like
             // https://github.com/apache/pulsar/pull/274
+            closeSocket();
+            break;
+        case proto::ServerError::AuthorizationError:
             closeSocket();
             break;
         default:


### PR DESCRIPTION
### Motivation

When receiving the authorization error, we need to close the connection between the broker and the client.

### Modifications

Add check the `ServerError.AuthorizationError`. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
