### PR TITLE
[fix] Fix a crash when closing a connection while connecting

### DIFF
--- a/tests/ClientTest.cc
+++ b/tests/ClientTest.cc
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
 
+#include <chrono>
 #include <future>
 
 #include "HttpHelper.h"
@@ -292,4 +293,18 @@ TEST(ClientTest, testMultiBrokerUrl) {
     PulsarFriend::setServiceUrlIndex(client, 0);
     ASSERT_EQ(ResultOk, client.createReader(topic, MessageId::earliest(), {}, reader));
     client.close();
+}
+
+TEST(ClientTest, testCloseClient) {
+    const std::string topic = "client-test-close-client-" + std::to_string(time(nullptr));
+
+    for (int i = 0; i < 1000; ++i) {
+        Client client(lookupUrl);
+        client.createProducerAsync(topic, [](Result result, Producer producer) { producer.close(); });
+        // simulate different time interval before close
+        auto t0 = std::chrono::steady_clock::now();
+        while ((std::chrono::steady_clock::now() - t0) < std::chrono::microseconds(i)) {
+        }
+        client.close();
+    }
 }


### PR DESCRIPTION
### Motivation

Fix a crash when closing a connection while connecting.

There are race conditions in ClientConnection. The normal state change is Pending->TcpConnected->Ready and close will change state to Disconnected. In the current code, when close is called right before state changes to TcpConnected or Ready, state is set to Disconnected and then overwritten to TcpConnected or Ready. Then connection is in an error state and subsequence operations may crash.

### Modifications

* Check isClosed() before state changes
* Use lock to access executor_ to avoid data race in handlePulsarConnected()

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
* Added a unit test ClientTest.testCloseClient

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
bug fix only

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
