### PR TITLE
[improve] Add configuration to limit times of client's lookup redirection.

### DIFF
--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -64,12 +64,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param timeout the timeout after which the operation will be considered as failed
      */
-    ClientConfiguration& setOperationTimeoutSeconds(int timeout);
+    ClientConfiguration& setOperationTimeoutSeconds(int32_t timeout);
 
     /**
      * @return the client operations timeout in seconds
      */
-    int getOperationTimeoutSeconds() const;
+    int32_t getOperationTimeoutSeconds() const;
 
     /**
      * Set the number of IO threads to be used by the Pulsar client. Default is 1
@@ -77,12 +77,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param threads number of threads
      */
-    ClientConfiguration& setIOThreads(int threads);
+    ClientConfiguration& setIOThreads(int32_t threads);
 
     /**
      * @return the number of IO threads to use
      */
-    int getIOThreads() const;
+    int32_t getIOThreads() const;
 
     /**
      * Set the number of threads to be used by the Pulsar client when delivering messages
@@ -94,12 +94,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param threads number of threads
      */
-    ClientConfiguration& setMessageListenerThreads(int threads);
+    ClientConfiguration& setMessageListenerThreads(int32_t threads);
 
     /**
      * @return the number of IO threads to use
      */
-    int getMessageListenerThreads() const;
+    int32_t getMessageListenerThreads() const;
 
     /**
      * Number of concurrent lookup-requests allowed on each broker-connection to prevent overload on broker.
@@ -109,12 +109,51 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param concurrentLookupRequest
      */
-    ClientConfiguration& setConcurrentLookupRequest(int concurrentLookupRequest);
+    ClientConfiguration& setConcurrentLookupRequest(int32_t concurrentLookupRequest);
 
     /**
      * @return Get configured total allowed concurrent lookup-request.
      */
-    int getConcurrentLookupRequest() const;
+    int32_t getConcurrentLookupRequest() const;
+
+    /**
+     * Max number of lookup redirection allowed on each look request to prevent overload on broker.
+     * <i>(default: 20)</i>
+     *
+     * @param maxLookupRedirects
+     */
+    ClientConfiguration& setMaxLookupRedirects(int32_t maxLookupRedirects);
+
+    /**
+     * @return Get configured total allowed lookup redirecting.
+     */
+    int32_t getMaxLookupRedirects() const;
+
+    /**
+     * Initial backoff interval in milliseconds.
+     * <i>(default: 100)</i>
+     *
+     * @param initialBackoffIntervalMs
+     */
+    ClientConfiguration& setInitialBackoffIntervalMs(int32_t initialBackoffIntervalMs);
+
+    /**
+     * @return Get initial backoff interval in milliseconds.
+     */
+    int32_t getInitialBackoffIntervalMs() const;
+
+    /**
+     * Max backoff interval in milliseconds.
+     * <i>(default: 60000)</i>
+     *
+     * @param maxBackoffIntervalMs
+     */
+    ClientConfiguration& setMaxBackoffIntervalMs(int32_t maxBackoffIntervalMs);
+
+    /**
+     * @return Get max backoff interval in milliseconds.
+     */
+    int32_t getMaxBackoffIntervalMs() const;
 
     /**
      * Initialize the log configuration
@@ -245,12 +284,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * Set to 0 means disabling stats collection.
      */
-    ClientConfiguration& setStatsIntervalInSeconds(const unsigned int&);
+    ClientConfiguration& setStatsIntervalInSeconds(const uint32_t&);
 
     /**
      * @return the stats interval configured for the client
      */
-    const unsigned int& getStatsIntervalInSeconds() const;
+    const uint32_t& getStatsIntervalInSeconds() const;
 
     /**
      * Set partitions update interval in seconds.
@@ -261,12 +300,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param intervalInSeconds the seconds between two lookup request for partitioned topic's metadata
      */
-    ClientConfiguration& setPartititionsUpdateInterval(unsigned int intervalInSeconds);
+    ClientConfiguration& setPartititionsUpdateInterval(uint32_t intervalInSeconds);
 
     /**
      * Get partitions update interval in seconds.
      */
-    unsigned int getPartitionsUpdateInterval() const;
+    uint32_t getPartitionsUpdateInterval() const;
 
     /**
      * Set the duration of time to wait for a connection to a broker to be established. If the duration passes
@@ -277,12 +316,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      * @param timeoutMs the duration in milliseconds
      * @return
      */
-    ClientConfiguration& setConnectionTimeout(int timeoutMs);
+    ClientConfiguration& setConnectionTimeout(int32_t timeoutMs);
 
     /**
      * The getter associated with setConnectionTimeout().
      */
-    int getConnectionTimeout() const;
+    int32_t getConnectionTimeout() const;
 
     friend class ClientImpl;
     friend class PulsarWrapper;

--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -64,12 +64,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param timeout the timeout after which the operation will be considered as failed
      */
-    ClientConfiguration& setOperationTimeoutSeconds(int32_t timeout);
+    ClientConfiguration& setOperationTimeoutSeconds(int timeout);
 
     /**
      * @return the client operations timeout in seconds
      */
-    int32_t getOperationTimeoutSeconds() const;
+    int getOperationTimeoutSeconds() const;
 
     /**
      * Set the number of IO threads to be used by the Pulsar client. Default is 1
@@ -77,12 +77,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param threads number of threads
      */
