### PR TITLE
Fix the broken master by the upgrade of GTest

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -31,7 +31,7 @@ jobs:
 
   unit-tests:
     name: Run unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
 
     steps:

--- a/tests/KeyValueSchemaTest.cc
+++ b/tests/KeyValueSchemaTest.cc
@@ -25,6 +25,12 @@ using namespace pulsar;
 
 static const std::string lookupUrl = "pulsar://localhost:6650";
 
+// NOTE: the default operator<< for KeyValueEncodingType (value, not const reference) might not work on some
+// GTest implementations. We need to implement the operator<< for const reference.
+inline std::ostream& operator<<(std::ostream& os, const KeyValueEncodingType& encodingType) {
+    return (os << strEncodingType(encodingType));
+}
+
 class KeyValueSchemaTest : public ::testing::TestWithParam<KeyValueEncodingType> {
    public:
     void TearDown() override { client.close(); }
@@ -85,5 +91,5 @@ TEST_P(KeyValueSchemaTest, testKeyValueSchema) {
     ASSERT_EQ(keyValueData.getValueAsString(), valueData);
 }
 
-INSTANTIATE_TEST_CASE_P(Pulsar, KeyValueSchemaTest,
-                        ::testing::Values(KeyValueEncodingType::INLINE, KeyValueEncodingType::SEPARATED));
+INSTANTIATE_TEST_SUITE_P(Pulsar, KeyValueSchemaTest,
+                         ::testing::Values(KeyValueEncodingType::INLINE, KeyValueEncodingType::SEPARATED));


### PR DESCRIPTION
### Motivation

The `ubuntu:latest` image became `ubuntu:22.04` after https://github.com/actions/runner-images/issues/6399. The GTest is no longer compatible with the current code so the CI failed.

### Modifications

Pass `int` to `TestWithParam` and stick the image version to `ubuntu-22.04` instead of `ubuntu-latest`.