### PR TITLE
[improve] Exclude debug artifact in the release and tar the windows artifacts

### DIFF
--- a/build-support/download-release-artifacts.py
+++ b/build-support/download-release-artifacts.py
@@ -45,6 +45,9 @@ with urllib.request.urlopen(request) as response:
     data = json.loads(response.read().decode("utf-8"))
     for artifact in data['artifacts']:
         name = artifact['name']
+        # Skip debug artifact
+        if name.endswith("-Debug"):
+            continue
         url = artifact['archive_download_url']
 
         print('Downloading %s from %s' % (name, url))

--- a/build-support/stage-release.sh
+++ b/build-support/stage-release.sh
@@ -39,6 +39,12 @@ cd $PULSAR_CPP_PATH
 build-support/generate-source-archive.sh $DEST_PATH
 build-support/download-release-artifacts.py $WORKFLOW_ID $DEST_PATH
 
+pushd "$DEST_PATH"
+tar cvzf x64-windows-static.tar.gz x64-windows-static
+tar cvzf x86-windows-static.tar.gz x86-windows-static
+rm -r x64-windows-static x86-windows-static
+popd
+
 # Sign all files
 cd $DEST_PATH
 find . -type f | xargs $PULSAR_CPP_PATH/build-support/sign-files.sh


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

The debug artifact for the windows system is too large. They are only used for debugging and don't need to include in the release. And it's better to tar the `windows-static` artifact to make it easier to download.

The final result looks like this: https://dist.apache.org/repos/dist/dev/pulsar/pulsar-client-cpp/pulsar-client-cpp-3.1.0-candidate-1/


### Modifications

* Exclude the windows debug artifact in the release
* Tar `windows-static` artifacts in the release.

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