-    ClientConfiguration& setIOThreads(int32_t threads);
+    ClientConfiguration& setIOThreads(int threads);
 
     /**
      * @return the number of IO threads to use
      */
-    int32_t getIOThreads() const;
+    int getIOThreads() const;
 
     /**
      * Set the number of threads to be used by the Pulsar client when delivering messages
@@ -94,12 +94,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param threads number of threads
      */
-    ClientConfiguration& setMessageListenerThreads(int32_t threads);
+    ClientConfiguration& setMessageListenerThreads(int threads);
 
     /**
      * @return the number of IO threads to use
      */
-    int32_t getMessageListenerThreads() const;
+    int getMessageListenerThreads() const;
 
     /**
      * Number of concurrent lookup-requests allowed on each broker-connection to prevent overload on broker.
@@ -109,12 +109,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param concurrentLookupRequest
      */
-    ClientConfiguration& setConcurrentLookupRequest(int32_t concurrentLookupRequest);
+    ClientConfiguration& setConcurrentLookupRequest(int concurrentLookupRequest);
 
     /**
      * @return Get configured total allowed concurrent lookup-request.
      */
-    int32_t getConcurrentLookupRequest() const;
+    int getConcurrentLookupRequest() const;
 
     /**
      * Max number of lookup redirection allowed on each look request to prevent overload on broker.
@@ -122,12 +122,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param maxLookupRedirects
      */
-    ClientConfiguration& setMaxLookupRedirects(int32_t maxLookupRedirects);
+    ClientConfiguration& setMaxLookupRedirects(int maxLookupRedirects);
 
     /**
      * @return Get configured total allowed lookup redirecting.
      */
-    int32_t getMaxLookupRedirects() const;
+    int getMaxLookupRedirects() const;
 
     /**
      * Initial backoff interval in milliseconds.
@@ -135,12 +135,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param initialBackoffIntervalMs
      */
-    ClientConfiguration& setInitialBackoffIntervalMs(int32_t initialBackoffIntervalMs);
+    ClientConfiguration& setInitialBackoffIntervalMs(int initialBackoffIntervalMs);
 
     /**
      * @return Get initial backoff interval in milliseconds.
      */
-    int32_t getInitialBackoffIntervalMs() const;
+    int getInitialBackoffIntervalMs() const;
 
     /**
      * Max backoff interval in milliseconds.
@@ -148,12 +148,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param maxBackoffIntervalMs
      */
-    ClientConfiguration& setMaxBackoffIntervalMs(int32_t maxBackoffIntervalMs);
+    ClientConfiguration& setMaxBackoffIntervalMs(int maxBackoffIntervalMs);
 
     /**
      * @return Get max backoff interval in milliseconds.
      */
-    int32_t getMaxBackoffIntervalMs() const;
+    int getMaxBackoffIntervalMs() const;
 
     /**
      * Initialize the log configuration
@@ -284,12 +284,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * Set to 0 means disabling stats collection.
      */
-    ClientConfiguration& setStatsIntervalInSeconds(const uint32_t&);
+    ClientConfiguration& setStatsIntervalInSeconds(const unsigned int&);
 
     /**
      * @return the stats interval configured for the client
      */
-    const uint32_t& getStatsIntervalInSeconds() const;
+    const unsigned int& getStatsIntervalInSeconds() const;
 
     /**
      * Set partitions update interval in seconds.
@@ -300,12 +300,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      *
      * @param intervalInSeconds the seconds between two lookup request for partitioned topic's metadata
      */
-    ClientConfiguration& setPartititionsUpdateInterval(uint32_t intervalInSeconds);
+    ClientConfiguration& setPartititionsUpdateInterval(unsigned int intervalInSeconds);
 
     /**
      * Get partitions update interval in seconds.
      */
-    uint32_t getPartitionsUpdateInterval() const;
+    unsigned int getPartitionsUpdateInterval() const;
 
     /**
      * Set the duration of time to wait for a connection to a broker to be established. If the duration passes
@@ -316,12 +316,12 @@ class PULSAR_PUBLIC ClientConfiguration {
      * @param timeoutMs the duration in milliseconds
      * @return
      */
-    ClientConfiguration& setConnectionTimeout(int32_t timeoutMs);
+    ClientConfiguration& setConnectionTimeout(int timeoutMs);
 
     /**
      * The getter associated with setConnectionTimeout().
      */
-    int32_t getConnectionTimeout() const;
+    int getConnectionTimeout() const;
 
     friend class ClientImpl;
     friend class PulsarWrapper;

--- a/lib/BinaryProtoLookupService.h
+++ b/lib/BinaryProtoLookupService.h
@@ -20,6 +20,7 @@
 #define _PULSAR_BINARY_LOOKUP_SERVICE_HEADER_
 
 #include <pulsar/Authentication.h>
+#include <pulsar/ClientConfiguration.h>
 #include <pulsar/Schema.h>
 
 #include <mutex>
@@ -38,8 +39,11 @@ using GetSchemaPromisePtr = std::shared_ptr<Promise<Result, boost::optional<Sche
 class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
    public:
     BinaryProtoLookupService(ServiceNameResolver& serviceNameResolver, ConnectionPool& pool,
-                             const std::string& listenerName)
-        : serviceNameResolver_(serviceNameResolver), cnxPool_(pool), listenerName_(listenerName) {}
+                             const ClientConfiguration& clientConfiguration)
+        : serviceNameResolver_(serviceNameResolver),
+          cnxPool_(pool),
+          listenerName_(clientConfiguration.getListenerName()),
+          maxLookupRedirects_(clientConfiguration.getMaxLookupRedirects()) {}
 
     LookupResultFuture getBroker(const TopicName& topicName) override;
 
