### PR TITLE
[fix] Fix PartitionedProducerImpl::closeAsync to close sub-producers properly

### DIFF
--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -266,13 +266,10 @@ void PartitionedProducerImpl::closeAsync(CloseCallback originalCallback) {
             originalCallback(result);
         }
     };
-    if (state_ == Closed) {
-        closeCallback(ResultAlreadyClosed);
-        return;
-    }
-    State expectedState = Ready;
-    if (!state_.compare_exchange_strong(expectedState, Closing)) {
-        return;
+
+    State previous_state = state_.exchange(Closed);
+    if (previous_state == Closed) {
+      return closeCallback(ResultAlreadyClosed);
     }
 
     cancelTimers();

--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -269,7 +269,7 @@ void PartitionedProducerImpl::closeAsync(CloseCallback originalCallback) {
 
     State previous_state = state_.exchange(Closed);
     if (previous_state == Closed) {
-      return closeCallback(ResultAlreadyClosed);
+        return closeCallback(ResultAlreadyClosed);
     }
 
     cancelTimers();

--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -267,8 +267,7 @@ void PartitionedProducerImpl::closeAsync(CloseCallback originalCallback) {
         }
     };
 
-    State previous_state = state_.exchange(Closed);
-    if (previous_state == Closed) {
+    if (state_.exchange(Closed) == Closed) {
         return closeCallback(ResultAlreadyClosed);
     }
 

--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -267,8 +267,9 @@ void PartitionedProducerImpl::closeAsync(CloseCallback originalCallback) {
         }
     };
 
-    if (state_.exchange(Closed) == Closed) {
-        return closeCallback(ResultAlreadyClosed);
+    if (state_ == Closed || state_.exchange(Closing) == Closing) {
+        closeCallback(ResultAlreadyClosed);
+        return;
     }
 
     cancelTimers();

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -421,7 +421,7 @@ TEST_P(ProducerTest, testCloseSubProducerWhenFail) {
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    // create producer for partition-1, should succ
+    // create producer for partition-1, should succeed
     Producer producer;
     ASSERT_EQ(ResultOk, client.createProducer(topicName + "-partition-1", producerConfiguration, producer));
     producers.push_back(producer);

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -406,7 +406,7 @@ TEST_P(ProducerTest, testCloseSubProducerWhenFail) {
         producers.push_back(producer);
     }
 
-    // create partitoined producer, should fail because partition-0 already reach max producer limit
+    // create partitioned producer, should fail because partition-0 already reach max producer limit
     for (int i = 0; i < maxProducersPerTopic; ++i) {
         auto partitionedProducer = std::make_shared<PartitionedProducerImpl>(
             PulsarFriend::getClientImplPtr(client), TopicName::get(topicName), partitionNum,

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -408,15 +408,8 @@ TEST_P(ProducerTest, testCloseSubProducerWhenFail) {
 
     // create partitioned producer, should fail because partition-0 already reach max producer limit
     for (int i = 0; i < maxProducersPerTopic; ++i) {
-        auto partitionedProducer = std::make_shared<PartitionedProducerImpl>(
-            PulsarFriend::getClientImplPtr(client), TopicName::get(topicName), partitionNum,
-            producerConfiguration);
-        partitionedProducer->start();
-        Result result;
-        ProducerImplBaseWeakPtr ptr;
-        ASSERT_TRUE(
-            partitionedProducer->getProducerCreatedFuture().get(result, ptr, std::chrono::seconds(1)));
-        ASSERT_EQ(result, ResultProducerBusy);  // reach max producer limit
+        Producer producer;
+        ASSERT_EQ(ResultProducerBusy, client.createProducer(topicName, producer));
     }
 
     std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -374,7 +374,7 @@ TEST_P(ProducerTest, testFlushNoBatch) {
     client.close();
 }
 
-TEST_P(ProducerTest, testCloseSubProducerWhenFail) {
+TEST(ProducerTest, testCloseSubProducerWhenFail) {
     Client client(serviceUrl);
 
     std::string ns = "test-close-sub-producer-when-fail";

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -22,7 +22,6 @@
 #include <thread>
 
 #include "HttpHelper.h"
-#include "PulsarFriend.h"
 #include "lib/Future.h"
 #include "lib/Latch.h"
 #include "lib/LogUtils.h"


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

PartitionedProducerImpl do not close sub-producers properly when any sub-producer creation fails. Continuing to retry creating producer will eventually reach the maximum producer limit. It seems a regression caused by #54. 

When sub-producer creation fails, state_ is set to Failed. PartitionedProducerImpl::closeAsync only do cleanup when state_==Ready and sub-producers do not close when state_==Failed.

https://github.com/apache/pulsar-client-cpp/blob/f0268ecd29a6d0030b7d07379ec609884b4c14ff/lib/PartitionedProducerImpl.cc#L273-L276

### Modifications

<!-- Describe the modifications you've done. -->

Close sub-producers when state != Closed.

### Verifying this change

test code:

    Client client("pulsar://localhost:6650");
    Producer producer;
    while (true) {
        Result result = client.createProducer("persistent://public/default/test", producer);
        if (result != ResultOk) {
            cerr << "Error creating producer: " << result << endl;
            std::this_thread::sleep_for(std::chrono::seconds(1));
            continue;
        }
        break;
    }

test cmd:

    pulsar-admin namespaces set-max-producers-per-topic -p 10 public/default
    pulsar-admin topics create-partitioned-topic -n 2 public/default/test
    pulsar-perf produce -r 1 -n 10 public/default/test-partition-0

test procedure:
1. set namespace max producer limit to 10
2. create partitoned topic public/default/test with 2 partitions
3. use pulsar-perf to create 10 prodcuers on test-partition-0
4. run test code to create producer for public/default/test, will fail because test-partition-0 already have 10 producer
5. 
    * without fix, test-partition-1 will have 10 producers because of sub-producer not close
    * with fix, test-partition-1 will have not more than 1 producer

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
bug-fix only

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