@@ -52,13 +56,14 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
    private:
     std::mutex mutex_;
     uint64_t requestIdGenerator_ = 0;
+    const int32_t maxLookupRedirects_;
 
     ServiceNameResolver& serviceNameResolver_;
     ConnectionPool& cnxPool_;
     std::string listenerName_;
 
-    // TODO: limit the redirect count, see https://github.com/apache/pulsar/pull/7096
-    LookupResultFuture findBroker(const std::string& address, bool authoritative, const std::string& topic);
+    LookupResultFuture findBroker(const std::string& address, bool authoritative, const std::string& topic,
+                                  size_t redirectCount);
 
     void sendPartitionMetadataLookupRequest(const std::string& topicName, Result result,
                                             const ClientConnectionWeakPtr& clientCnx,

--- a/lib/BinaryProtoLookupService.h
+++ b/lib/BinaryProtoLookupService.h
@@ -56,11 +56,11 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
    private:
     std::mutex mutex_;
     uint64_t requestIdGenerator_ = 0;
-    const int32_t maxLookupRedirects_;
 
     ServiceNameResolver& serviceNameResolver_;
     ConnectionPool& cnxPool_;
     std::string listenerName_;
+    const int32_t maxLookupRedirects_;
 
     LookupResultFuture findBroker(const std::string& address, bool authoritative, const std::string& topic,
                                   size_t redirectCount);

--- a/lib/BinaryProtoLookupService.h
+++ b/lib/BinaryProtoLookupService.h
@@ -53,6 +53,11 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
 
     Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override;
 
+   protected:
+    // Mark findBroker as protected to make it accessible from test.
+    LookupResultFuture findBroker(const std::string& address, bool authoritative, const std::string& topic,
+                                  size_t redirectCount);
+
    private:
     std::mutex mutex_;
     uint64_t requestIdGenerator_ = 0;
@@ -61,9 +66,6 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
     ConnectionPool& cnxPool_;
     std::string listenerName_;
     const int32_t maxLookupRedirects_;
-
-    LookupResultFuture findBroker(const std::string& address, bool authoritative, const std::string& topic,
-                                  size_t redirectCount);
 
     void sendPartitionMetadataLookupRequest(const std::string& topicName, Result result,
                                             const ClientConnectionWeakPtr& clientCnx,

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -47,26 +47,26 @@ Authentication& ClientConfiguration::getAuth() const { return *impl_->authentica
 
 const AuthenticationPtr& ClientConfiguration::getAuthPtr() const { return impl_->authenticationPtr; }
 
-ClientConfiguration& ClientConfiguration::setOperationTimeoutSeconds(int32_t timeout) {
+ClientConfiguration& ClientConfiguration::setOperationTimeoutSeconds(int timeout) {
     impl_->operationTimeoutSeconds = timeout;
     return *this;
 }
 
-int32_t ClientConfiguration::getOperationTimeoutSeconds() const { return impl_->operationTimeoutSeconds; }
+int ClientConfiguration::getOperationTimeoutSeconds() const { return impl_->operationTimeoutSeconds; }
 
-ClientConfiguration& ClientConfiguration::setIOThreads(int32_t threads) {
+ClientConfiguration& ClientConfiguration::setIOThreads(int threads) {
     impl_->ioThreads = threads;
     return *this;
 }
 
-int32_t ClientConfiguration::getIOThreads() const { return impl_->ioThreads; }
+int ClientConfiguration::getIOThreads() const { return impl_->ioThreads; }
 
-ClientConfiguration& ClientConfiguration::setMessageListenerThreads(int32_t threads) {
+ClientConfiguration& ClientConfiguration::setMessageListenerThreads(int threads) {
     impl_->messageListenerThreads = threads;
     return *this;
 }
 
-int32_t ClientConfiguration::getMessageListenerThreads() const { return impl_->messageListenerThreads; }
+int ClientConfiguration::getMessageListenerThreads() const { return impl_->messageListenerThreads; }
 
 ClientConfiguration& ClientConfiguration::setUseTls(bool useTls) {
     impl_->useTls = useTls;
@@ -116,33 +116,33 @@ ClientConfiguration& ClientConfiguration::setTlsAllowInsecureConnection(bool all
 
 bool ClientConfiguration::isTlsAllowInsecureConnection() const { return impl_->tlsAllowInsecureConnection; }
 
-ClientConfiguration& ClientConfiguration::setConcurrentLookupRequest(int32_t concurrentLookupRequest) {
+ClientConfiguration& ClientConfiguration::setConcurrentLookupRequest(int concurrentLookupRequest) {
     impl_->concurrentLookupRequest = concurrentLookupRequest;
     return *this;
 }
 
-int32_t ClientConfiguration::getConcurrentLookupRequest() const { return impl_->concurrentLookupRequest; }
+int ClientConfiguration::getConcurrentLookupRequest() const { return impl_->concurrentLookupRequest; }
 
-ClientConfiguration& ClientConfiguration::setMaxLookupRedirects(int32_t maxLookupRedirects) {
+ClientConfiguration& ClientConfiguration::setMaxLookupRedirects(int maxLookupRedirects) {
     impl_->maxLookupRedirects = maxLookupRedirects;
     return *this;
 }
 
-int32_t ClientConfiguration::getMaxLookupRedirects() const { return impl_->maxLookupRedirects; }
+int ClientConfiguration::getMaxLookupRedirects() const { return impl_->maxLookupRedirects; }
 
-ClientConfiguration& ClientConfiguration::setInitialBackoffIntervalMs(int32_t initialBackoffIntervalMs) {
+ClientConfiguration& ClientConfiguration::setInitialBackoffIntervalMs(int initialBackoffIntervalMs) {
     impl_->initialBackoffIntervalMs = initialBackoffIntervalMs;
     return *this;
 }
 
-int32_t ClientConfiguration::getInitialBackoffIntervalMs() const { return impl_->initialBackoffIntervalMs; }
+int ClientConfiguration::getInitialBackoffIntervalMs() const { return impl_->initialBackoffIntervalMs; }
 
-ClientConfiguration& ClientConfiguration::setMaxBackoffIntervalMs(int32_t maxBackoffIntervalMs) {
+ClientConfiguration& ClientConfiguration::setMaxBackoffIntervalMs(int maxBackoffIntervalMs) {
     impl_->maxBackoffIntervalMs = maxBackoffIntervalMs;
     return *this;
 }
 
-int32_t ClientConfiguration::getMaxBackoffIntervalMs() const { return impl_->maxBackoffIntervalMs; }
+int ClientConfiguration::getMaxBackoffIntervalMs() const { return impl_->maxBackoffIntervalMs; }
 
 ClientConfiguration& ClientConfiguration::setLogConfFilePath(const std::string& logConfFilePath) {
     impl_->logConfFilePath = logConfFilePath;
@@ -156,21 +156,24 @@ ClientConfiguration& ClientConfiguration::setLogger(LoggerFactory* loggerFactory
     return *this;
 }
 
-ClientConfiguration& ClientConfiguration::setStatsIntervalInSeconds(const uint32_t& statsIntervalInSeconds) {
+ClientConfiguration& ClientConfiguration::setStatsIntervalInSeconds(
+    const unsigned int& statsIntervalInSeconds) {
     impl_->statsIntervalInSeconds = statsIntervalInSeconds;
     return *this;
 }
 
-const uint32_t& ClientConfiguration::getStatsIntervalInSeconds() const {
+const unsigned int& ClientConfiguration::getStatsIntervalInSeconds() const {
     return impl_->statsIntervalInSeconds;
 }
 
-ClientConfiguration& ClientConfiguration::setPartititionsUpdateInterval(uint32_t intervalInSeconds) {
+ClientConfiguration& ClientConfiguration::setPartititionsUpdateInterval(unsigned int intervalInSeconds) {
     impl_->partitionsUpdateInterval = intervalInSeconds;
     return *this;
 }
 
-uint32_t ClientConfiguration::getPartitionsUpdateInterval() const { return impl_->partitionsUpdateInterval; }
+unsigned int ClientConfiguration::getPartitionsUpdateInterval() const {
+    return impl_->partitionsUpdateInterval;
+}
 
 ClientConfiguration& ClientConfiguration::setListenerName(const std::string& listenerName) {
     impl_->listenerName = listenerName;
@@ -179,11 +182,11 @@ ClientConfiguration& ClientConfiguration::setListenerName(const std::string& lis
 
 const std::string& ClientConfiguration::getListenerName() const { return impl_->listenerName; }
 
-ClientConfiguration& ClientConfiguration::setConnectionTimeout(int32_t timeoutMs) {
+ClientConfiguration& ClientConfiguration::setConnectionTimeout(int timeoutMs) {
     impl_->connectionTimeoutMs = timeoutMs;
     return *this;
 }
 
-int32_t ClientConfiguration::getConnectionTimeout() const { return impl_->connectionTimeoutMs; }
+int ClientConfiguration::getConnectionTimeout() const { return impl_->connectionTimeoutMs; }
 
 }  // namespace pulsar

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -47,26 +47,26 @@ Authentication& ClientConfiguration::getAuth() const { return *impl_->authentica
 
 const AuthenticationPtr& ClientConfiguration::getAuthPtr() const { return impl_->authenticationPtr; }
 
-ClientConfiguration& ClientConfiguration::setOperationTimeoutSeconds(int timeout) {
+ClientConfiguration& ClientConfiguration::setOperationTimeoutSeconds(int32_t timeout) {
     impl_->operationTimeoutSeconds = timeout;
     return *this;
 }
 
-int ClientConfiguration::getOperationTimeoutSeconds() const { return impl_->operationTimeoutSeconds; }
+int32_t ClientConfiguration::getOperationTimeoutSeconds() const { return impl_->operationTimeoutSeconds; }
 
-ClientConfiguration& ClientConfiguration::setIOThreads(int threads) {
+ClientConfiguration& ClientConfiguration::setIOThreads(int32_t threads) {
     impl_->ioThreads = threads;
     return *this;
 }
 
-int ClientConfiguration::getIOThreads() const { return impl_->ioThreads; }
+int32_t ClientConfiguration::getIOThreads() const { return impl_->ioThreads; }
 
-ClientConfiguration& ClientConfiguration::setMessageListenerThreads(int threads) {
+ClientConfiguration& ClientConfiguration::setMessageListenerThreads(int32_t threads) {
     impl_->messageListenerThreads = threads;
     return *this;
 }
 
-int ClientConfiguration::getMessageListenerThreads() const { return impl_->messageListenerThreads; }
+int32_t ClientConfiguration::getMessageListenerThreads() const { return impl_->messageListenerThreads; }
 
 ClientConfiguration& ClientConfiguration::setUseTls(bool useTls) {
     impl_->useTls = useTls;
@@ -116,12 +116,33 @@ ClientConfiguration& ClientConfiguration::setTlsAllowInsecureConnection(bool all
 
 bool ClientConfiguration::isTlsAllowInsecureConnection() const { return impl_->tlsAllowInsecureConnection; }
 
-ClientConfiguration& ClientConfiguration::setConcurrentLookupRequest(int concurrentLookupRequest) {
+ClientConfiguration& ClientConfiguration::setConcurrentLookupRequest(int32_t concurrentLookupRequest) {
     impl_->concurrentLookupRequest = concurrentLookupRequest;
     return *this;
 }
 
-int ClientConfiguration::getConcurrentLookupRequest() const { return impl_->concurrentLookupRequest; }
+int32_t ClientConfiguration::getConcurrentLookupRequest() const { return impl_->concurrentLookupRequest; }
+
+ClientConfiguration& ClientConfiguration::setMaxLookupRedirects(int32_t maxLookupRedirects) {
+    impl_->maxLookupRedirects = maxLookupRedirects;
+    return *this;
+}
+
+int32_t ClientConfiguration::getMaxLookupRedirects() const { return impl_->maxLookupRedirects; }
+
+ClientConfiguration& ClientConfiguration::setInitialBackoffIntervalMs(int32_t initialBackoffIntervalMs) {
+    impl_->initialBackoffIntervalMs = initialBackoffIntervalMs;
+    return *this;
+}
+
+int32_t ClientConfiguration::getInitialBackoffIntervalMs() const { return impl_->initialBackoffIntervalMs; }
+
+ClientConfiguration& ClientConfiguration::setMaxBackoffIntervalMs(int32_t maxBackoffIntervalMs) {
+    impl_->maxBackoffIntervalMs = maxBackoffIntervalMs;
+    return *this;
+}
+
+int32_t ClientConfiguration::getMaxBackoffIntervalMs() const { return impl_->maxBackoffIntervalMs; }
 
 ClientConfiguration& ClientConfiguration::setLogConfFilePath(const std::string& logConfFilePath) {
     impl_->logConfFilePath = logConfFilePath;
@@ -135,24 +156,21 @@ ClientConfiguration& ClientConfiguration::setLogger(LoggerFactory* loggerFactory
     return *this;
 }
 
-ClientConfiguration& ClientConfiguration::setStatsIntervalInSeconds(
-    const unsigned int& statsIntervalInSeconds) {
+ClientConfiguration& ClientConfiguration::setStatsIntervalInSeconds(const uint32_t& statsIntervalInSeconds) {
     impl_->statsIntervalInSeconds = statsIntervalInSeconds;
     return *this;
 }
 
-const unsigned int& ClientConfiguration::getStatsIntervalInSeconds() const {
+const uint32_t& ClientConfiguration::getStatsIntervalInSeconds() const {
     return impl_->statsIntervalInSeconds;
 }
 
-ClientConfiguration& ClientConfiguration::setPartititionsUpdateInterval(unsigned int intervalInSeconds) {
+ClientConfiguration& ClientConfiguration::setPartititionsUpdateInterval(uint32_t intervalInSeconds) {
     impl_->partitionsUpdateInterval = intervalInSeconds;
     return *this;
 }
 
-unsigned int ClientConfiguration::getPartitionsUpdateInterval() const {
-    return impl_->partitionsUpdateInterval;
-}
+uint32_t ClientConfiguration::getPartitionsUpdateInterval() const { return impl_->partitionsUpdateInterval; }
 
 ClientConfiguration& ClientConfiguration::setListenerName(const std::string& listenerName) {
     impl_->listenerName = listenerName;
@@ -161,11 +179,11 @@ ClientConfiguration& ClientConfiguration::setListenerName(const std::string& lis
 
 const std::string& ClientConfiguration::getListenerName() const { return impl_->listenerName; }
 
-ClientConfiguration& ClientConfiguration::setConnectionTimeout(int timeoutMs) {
+ClientConfiguration& ClientConfiguration::setConnectionTimeout(int32_t timeoutMs) {
     impl_->connectionTimeoutMs = timeoutMs;
     return *this;
 }
 
-int ClientConfiguration::getConnectionTimeout() const { return impl_->connectionTimeoutMs; }
+int32_t ClientConfiguration::getConnectionTimeout() const { return impl_->connectionTimeoutMs; }
 
 }  // namespace pulsar

--- a/lib/ClientConfigurationImpl.h
+++ b/lib/ClientConfigurationImpl.h
@@ -26,22 +26,25 @@ namespace pulsar {
 struct ClientConfigurationImpl {
     AuthenticationPtr authenticationPtr{AuthFactory::Disabled()};
     uint64_t memoryLimit{0ull};
-    int ioThreads{1};
-    int operationTimeoutSeconds{30};
-    int messageListenerThreads{1};
-    int concurrentLookupRequest{50000};
+    int32_t ioThreads{1};
+    int32_t operationTimeoutSeconds{30};
+    int32_t messageListenerThreads{1};
+    int32_t concurrentLookupRequest{50000};
+    int32_t maxLookupRedirects{20};
+    int32_t initialBackoffIntervalMs{100};
+    int32_t maxBackoffIntervalMs{60000};
     std::string logConfFilePath;
     bool useTls{false};
     std::string tlsPrivateKeyFilePath;
     std::string tlsCertificateFilePath;
     std::string tlsTrustCertsFilePath;
     bool tlsAllowInsecureConnection{false};
-    unsigned int statsIntervalInSeconds{600};  // 10 minutes
+    uint32_t statsIntervalInSeconds{600};  // 10 minutes
     std::unique_ptr<LoggerFactory> loggerFactory;
     bool validateHostName{false};
-    unsigned int partitionsUpdateInterval{60};  // 1 minute
+    uint32_t partitionsUpdateInterval{60};  // 1 minute
     std::string listenerName;
-    int connectionTimeoutMs{10000};  // 10 seconds
+    int32_t connectionTimeoutMs{10000};  // 10 seconds
 
     std::unique_ptr<LoggerFactory> takeLogger() { return std::move(loggerFactory); }
 };

--- a/lib/ClientConfigurationImpl.h
+++ b/lib/ClientConfigurationImpl.h
@@ -26,25 +26,25 @@ namespace pulsar {
 struct ClientConfigurationImpl {
     AuthenticationPtr authenticationPtr{AuthFactory::Disabled()};
     uint64_t memoryLimit{0ull};
-    int32_t ioThreads{1};
-    int32_t operationTimeoutSeconds{30};
-    int32_t messageListenerThreads{1};
-    int32_t concurrentLookupRequest{50000};
-    int32_t maxLookupRedirects{20};
-    int32_t initialBackoffIntervalMs{100};
-    int32_t maxBackoffIntervalMs{60000};
+    int ioThreads{1};
+    int operationTimeoutSeconds{30};
+    int messageListenerThreads{1};
+    int concurrentLookupRequest{50000};
+    int maxLookupRedirects{20};
+    int initialBackoffIntervalMs{100};
+    int maxBackoffIntervalMs{60000};
     std::string logConfFilePath;
     bool useTls{false};
     std::string tlsPrivateKeyFilePath;
     std::string tlsCertificateFilePath;
     std::string tlsTrustCertsFilePath;
     bool tlsAllowInsecureConnection{false};
-    uint32_t statsIntervalInSeconds{600};  // 10 minutes
+    unsigned int statsIntervalInSeconds{600};  // 10 minutes
     std::unique_ptr<LoggerFactory> loggerFactory;
     bool validateHostName{false};
-    uint32_t partitionsUpdateInterval{60};  // 1 minute
+    unsigned int partitionsUpdateInterval{60};  // 1 minute
     std::string listenerName;
-    int32_t connectionTimeoutMs{10000};  // 10 seconds
+    int connectionTimeoutMs{10000};  // 10 seconds
 
     std::unique_ptr<LoggerFactory> takeLogger() { return std::move(loggerFactory); }
 };

--- a/lib/ClientImpl.cc
+++ b/lib/ClientImpl.cc
@@ -116,9 +116,8 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
             std::cref(clientConfiguration_.getAuthPtr()));
     } else {
         LOG_DEBUG("Using Binary Lookup");
-        underlyingLookupServicePtr =
-            std::make_shared<BinaryProtoLookupService>(std::ref(serviceNameResolver_), std::ref(pool_),
-                                                       std::cref(clientConfiguration_.getListenerName()));
+        underlyingLookupServicePtr = std::make_shared<BinaryProtoLookupService>(
+            std::ref(serviceNameResolver_), std::ref(pool_), std::cref(clientConfiguration_));
     }
 
     lookupServicePtr_ = RetryableLookupService::create(

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -60,10 +60,12 @@ ConsumerImpl::ConsumerImpl(const ClientImplPtr client, const std::string& topic,
                            const ExecutorServicePtr listenerExecutor /* = NULL by default */,
                            bool hasParent /* = false by default */,
                            const ConsumerTopicType consumerTopicType /* = NonPartitioned by default */,
-                           Commands::SubscriptionMode subscriptionMode,
-                           boost::optional<MessageId> startMessageId)
-    : ConsumerImplBase(client, topic, Backoff(milliseconds(100), seconds(60), milliseconds(0)), conf,
-                       listenerExecutor ? listenerExecutor : client->getListenerExecutorProvider()->get()),
+                           Commands::SubscriptionMode subscriptionMode, Optional<MessageId> startMessageId)
+    : ConsumerImplBase(
+          client, topic,
+          Backoff(milliseconds(client->getClientConfig().getInitialBackoffIntervalMs()),
+                  milliseconds(client->getClientConfig().getMaxBackoffIntervalMs()), milliseconds(0)),
+          conf, listenerExecutor ? listenerExecutor : client->getListenerExecutorProvider()->get()),
       waitingForZeroQueueSizeMessage(false),
       config_(conf),
       subscription_(subscriptionName),

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -60,7 +60,8 @@ ConsumerImpl::ConsumerImpl(const ClientImplPtr client, const std::string& topic,
                            const ExecutorServicePtr listenerExecutor /* = NULL by default */,
                            bool hasParent /* = false by default */,
                            const ConsumerTopicType consumerTopicType /* = NonPartitioned by default */,
-                           Commands::SubscriptionMode subscriptionMode, Optional<MessageId> startMessageId)
+                           Commands::SubscriptionMode subscriptionMode,
+                           boost::optional<MessageId> startMessageId)
     : ConsumerImplBase(
           client, topic,
           Backoff(milliseconds(client->getClientConfig().getInitialBackoffIntervalMs()),

--- a/lib/HTTPLookupService.cc
+++ b/lib/HTTPLookupService.cc
@@ -42,7 +42,6 @@ const static std::string V2_PATH = "/lookup/v2/topic/";
 const static std::string ADMIN_PATH_V1 = "/admin/";
 const static std::string ADMIN_PATH_V2 = "/admin/v2/";
 
-const static int MAX_HTTP_REDIRECTS = 20;
 const static std::string PARTITION_METHOD_NAME = "partitions";
 const static int NUMBER_OF_LOOKUP_THREADS = 1;
 
@@ -63,6 +62,7 @@ HTTPLookupService::HTTPLookupService(ServiceNameResolver &serviceNameResolver,
       serviceNameResolver_(serviceNameResolver),
       authenticationPtr_(authData),
       lookupTimeoutInSeconds_(clientConfiguration.getOperationTimeoutSeconds()),
+      maxLookupRedirects_(clientConfiguration.getMaxLookupRedirects()),
       tlsPrivateFilePath_(clientConfiguration.getTlsPrivateKeyFilePath()),
       tlsCertificateFilePath_(clientConfiguration.getTlsCertificateFilePath()),
       tlsTrustCertsFilePath_(clientConfiguration.getTlsTrustCertsFilePath()),
@@ -189,7 +189,7 @@ Result HTTPLookupService::sendHTTPRequest(std::string completeUrl, std::string &
                                           long &responseCode) {
     uint16_t reqCount = 0;
     Result retResult = ResultOk;
-    while (++reqCount <= MAX_HTTP_REDIRECTS) {
+    while (++reqCount <= maxLookupRedirects_) {
         CURL *handle;
         CURLcode res;
         std::string version = std::string("Pulsar-CPP-v") + PULSAR_VERSION_STR;

--- a/lib/HTTPLookupService.h
+++ b/lib/HTTPLookupService.h
@@ -50,6 +50,7 @@ class HTTPLookupService : public LookupService, public std::enable_shared_from_t
     ServiceNameResolver& serviceNameResolver_;
     AuthenticationPtr authenticationPtr_;
     int lookupTimeoutInSeconds_;
+    const int maxLookupRedirects_;
     std::string tlsPrivateFilePath_;
     std::string tlsCertificateFilePath_;
     std::string tlsTrustCertsFilePath_;

--- a/lib/HandlerBase.h
+++ b/lib/HandlerBase.h
@@ -113,13 +113,14 @@ class HandlerBase {
 
     enum State
     {
-        NotStarted,
-        Pending,
-        Ready,
-        Closing,
-        Closed,
-        Failed,
-        Producer_Fenced
+        NotStarted,       // Not initialized, in Java client: HandlerState.State.Uninitialized
+        Pending,          // Client connecting to broker, in Java client: HandlerState.State.Connecting
+        Ready,            // Handler is being used, in Java client: HandlerState.State.Ready
+        Closing,          // Close cmd has been sent to broker, in Java client: HandlerState.State.Closing
+        Closed,           // Broker acked the close, in Java client: HandlerState.State.Closed
+        Failed,           // Handler is failed, in Java client: HandlerState.State.Failed
+        Producer_Fenced,  // The producer has been fenced by the broker
+                          // in Java client: HandlerState.State.ProducerFenced
     };
 
     std::atomic<State> state_;

--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -275,6 +275,10 @@ void PartitionedProducerImpl::closeAsync(CloseCallback originalCallback) {
         closeCallback(ResultAlreadyClosed);
         return;
     }
+    State expectedState = Ready;
+    if (!state_.compare_exchange_strong(expectedState, Closing)) {
+        return;
+    }
 
     cancelTimers();
 

--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -275,10 +275,6 @@ void PartitionedProducerImpl::closeAsync(CloseCallback originalCallback) {
         closeCallback(ResultAlreadyClosed);
         return;
     }
-    State expectedState = Ready;
-    if (!state_.compare_exchange_strong(expectedState, Closing)) {
-        return;
-    }
 
     cancelTimers();
 

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -56,9 +56,10 @@ struct ProducerImpl::PendingCallbacks {
 
 ProducerImpl::ProducerImpl(ClientImplPtr client, const TopicName& topicName,
                            const ProducerConfiguration& conf, int32_t partition)
-    : HandlerBase(
-          client, (partition < 0) ? topicName.toString() : topicName.getTopicPartitionName(partition),
-          Backoff(milliseconds(100), seconds(60), milliseconds(std::max(100, conf.getSendTimeout() - 100)))),
+    : HandlerBase(client, (partition < 0) ? topicName.toString() : topicName.getTopicPartitionName(partition),
+                  Backoff(milliseconds(client->getClientConfig().getInitialBackoffIntervalMs()),
+                          milliseconds(client->getClientConfig().getMaxBackoffIntervalMs()),
+                          milliseconds(std::max(100, conf.getSendTimeout() - 100)))),
       conf_(conf),
       semaphore_(),
       pendingMessagesQueue_(),
@@ -978,4 +979,4 @@ void ProducerImpl::asyncWaitSendTimeout(DurationType expiryTime) {
 ProducerImplWeakPtr ProducerImpl::weak_from_this() noexcept { return shared_from_this(); }
 
 }  // namespace pulsar
-/* namespace pulsar */
+   /* namespace pulsar */

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -979,4 +979,3 @@ void ProducerImpl::asyncWaitSendTimeout(DurationType expiryTime) {
 ProducerImplWeakPtr ProducerImpl::weak_from_this() noexcept { return shared_from_this(); }
 
 }  // namespace pulsar
-   /* namespace pulsar */

--- a/tests/LookupServiceTest.cc
+++ b/tests/LookupServiceTest.cc
@@ -50,7 +50,7 @@ TEST(LookupServiceTest, basicLookup) {
     ExecutorServiceProviderPtr ioExecutorProvider_(std::make_shared<ExecutorServiceProvider>(1));
     ConnectionPool pool_(conf, ioExecutorProvider_, authData, true);
     ServiceNameResolver serviceNameResolver(url);
-    BinaryProtoLookupService lookupService(serviceNameResolver, pool_, "");
+    BinaryProtoLookupService lookupService(serviceNameResolver, pool_, conf);
 
     TopicNamePtr topicName = TopicName::get("topic");
 
@@ -115,7 +115,7 @@ TEST(LookupServiceTest, basicGetNamespaceTopics) {
     ExecutorServiceProviderPtr ioExecutorProvider_(std::make_shared<ExecutorServiceProvider>(1));
     ConnectionPool pool_(conf, ioExecutorProvider_, authData, true);
     ServiceNameResolver serviceNameResolver(url);
-    BinaryProtoLookupService lookupService(serviceNameResolver, pool_, "");
+    BinaryProtoLookupService lookupService(serviceNameResolver, pool_, conf);
 
     TopicNamePtr topicName = TopicName::get(topicName1);
     NamespaceNamePtr nsName = topicName->getNamespaceName();
@@ -177,7 +177,8 @@ static void testMultiAddresses(LookupService& lookupService) {
 TEST(LookupServiceTest, testMultiAddresses) {
     ConnectionPool pool({}, std::make_shared<ExecutorServiceProvider>(1), AuthFactory::Disabled(), true);
     ServiceNameResolver serviceNameResolver("pulsar://localhost,localhost:9999");
-    BinaryProtoLookupService binaryLookupService(serviceNameResolver, pool, "");
+    ClientConfiguration conf;
+    BinaryProtoLookupService binaryLookupService(serviceNameResolver, pool, conf);
     testMultiAddresses(binaryLookupService);
 
     // HTTPLookupService calls shared_from_this() internally, we must create a shared pointer to test
@@ -190,9 +191,10 @@ TEST(LookupServiceTest, testRetry) {
     auto executorProvider = std::make_shared<ExecutorServiceProvider>(1);
     ConnectionPool pool({}, executorProvider, AuthFactory::Disabled(), true);
     ServiceNameResolver serviceNameResolver("pulsar://localhost:9999,localhost");
+    ClientConfiguration conf;
 
     auto lookupService = RetryableLookupService::create(
-        std::make_shared<BinaryProtoLookupService>(serviceNameResolver, pool, ""), 30 /* seconds */,
+        std::make_shared<BinaryProtoLookupService>(serviceNameResolver, pool, conf), 30 /* seconds */,
         executorProvider);
 
     PulsarFriend::setServiceUrlIndex(serviceNameResolver, 0);
@@ -240,10 +242,11 @@ TEST(LookupServiceTest, testTimeout) {
     auto executorProvider = std::make_shared<ExecutorServiceProvider>(1);
     ConnectionPool pool({}, executorProvider, AuthFactory::Disabled(), true);
     ServiceNameResolver serviceNameResolver("pulsar://localhost:9990,localhost:9902,localhost:9904");
+    ClientConfiguration conf;
 
     constexpr int timeoutInSeconds = 2;
     auto lookupService = RetryableLookupService::create(
-        std::make_shared<BinaryProtoLookupService>(serviceNameResolver, pool, ""), timeoutInSeconds,
+        std::make_shared<BinaryProtoLookupService>(serviceNameResolver, pool, conf), timeoutInSeconds,
         executorProvider);
     auto topicNamePtr = TopicName::get("lookup-service-test-retry");
 


### PR DESCRIPTION
Master Issue: apache/pulsar#7096

### Motivation

C++ client's `BinaryProtoLookupService` does not limit the times of client's lookup redirection. It may result in broker overloading as described in apache/pulsar#7096.

### Modifications

1. Added max. look redirection limit in `BinaryProtoLookupService::findBroker`.
2. Added configuration to control max times of lookup redirection in both `BinaryProtoLookupService` and `HTTPLookupService`.
3. Added configuration to control initial- and max-backoff interval in both `ProducerImpl` and `ConsumerImpl`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Test cases are on the way

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

- [ ] `doc-required`

- [ ] `doc-not-needed`

- [ ] `doc` 

- [x] `doc-complete`
