### PR TITLE
[feat] Support Dead Letter Topic.

### DIFF
--- a/include/pulsar/ConsumerConfiguration.h
+++ b/include/pulsar/ConsumerConfiguration.h
@@ -35,11 +35,13 @@
 #include <memory>
 
 #include "BatchReceivePolicy.h"
+#include "DeadLetterPolicy.h"
 
 namespace pulsar {
 
 class Consumer;
 class PulsarWrapper;
+class PulsarFriend;
 
 /// Callback definition for non-data operation
 typedef std::vector<Message> Messages;
@@ -409,6 +411,42 @@ class PULSAR_PUBLIC ConsumerConfiguration {
     const BatchReceivePolicy& getBatchReceivePolicy() const;
 
     /**
+     * Set dead letter policy for consumer
+     *
+     * By default, some messages are redelivered many times, even to the extent that they can never be
+     * stopped. By using the dead letter mechanism, messages have the max redelivery count, when they
+     * exceeding the maximum number of redeliveries. Messages are sent to dead letter topics and acknowledged
+     * automatically.
+     *
+     * You can enable the dead letter mechanism by setting the dead letter policy.
+     * Example:
+     *
+     * <pre>
+     * * DeadLetterPolicy dlqPolicy = DeadLetterPolicyBuilder()
+     *                       .maxRedeliverCount(10)
+     *                       .build();
+     * </pre>
+     * Default dead letter topic name is {TopicName}-{Subscription}-DLQ.
+     * To set a custom dead letter topic name
+     * <pre>
+     * DeadLetterPolicy dlqPolicy = DeadLetterPolicyBuilder()
+     *                       .deadLetterTopic("dlq-topic")
+     *                       .maxRedeliverCount(10)
+     *                       .initialSubscriptionName("init-sub-name")
+     *                       .build();
+     * </pre>
+     * @param deadLetterPolicy Default value is empty
+     */
+    void setDeadLetterPolicy(const DeadLetterPolicy& deadLetterPolicy);
+
+    /**
+     * Get dead letter policy.
+     *
+     * @return dead letter policy
+     */
+    const DeadLetterPolicy& getDeadLetterPolicy() const;
+
+    /**
      * Set whether the subscription status should be replicated.
      * The default value is `false`.
      *
@@ -581,6 +619,7 @@ class PULSAR_PUBLIC ConsumerConfiguration {
     bool isBatchIndexAckEnabled() const;
 
     friend class PulsarWrapper;
+    friend class PulsarFriend;
 
    private:
     std::shared_ptr<ConsumerConfigurationImpl> impl_;

--- a/include/pulsar/DeadLetterPolicy.h
+++ b/include/pulsar/DeadLetterPolicy.h
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef DEAD_LETTER_POLICY_HPP_
+#define DEAD_LETTER_POLICY_HPP_
+
+#include <pulsar/defines.h>
+
+#include <memory>
+#include <string>
+
+namespace pulsar {
+
+struct DeadLetterPolicyImpl;
+
+/**
+ * Configuration for the "dead letter queue" feature in consumer.
+ *
+ * see @DeadLetterPolicyBuilder
+ */
+class PULSAR_PUBLIC DeadLetterPolicy {
+   public:
+    DeadLetterPolicy();
+
+    /**
+     * Get dead letter topic
+     *
+     * @return
+     */
+    const std::string& getDeadLetterTopic() const;
+
+    /**
+     * Get max redeliver count
+     *
+     * @return
+     */
+    int getMaxRedeliverCount() const;
+
+    /**
+     * Get initial subscription name
+     *
+     * @return
+     */
+    const std::string& getInitialSubscriptionName() const;
+
+   private:
+    friend class DeadLetterPolicyBuilder;
+
+    typedef std::shared_ptr<DeadLetterPolicyImpl> DeadLetterPolicyImplPtr;
+    DeadLetterPolicyImplPtr impl_;
+
+    explicit DeadLetterPolicy(const DeadLetterPolicyImplPtr& impl);
+};
+}  // namespace pulsar
+
+#endif /* DEAD_LETTER_POLICY_HPP_ */

--- a/include/pulsar/DeadLetterPolicyBuilder.h
+++ b/include/pulsar/DeadLetterPolicyBuilder.h
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef DEAD_LETTER_POLICY_BUILD_HPP_
+#define DEAD_LETTER_POLICY_BUILD_HPP_
+
+#include <pulsar/DeadLetterPolicy.h>
+#include <pulsar/defines.h>
+
+#include <memory>
+
+namespace pulsar {
+
+struct DeadLetterPolicyImpl;
+
+/**
+ * The builder to build a DeadLetterPolicyBuilder
+ *
+ * Example of building DeadLetterPolicy:
+ *
+ * ```c++
+ * DeadLetterPolicy dlqPolicy = DeadLetterPolicyBuilder()
+ *                       .deadLetterTopic("dlq-topic")
+ *                       .maxRedeliverCount(10)
+ *                       .initialSubscriptionName("init-sub-name")
+ *                       .build();
+ * ```
+ */
+class PULSAR_PUBLIC DeadLetterPolicyBuilder {
+   public:
+    DeadLetterPolicyBuilder();
+
+    /**
+     * Set dead letter topic.
+     *
+     * @param deadLetterTopic Name of the dead topic where the failing messages are sent.
+     * The default value is: sourceTopicName + "-" + subscriptionName + "-DLQ"
+     *
+     * @return
+     */
+    DeadLetterPolicyBuilder& deadLetterTopic(const std::string& deadLetterTopic);
+
+    /**
+     * Set max redeliver count
+     *
+     * @param maxRedeliverCount Maximum number of times that a message is redelivered before being sent
+     * to the dead letter queue.
+     * - The maxRedeliverCount must be greater than 0.
+     * - The default value is {INT_MAX} (DLQ is not enabled)
+     *
+     * @return
+     */
+    DeadLetterPolicyBuilder& maxRedeliverCount(int maxRedeliverCount);
+
+    /**
+     * Set initial subscription name
+     *
+     * @param initialSubscriptionName  Name of the initial subscription name of the dead letter topic.
+     * If this field is not set, the initial subscription for the dead letter topic is not created.
+     * If this field is set but the broker's `allowAutoSubscriptionCreation` is disabled, the DLQ producer
+     * fails to be created.
+     *
+     * @return
+     */
+    DeadLetterPolicyBuilder& initialSubscriptionName(const std::string& initialSubscriptionName);
+
+    /**
+     * Build DeadLetterPolicy.
+     *
+     * @return
+     */
+    DeadLetterPolicy build();
+
+   private:
+    std::shared_ptr<DeadLetterPolicyImpl> impl_;
+};
+}  // namespace pulsar
+
+#endif /* DEAD_LETTER_POLICY_BUILD_HPP_ */

--- a/include/pulsar/ProducerConfiguration.h
+++ b/include/pulsar/ProducerConfiguration.h
@@ -532,11 +532,12 @@ class PULSAR_PUBLIC ProducerConfiguration {
      */
     ProducerAccessMode getAccessMode() const;
 
-    friend class PulsarWrapper;
-
    private:
-    struct Impl;
     std::shared_ptr<ProducerConfigurationImpl> impl_;
+
+    friend class PulsarWrapper;
+    friend class ConsumerImpl;
+    friend class ProducerImpl;
 };
 }  // namespace pulsar
 #endif /* PULSAR_PRODUCERCONFIGURATION_H_ */

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -387,7 +387,8 @@ SharedBuffer Commands::newProducer(const std::string& topic, uint64_t producerId
                                    const std::map<std::string, std::string>& metadata,
                                    const SchemaInfo& schemaInfo, uint64_t epoch,
                                    bool userProvidedProducerName, bool encrypted,
-                                   ProducerAccessMode accessMode, boost::optional<uint64_t> topicEpoch) {
+                                   ProducerAccessMode accessMode, boost::optional<uint64_t> topicEpoch,
+                                   const std::string& initialSubscriptionName) {
     BaseCommand cmd;
     cmd.set_type(BaseCommand::PRODUCER);
     CommandProducer* producer = cmd.mutable_producer();
@@ -400,6 +401,9 @@ SharedBuffer Commands::newProducer(const std::string& topic, uint64_t producerId
     producer->set_producer_access_mode(static_cast<proto::ProducerAccessMode>(accessMode));
     if (topicEpoch) {
         producer->set_topic_epoch(topicEpoch.value());
+    }
+    if (!initialSubscriptionName.empty()) {
+        producer->set_initial_subscription_name(initialSubscriptionName);
     }
 
     for (std::map<std::string, std::string>::const_iterator it = metadata.begin(); it != metadata.end();

--- a/lib/Commands.h
+++ b/lib/Commands.h
@@ -111,7 +111,8 @@ class Commands {
                                     const std::map<std::string, std::string>& metadata,
                                     const SchemaInfo& schemaInfo, uint64_t epoch,
                                     bool userProvidedProducerName, bool encrypted,
-                                    ProducerAccessMode accessMode, boost::optional<uint64_t> topicEpoch);
+                                    ProducerAccessMode accessMode, boost::optional<uint64_t> topicEpoch,
+                                    const std::string& initialSubscriptionName);
 
     static SharedBuffer newAck(uint64_t consumerId, int64_t ledgerId, int64_t entryId, const BitSet& ackSet,
                                CommandAck_AckType ackType, CommandAck_ValidationError validationError);

--- a/lib/ConsumerConfiguration.cc
+++ b/lib/ConsumerConfiguration.cc
@@ -294,4 +294,10 @@ ConsumerConfiguration& ConsumerConfiguration::setBatchIndexAckEnabled(bool enabl
 
 bool ConsumerConfiguration::isBatchIndexAckEnabled() const { return impl_->batchIndexAckEnabled; }
 
+void ConsumerConfiguration::setDeadLetterPolicy(const DeadLetterPolicy& deadLetterPolicy) {
+    impl_->deadLetterPolicy = deadLetterPolicy;
+}
+
+const DeadLetterPolicy& ConsumerConfiguration::getDeadLetterPolicy() const { return impl_->deadLetterPolicy; }
+
 }  // namespace pulsar

--- a/lib/ConsumerConfigurationImpl.h
+++ b/lib/ConsumerConfigurationImpl.h
@@ -46,6 +46,7 @@ struct ConsumerConfigurationImpl {
     bool readCompacted{false};
     InitialPosition subscriptionInitialPosition{InitialPosition::InitialPositionLatest};
     BatchReceivePolicy batchReceivePolicy{};
+    DeadLetterPolicy deadLetterPolicy;
     int patternAutoDiscoveryPeriod{60};
     bool replicateSubscriptionStateEnabled{false};
     std::map<std::string, std::string> properties;

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -31,11 +31,13 @@
 #include "CompressionCodec.h"
 #include "ConsumerImplBase.h"
 #include "MapCache.h"
+#include "MessageIdImpl.h"
 #include "NegativeAcksTracker.h"
 #include "Synchronized.h"
 #include "TestUtil.h"
 #include "TimeUtils.h"
 #include "UnboundedBlockingQueue.h"
+#include "lib/SynchronizedHashMap.h"
 
 namespace pulsar {
 class UnAckedMessageTrackerInterface;
@@ -45,6 +47,7 @@ class MessageCrypto;
 class GetLastMessageIdResponse;
 typedef std::shared_ptr<MessageCrypto> MessageCryptoPtr;
 typedef std::shared_ptr<Backoff> BackoffPtr;
+typedef std::function<void(bool processSuccess)> ProcessDLQCallBack;
 
 class AckGroupingTracker;
 using AckGroupingTrackerPtr = std::shared_ptr<AckGroupingTracker>;
@@ -64,6 +67,10 @@ enum ConsumerTopicType
     NonPartitioned,
     Partitioned
 };
+
+const static std::string SYSTEM_PROPERTY_REAL_TOPIC = "REAL_TOPIC";
+const static std::string PROPERTY_ORIGIN_MESSAGE_ID = "ORIGIN_MESSAGE_ID";
+const static std::string DLQ_GROUP_TOPIC_SUFFIX = "-DLQ";
 
 class ConsumerImpl : public ConsumerImplBase {
    public:
@@ -182,9 +189,11 @@ class ConsumerImpl : public ConsumerImplBase {
     boost::optional<MessageId> clearReceiveQueue();
     void seekAsyncInternal(long requestId, SharedBuffer seek, const MessageId& seekId, long timestamp,
                            ResultCallback callback);
+    void processPossibleToDLQ(const MessageId& messageId, ProcessDLQCallBack cb);
 
     std::mutex mutexForReceiveWithZeroQueueSize;
     const ConsumerConfiguration config_;
+    DeadLetterPolicy deadLetterPolicy_;
     const std::string subscription_;
     std::string originalSubscriptionName_;
     const bool isPersistent_;
@@ -214,6 +223,10 @@ class ConsumerImpl : public ConsumerImplBase {
 
     MessageCryptoPtr msgCrypto_;
     const bool readCompacted_;
+
+    SynchronizedHashMap<MessageId, std::vector<Message>> possibleSendToDeadLetterTopicMessages_;
+    std::shared_ptr<Promise<Result, Producer>> deadLetterProducer_;
+    std::mutex createProducerLock_;
 
     // Make the access to `lastDequedMessageId_` and `lastMessageIdInBroker_` thread safe
     mutable std::mutex mutexForMessageId_;
@@ -319,6 +332,7 @@ class ConsumerImpl : public ConsumerImplBase {
     FRIEND_TEST(ConsumerTest, testPartitionedConsumerUnAckedMessageRedelivery);
     FRIEND_TEST(ConsumerTest, testMultiTopicsConsumerUnAckedMessageRedelivery);
     FRIEND_TEST(ConsumerTest, testBatchUnAckedMessageTracker);
+    FRIEND_TEST(DeadLetterQueueTest, testAutoSetDLQTopicName);
 };
 
 } /* namespace pulsar */

--- a/lib/DeadLetterPolicyBuilder.cc
+++ b/lib/DeadLetterPolicyBuilder.cc
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <pulsar/DeadLetterPolicy.h>
+#include <pulsar/DeadLetterPolicyBuilder.h>
+
+#include "DeadLetterPolicyImpl.h"
+#include "stdexcept"
+
+using namespace pulsar;
+
+namespace pulsar {
+
+DeadLetterPolicyBuilder::DeadLetterPolicyBuilder() : impl_(std::make_shared<DeadLetterPolicyImpl>()) {}
+
+DeadLetterPolicyBuilder& DeadLetterPolicyBuilder::deadLetterTopic(const std::string& deadLetterTopic) {
+    impl_->deadLetterTopic = deadLetterTopic;
+    return *this;
+}
+
+DeadLetterPolicyBuilder& DeadLetterPolicyBuilder::maxRedeliverCount(int maxRedeliverCount) {
+    impl_->maxRedeliverCount = maxRedeliverCount;
+    return *this;
+}
+
+DeadLetterPolicyBuilder& DeadLetterPolicyBuilder::initialSubscriptionName(
+    const std::string& initialSubscriptionName) {
+    impl_->initialSubscriptionName = initialSubscriptionName;
+    return *this;
+}
+
+DeadLetterPolicy DeadLetterPolicyBuilder::build() {
+    if (impl_->maxRedeliverCount <= 0) {
+        throw std::invalid_argument("maxRedeliverCount must be > 0.");
+    }
+    return DeadLetterPolicy(impl_);
+}
+
+}  // namespace pulsar

--- a/lib/DeadLetterPolicyImpl.cc
+++ b/lib/DeadLetterPolicyImpl.cc
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "DeadLetterPolicyImpl.h"
+
+#include <pulsar/DeadLetterPolicy.h>
+
+using namespace pulsar;
+
+namespace pulsar {
+
+DeadLetterPolicy::DeadLetterPolicy() : impl_(std::make_shared<DeadLetterPolicyImpl>()) {}
+
+const std::string& DeadLetterPolicy::getDeadLetterTopic() const { return impl_->deadLetterTopic; }
+
+int DeadLetterPolicy::getMaxRedeliverCount() const { return impl_->maxRedeliverCount; }
+
+const std::string& DeadLetterPolicy::getInitialSubscriptionName() const {
+    return impl_->initialSubscriptionName;
+}
+
+DeadLetterPolicy::DeadLetterPolicy(const DeadLetterPolicy::DeadLetterPolicyImplPtr& impl) : impl_(impl) {}
+
+}  // namespace pulsar

--- a/lib/DeadLetterPolicyImpl.h
+++ b/lib/DeadLetterPolicyImpl.h
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <climits>
+#include <string>
+
+namespace pulsar {
+
+struct DeadLetterPolicyImpl {
+    std::string deadLetterTopic;
+    int maxRedeliverCount{INT_MAX};
+    std::string initialSubscriptionName;
+};
+
+}  // namespace pulsar

--- a/lib/MessageIdImpl.h
+++ b/lib/MessageIdImpl.h
@@ -19,10 +19,35 @@
 
 #pragma once
 
+#include <boost/functional/hash.hpp>
 #include <cstdint>
 #include <string>
 
 #include "BitSet.h"
+
+namespace std {
+
+template <>
+struct hash<pulsar::MessageId> {
+    std::size_t operator()(const pulsar::MessageId& msgId) const {
+        using boost::hash_combine;
+        using boost::hash_value;
+
+        // Start with a hash value of 0    .
+        std::size_t seed = 0;
+
+        // Modify 'seed' by XORing and bit-shifting in
+        // one member of 'Key' after the other:
+        hash_combine(seed, hash_value(msgId.ledgerId()));
+        hash_combine(seed, hash_value(msgId.entryId()));
+        hash_combine(seed, hash_value(msgId.batchIndex()));
+        hash_combine(seed, hash_value(msgId.partition()));
+
+        // Return the result.
+        return seed;
+    }
+};
+}  // namespace std
 
 namespace pulsar {
 

--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -771,10 +771,22 @@ void MultiTopicsConsumerImpl::redeliverUnacknowledgedMessages(const std::set<Mes
         redeliverUnacknowledgedMessages();
         return;
     }
+
     LOG_DEBUG("Sending RedeliverUnacknowledgedMessages command for partitioned consumer.");
-    consumers_.forEachValue([&messageIds](const ConsumerImplPtr& consumer) {
-        consumer->redeliverUnacknowledgedMessages(messageIds);
-    });
+    std::unordered_map<std::string, std::set<MessageId>> topicToMessageId;
+    for (const MessageId& messageId : messageIds) {
+        auto topicName = messageId.getTopicName();
+        topicToMessageId[topicName].emplace(messageId);
+    }
+
+    for (const auto& kv : topicToMessageId) {
+        auto optConsumer = consumers_.find(kv.first);
+        if (optConsumer) {
+            optConsumer.value()->redeliverUnacknowledgedMessages(kv.second);
+        } else {
+            LOG_ERROR("Message of topic: " << kv.first << " not in consumers");
+        }
+    }
 }
 
 int MultiTopicsConsumerImpl::getNumOfPrefetchedMessages() const { return incomingMessages_.size(); }

--- a/lib/NegativeAcksTracker.cc
+++ b/lib/NegativeAcksTracker.cc
@@ -80,7 +80,7 @@ void NegativeAcksTracker::handleTimer(const boost::system::error_code &ec) {
     }
 
     if (!messagesToRedeliver.empty()) {
-        consumer_.redeliverMessages(messagesToRedeliver);
+        consumer_.redeliverUnacknowledgedMessages(messagesToRedeliver);
     }
     scheduleTimer();
 }

--- a/lib/ProducerConfigurationImpl.h
+++ b/lib/ProducerConfigurationImpl.h
@@ -50,6 +50,7 @@ struct ProducerConfigurationImpl {
     std::map<std::string, std::string> properties;
     bool chunkingEnabled{false};
     ProducerConfiguration::ProducerAccessMode accessMode{ProducerConfiguration::Shared};
+    std::string initialSubscriptionName;
 };
 }  // namespace pulsar
 

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -34,6 +34,7 @@
 #include "MessageCrypto.h"
 #include "MessageImpl.h"
 #include "OpSendMsg.h"
+#include "ProducerConfigurationImpl.h"
 #include "PulsarApi.pb.h"
 #include "TimeUtils.h"
 #include "TopicName.h"
@@ -148,10 +149,11 @@ void ProducerImpl::connectionOpened(const ClientConnectionPtr& cnx) {
     ClientImplPtr client = client_.lock();
     int requestId = client->newRequestId();
 
-    SharedBuffer cmd = Commands::newProducer(
-        topic_, producerId_, producerName_, requestId, conf_.getProperties(), conf_.getSchema(), epoch_,
-        userProvidedProducerName_, conf_.isEncryptionEnabled(),
-        static_cast<proto::ProducerAccessMode>(conf_.getAccessMode()), topicEpoch);
+    SharedBuffer cmd = Commands::newProducer(topic_, producerId_, producerName_, requestId,
+                                             conf_.getProperties(), conf_.getSchema(), epoch_,
+                                             userProvidedProducerName_, conf_.isEncryptionEnabled(),
+                                             static_cast<proto::ProducerAccessMode>(conf_.getAccessMode()),
+                                             topicEpoch, conf_.impl_->initialSubscriptionName);
     cnx->sendRequestWithId(cmd, requestId)
         .addListener(std::bind(&ProducerImpl::handleCreateProducer, shared_from_this(), cnx,
                                std::placeholders::_1, std::placeholders::_2));

--- a/tests/ConsumerConfigurationTest.cc
+++ b/tests/ConsumerConfigurationTest.cc
@@ -20,9 +20,13 @@
 #include <lib/LogUtils.h>
 #include <pulsar/Client.h>
 
+#include <climits>
+
 #include "NoOpsCryptoKeyReader.h"
 
 DECLARE_LOG_OBJECT()
+
+#include <pulsar/DeadLetterPolicyBuilder.h>
 
 #include "../lib/Future.h"
 #include "../lib/Utils.h"
@@ -320,4 +324,16 @@ TEST(ConsumerConfigurationTest, testResetAckTimeOut) {
     // should be able to set it back to 0.
     config.setUnAckedMessagesTimeoutMs(0);
     ASSERT_EQ(0, config.getUnAckedMessagesTimeoutMs());
+}
+
+TEST(ConsumerConfigurationTest, testDeadLetterPolicy) {
+    ConsumerConfiguration config;
+    auto dlqPolicy = config.getDeadLetterPolicy();
+    ASSERT_TRUE(dlqPolicy.getDeadLetterTopic().empty());
+    ASSERT_EQ(dlqPolicy.getMaxRedeliverCount(), INT_MAX);
+    ASSERT_TRUE(dlqPolicy.getInitialSubscriptionName().empty());
+
+    config.setDeadLetterPolicy(DeadLetterPolicyBuilder().maxRedeliverCount(10).build());
+    auto dlqPolicy2 = config.getDeadLetterPolicy();
+    ASSERT_EQ(dlqPolicy2.getMaxRedeliverCount(), 10);
 }

--- a/tests/DeadLetterPolicyTest.cc
+++ b/tests/DeadLetterPolicyTest.cc
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/DeadLetterPolicyBuilder.h>
+
+#include <climits>
+
+using namespace pulsar;
+
+TEST(DeadLetterPolicy, testDeadLetterPolicy) {
+    // test default value.
+    DeadLetterPolicy deadLetterPolicy;
+    ASSERT_EQ(deadLetterPolicy.getMaxRedeliverCount(), INT_MAX);
+    ASSERT_TRUE(deadLetterPolicy.getDeadLetterTopic().empty());
+    ASSERT_TRUE(deadLetterPolicy.getInitialSubscriptionName().empty());
+
+    // test don't allowed max redeliver count less than 0.
+    ASSERT_THROW(DeadLetterPolicyBuilder().maxRedeliverCount(-1).build(), std::invalid_argument);
+
+    // test create DeadLetterPolicy by builder.
+    deadLetterPolicy = DeadLetterPolicyBuilder()
+                           .maxRedeliverCount(10)
+                           .deadLetterTopic("topic-subscription-DLQ")
+                           .initialSubscriptionName("init-DLQ-subscription")
+                           .build();
+    ASSERT_EQ(deadLetterPolicy.getMaxRedeliverCount(), 10);
+    ASSERT_EQ(deadLetterPolicy.getDeadLetterTopic(), "topic-subscription-DLQ");
+    ASSERT_EQ(deadLetterPolicy.getInitialSubscriptionName(), "init-DLQ-subscription");
+}

--- a/tests/DeadLetterQueueTest.cc
+++ b/tests/DeadLetterQueueTest.cc
@@ -1,0 +1,392 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/Client.h>
+#include <pulsar/ConsumerConfiguration.h>
+#include <pulsar/DeadLetterPolicyBuilder.h>
+
+#include "HttpHelper.h"
+#include "PulsarFriend.h"
+#include "lib/ConsumerConfigurationImpl.h"
+#include "lib/LogUtils.h"
+#include "lib/MessageIdUtil.h"
+#include "lib/UnAckedMessageTrackerEnabled.h"
+#include "lib/Utils.h"
+
+static const std::string lookupUrl = "pulsar://localhost:6650";
+static const std::string adminUrl = "http://localhost:8080/";
+
+DECLARE_LOG_OBJECT()
+
+namespace pulsar {
+
+TEST(DeadLetterQueueTest, testDLQWithSchema) {
+    Client client(lookupUrl);
+    const std::string topic = "testDLQWithSchema-" + std::to_string(time(nullptr));
+    const std::string subName = "test-sub";
+
+    static const std::string jsonSchema =
+        R"({"type":"record","name":"cpx","fields":[{"name":"re","type":"double"},{"name":"im","type":"double"}]})";
+    SchemaInfo schemaInfo(JSON, "test-json", jsonSchema);
+
+    auto dlqPolicy = DeadLetterPolicyBuilder()
+                         .maxRedeliverCount(3)
+                         .deadLetterTopic(topic + subName + "-DLQ")
+                         .initialSubscriptionName("init-sub")
+                         .build();
+    ConsumerConfiguration consumerConfig;
+    consumerConfig.setDeadLetterPolicy(dlqPolicy);
+    consumerConfig.setNegativeAckRedeliveryDelayMs(100);
+    consumerConfig.setConsumerType(ConsumerType::ConsumerShared);
+    consumerConfig.setSchema(schemaInfo);
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, subName, consumerConfig, consumer));
+
+    // Initialize the DLQ subscription first and make sure that DLQ topic is created and a schema exists.
+    ConsumerConfiguration dlqConsumerConfig;
+    dlqConsumerConfig.setConsumerType(ConsumerType::ConsumerShared);
+    dlqConsumerConfig.setSchema(schemaInfo);
+    Consumer deadLetterConsumer;
+    ASSERT_EQ(ResultOk, client.subscribe(dlqPolicy.getDeadLetterTopic(), subName, dlqConsumerConfig,
+                                         deadLetterConsumer));
+
+    Producer producer;
+    ProducerConfiguration producerConfig;
+    producerConfig.setSchema(schemaInfo);
+    ASSERT_EQ(ResultOk, client.createProducer(topic, producerConfig, producer));
+    std::string data = "{\"re\":2.1,\"im\":1.23}";
+    const int num = 10;
+    for (int i = 0; i < num; ++i) {
+        ASSERT_EQ(ResultOk, producer.send(MessageBuilder().setContent(data).build()));
+    }
+
+    // nack all msg.
+    Message msg;
+    for (int i = 0; i < dlqPolicy.getMaxRedeliverCount() * num + num; ++i) {
+        ASSERT_EQ(ResultOk, consumer.receive(msg));
+        consumer.negativeAcknowledge(msg);
+    }
+
+    // assert dlq msg.
+    for (int i = 0; i < num; i++) {
+        ASSERT_EQ(ResultOk, deadLetterConsumer.receive(msg, 5000));
+        ASSERT_FALSE(msg.getDataAsString().empty());
+        ASSERT_TRUE(msg.getProperty(SYSTEM_PROPERTY_REAL_TOPIC).find(topic));
+        ASSERT_FALSE(msg.getProperty(PROPERTY_ORIGIN_MESSAGE_ID).empty());
+    }
+    ASSERT_EQ(ResultTimeout, deadLetterConsumer.receive(msg, 200));
+
+    client.close();
+}
+
+// If the user never receives this message, the message should not be delivered to the DLQ.
+TEST(DeadLetterQueueTest, testWithoutConsumerReceiveImmediately) {
+    Client client(lookupUrl);
+    const std::string topic = "testWithoutConsumerReceiveImmediately-" + std::to_string(time(nullptr));
+    const std::string subName = "dlq-sub";
+    auto dlqPolicy =
+        DeadLetterPolicyBuilder().maxRedeliverCount(3).initialSubscriptionName("init-sub").build();
+    ConsumerConfiguration consumerConfig;
+    consumerConfig.setDeadLetterPolicy(dlqPolicy);
+    consumerConfig.setNegativeAckRedeliveryDelayMs(100);
+    // set ack timeout is 10 ms.
+    PulsarFriend::setConsumerUnAckMessagesTimeoutMs(consumerConfig, 10);
+    consumerConfig.setConsumerType(ConsumerType::ConsumerShared);
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, subName, consumerConfig, consumer));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic, producer));
+    producer.send(MessageBuilder().setContent("msg").build());
+
+    // Wait a while, message should not be send to DLQ
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    Message msg;
+    ASSERT_EQ(ResultOk, consumer.receive(msg));
+    client.close();
+}
+
+TEST(DeadLetterQueueTest, testAutoSetDLQTopicName) {
+    Client client(lookupUrl);
+    const std::string topic = "testAutoSetDLQName-" + std::to_string(time(nullptr));
+    const std::string subName = "dlq-sub";
+    const std::string dlqTopic = "persistent://public/default/" + topic + "-" + subName + "-DLQ";
+    auto dlqPolicy =
+        DeadLetterPolicyBuilder().maxRedeliverCount(3).initialSubscriptionName("init-sub").build();
+    ConsumerConfiguration consumerConfig;
+    consumerConfig.setDeadLetterPolicy(dlqPolicy);
+    consumerConfig.setNegativeAckRedeliveryDelayMs(100);
+    consumerConfig.setConsumerType(ConsumerType::ConsumerShared);
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, subName, consumerConfig, consumer));
+
+    auto &consumerImpl = PulsarFriend::getConsumerImpl(consumer);
+    ASSERT_EQ(consumerImpl.deadLetterPolicy_.getDeadLetterTopic(), dlqTopic);
+
+    client.close();
+}
+
+class DeadLetterQueueTest : public ::testing::TestWithParam<std::tuple<bool, bool, ConsumerType>> {
+   public:
+    void SetUp() override {
+        bool isProducerBatch = std::get<0>(GetParam());
+        bool isMultiConsumer = std::get<1>(GetParam());
+        ConsumerType consumerType = std::get<2>(GetParam());
+
+        std::string testSuiteName = testing::UnitTest::GetInstance()->current_test_info()->name();
+        std::replace(testSuiteName.begin(), testSuiteName.end(), '/', '_');
+        topic_ = testSuiteName + std::to_string(time(nullptr));
+        subName_ = "test-sub";
+        dlqTopic_ = topic_ + "-" + subName_ + "-DLQ";
+
+        if (isMultiConsumer) {
+            // call admin api to make it partitioned
+            std::string url = adminUrl + "admin/v2/persistent/public/default/" + topic_ + "/partitions";
+            int res = makePutRequest(url, "5");
+            LOG_INFO("res = " << res);
+            ASSERT_FALSE(res != 204 && res != 409);
+        }
+
+        producerConf_.setBatchingEnabled(isProducerBatch);
+        consumerConf_.setConsumerType(consumerType);
+        consumerConf_.setDeadLetterPolicy(
+            DeadLetterPolicyBuilder().maxRedeliverCount(3).deadLetterTopic(dlqTopic_).build());
+    }
+
+    void TearDown() override { client_.close(); }
+
+   protected:
+    Client client_{lookupUrl};
+    ProducerConfiguration producerConf_;
+    ConsumerConfiguration consumerConf_;
+    std::string topic_;
+    std::string subName_;
+    std::string dlqTopic_;
+};
+
+TEST_P(DeadLetterQueueTest, testSendDLQTriggerByAckTimeOutAndNeAck) {
+    Client client(lookupUrl);
+
+    Consumer consumer;
+    PulsarFriend::setConsumerUnAckMessagesTimeoutMs(consumerConf_, 200);
+    consumerConf_.setNegativeAckRedeliveryDelayMs(100);
+    ASSERT_EQ(ResultOk, client.subscribe(topic_, subName_, consumerConf_, consumer));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic_, producerConf_, producer));
+    const int num = 100;
+    Message msg;
+    for (int i = 0; i < num; ++i) {
+        msg = MessageBuilder()
+                  .setContent(std::to_string(i))
+                  .setPartitionKey("p-key")
+                  .setOrderingKey("o-key")
+                  .setProperty("pk-1", "pv-1")
+                  .build();
+        producer.sendAsync(msg, [](Result res, const MessageId &msgId) { ASSERT_EQ(res, ResultOk); });
+    }
+
+    // receive messages and don't ack.
+    for (int i = 0; i < consumerConf_.getDeadLetterPolicy().getMaxRedeliverCount() * num + num; ++i) {
+        ASSERT_EQ(ResultOk, consumer.receive(msg));
+        // Randomly specify some messages manually negativeAcknowledge.
+        if (rand() % 2 == 0) {
+            consumer.negativeAcknowledge(msg);
+        }
+    }
+
+    // assert dlq msg.
+    Consumer deadLetterQueueConsumer;
+    ConsumerConfiguration dlqConsumerConfig;
+    dlqConsumerConfig.setSubscriptionInitialPosition(InitialPositionEarliest);
+    ASSERT_EQ(ResultOk, client.subscribe(dlqTopic_, subName_, dlqConsumerConfig, deadLetterQueueConsumer));
+    for (int i = 0; i < num; i++) {
+        ASSERT_EQ(ResultOk, deadLetterQueueConsumer.receive(msg));
+        ASSERT_FALSE(msg.getDataAsString().empty());
+        ASSERT_EQ(msg.getPartitionKey(), "p-key");
+        ASSERT_EQ(msg.getOrderingKey(), "o-key");
+        ASSERT_EQ(msg.getProperty("pk-1"), "pv-1");
+        ASSERT_TRUE(msg.getProperty(SYSTEM_PROPERTY_REAL_TOPIC).find(topic_));
+        ASSERT_FALSE(msg.getProperty(PROPERTY_ORIGIN_MESSAGE_ID).empty());
+    }
+
+    ASSERT_EQ(ResultTimeout, deadLetterQueueConsumer.receive(msg, 200));
+}
+
+TEST_P(DeadLetterQueueTest, testSendDLQTriggerByRedeliverUnacknowledgedMessages) {
+    Client client(lookupUrl);
+
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic_, subName_, consumerConf_, consumer));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic_, producerConf_, producer));
+
+    const int num = 10;
+    Message msg;
+    for (int i = 0; i < num; ++i) {
+        msg = MessageBuilder()
+                  .setContent(std::to_string(i))
+                  .setPartitionKey("p-key")
+                  .setOrderingKey("o-key")
+                  .setProperty("pk-1", "pv-1")
+                  .build();
+        producer.sendAsync(msg, [](Result res, const MessageId &msgId) { ASSERT_EQ(res, ResultOk); });
+    }
+
+    // nack all msg.
+    for (int i = 1; i <= consumerConf_.getDeadLetterPolicy().getMaxRedeliverCount() * num + num; ++i) {
+        ASSERT_EQ(ResultOk, consumer.receive(msg));
+        if (i % num == 0) {
+            consumer.redeliverUnacknowledgedMessages();
+        }
+    }
+
+    // assert dlq msg.
+    Consumer deadLetterQueueConsumer;
+    ConsumerConfiguration dlqConsumerConfig;
+    dlqConsumerConfig.setSubscriptionInitialPosition(InitialPositionEarliest);
+    ASSERT_EQ(ResultOk, client.subscribe(dlqTopic_, subName_, dlqConsumerConfig, deadLetterQueueConsumer));
+    for (int i = 0; i < num; i++) {
+        ASSERT_EQ(ResultOk, deadLetterQueueConsumer.receive(msg));
+        ASSERT_FALSE(msg.getDataAsString().empty());
+        ASSERT_EQ(msg.getPartitionKey(), "p-key");
+        ASSERT_EQ(msg.getOrderingKey(), "o-key");
+        ASSERT_EQ(msg.getProperty("pk-1"), "pv-1");
+        ASSERT_TRUE(msg.getProperty(SYSTEM_PROPERTY_REAL_TOPIC).find(topic_));
+        ASSERT_FALSE(msg.getProperty(PROPERTY_ORIGIN_MESSAGE_ID).empty());
+    }
+    ASSERT_EQ(ResultTimeout, deadLetterQueueConsumer.receive(msg, 200));
+}
+
+TEST_P(DeadLetterQueueTest, testSendDLQTriggerByNegativeAcknowledge) {
+    Client client(lookupUrl);
+
+    Consumer consumer;
+    consumerConf_.setNegativeAckRedeliveryDelayMs(100);
+    ASSERT_EQ(ResultOk, client.subscribe(topic_, subName_, consumerConf_, consumer));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic_, producerConf_, producer));
+
+    const int num = 10;
+    Message msg;
+    for (int i = 0; i < num; ++i) {
+        msg = MessageBuilder()
+                  .setContent(std::to_string(i))
+                  .setPartitionKey("p-key")
+                  .setOrderingKey("o-key")
+                  .setProperty("pk-1", "pv-1")
+                  .build();
+        producer.sendAsync(msg, [](Result res, const MessageId &msgId) { ASSERT_EQ(res, ResultOk); });
+    }
+
+    // nack all msg.
+    for (int i = 0; i < consumerConf_.getDeadLetterPolicy().getMaxRedeliverCount() * num + num; ++i) {
+        ASSERT_EQ(ResultOk, consumer.receive(msg));
+        consumer.negativeAcknowledge(msg);
+    }
+
+    // assert dlq msg.
+    Consumer deadLetterQueueConsumer;
+    ConsumerConfiguration dlqConsumerConfig;
+    dlqConsumerConfig.setSubscriptionInitialPosition(InitialPositionEarliest);
+    ASSERT_EQ(ResultOk, client.subscribe(dlqTopic_, "dlq-sub", dlqConsumerConfig, deadLetterQueueConsumer));
+    for (int i = 0; i < num; i++) {
+        ASSERT_EQ(ResultOk, deadLetterQueueConsumer.receive(msg));
+        ASSERT_FALSE(msg.getDataAsString().empty());
+        ASSERT_EQ(msg.getPartitionKey(), "p-key");
+        ASSERT_EQ(msg.getOrderingKey(), "o-key");
+        ASSERT_EQ(msg.getProperty("pk-1"), "pv-1");
+        ASSERT_TRUE(msg.getProperty(SYSTEM_PROPERTY_REAL_TOPIC).find(topic_));
+        ASSERT_FALSE(msg.getProperty(PROPERTY_ORIGIN_MESSAGE_ID).empty());
+    }
+    ASSERT_EQ(ResultTimeout, deadLetterQueueConsumer.receive(msg, 200));
+}
+
+TEST_P(DeadLetterQueueTest, testInitSubscription) {
+    Client client(lookupUrl);
+
+    const std::string dlqInitSub = "dlq-init-sub";
+    auto dlqPolicy = DeadLetterPolicyBuilder()
+                         .maxRedeliverCount(3)
+                         .initialSubscriptionName(dlqInitSub)
+                         .deadLetterTopic(dlqTopic_)
+                         .build();
+    consumerConf_.setDeadLetterPolicy(dlqPolicy);
+    consumerConf_.setNegativeAckRedeliveryDelayMs(100);
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic_, subName_, consumerConf_, consumer));
+
+    Consumer deadLetterQueueConsumer;
+    ConsumerConfiguration dlqConsumerConfig;
+    dlqConsumerConfig.setSubscriptionInitialPosition(InitialPositionEarliest);
+    ASSERT_EQ(ResultOk, client.subscribe(dlqTopic_, subName_, dlqConsumerConfig, deadLetterQueueConsumer));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic_, producerConf_, producer));
+
+    const int num = 10;
+    Message msg;
+    for (int i = 0; i < num; ++i) {
+        msg = MessageBuilder().setContent(std::to_string(i)).build();
+        ASSERT_EQ(ResultOk, producer.send(msg));
+    }
+
+    // nack all msg.
+    for (int i = 0; i < dlqPolicy.getMaxRedeliverCount() * num + num; ++i) {
+        ASSERT_EQ(ResultOk, consumer.receive(msg));
+        consumer.negativeAcknowledge(msg);
+    }
+
+    // Use this subscription to ensure that messages are sent to the DLQ.
+    for (int i = 0; i < num; i++) {
+        ASSERT_EQ(ResultOk, deadLetterQueueConsumer.receive(msg));
+        ASSERT_FALSE(msg.getDataAsString().empty());
+        ASSERT_TRUE(msg.getProperty(SYSTEM_PROPERTY_REAL_TOPIC).find(topic_));
+        ASSERT_FALSE(msg.getProperty(PROPERTY_ORIGIN_MESSAGE_ID).empty());
+    }
+
+    // If there is no initial subscription, then the subscription will not receive the DLQ messages sent
+    // before the subscription.
+    Consumer initDLQConsumer;
+    ConsumerConfiguration initDLQConsumerConfig;
+    dlqConsumerConfig.setSubscriptionInitialPosition(InitialPositionLatest);
+    ASSERT_EQ(ResultOk, client.subscribe(dlqTopic_, dlqInitSub, initDLQConsumerConfig, initDLQConsumer));
+    for (int i = 0; i < num; i++) {
+        ASSERT_EQ(ResultOk, initDLQConsumer.receive(msg, 1000));
+        ASSERT_FALSE(msg.getDataAsString().empty());
+        ASSERT_TRUE(msg.getProperty(SYSTEM_PROPERTY_REAL_TOPIC).find(topic_));
+        ASSERT_FALSE(msg.getProperty(PROPERTY_ORIGIN_MESSAGE_ID).empty());
+    }
+    ASSERT_EQ(ResultTimeout, initDLQConsumer.receive(msg, 200));
+}
+
+INSTANTIATE_TEST_SUITE_P(Pulsar, DeadLetterQueueTest,
+                         testing::Combine(testing::Values(true, false), testing::Values(true, false),
+                                          testing::Values(ConsumerType::ConsumerShared,
+                                                          ConsumerType::ConsumerKeyShared)),
+                         [](const testing::TestParamInfo<DeadLetterQueueTest::ParamType> &info) {
+                             return "isBatch_" + std::to_string(std::get<0>(info.param)) + "_isMultiTopics_" +
+                                    std::to_string(std::get<1>(info.param)) + "_subType_" +
+                                    std::to_string(std::get<2>(info.param));
+                         });
+
+}  // namespace pulsar

--- a/tests/PulsarFriend.h
+++ b/tests/PulsarFriend.h
@@ -23,6 +23,7 @@
 
 #include "lib/ClientConnection.h"
 #include "lib/ClientImpl.h"
+#include "lib/ConsumerConfigurationImpl.h"
 #include "lib/ConsumerImpl.h"
 #include "lib/MessageImpl.h"
 #include "lib/MultiTopicsConsumerImpl.h"
@@ -181,6 +182,11 @@ class PulsarFriend {
     static proto::MessageMetadata& getMessageMetadata(Message& message) { return message.impl_->metadata; }
 
     static std::shared_ptr<MessageIdImpl> getMessageIdImpl(MessageId& msgId) { return msgId.impl_; }
+
+    static void setConsumerUnAckMessagesTimeoutMs(const ConsumerConfiguration& consumerConfiguration,
+                                                  long unAckedMessagesTimeoutMs) {
+        consumerConfiguration.impl_->unAckedMessagesTimeoutMs = unAckedMessagesTimeoutMs;
+    }
 };
 }  // namespace pulsar
 


### PR DESCRIPTION
Master Issue: #114 

### Motivation
#77, #114 

### Modifications
-  Add DeadLetterPolicy. When the message `redeliveryCount > DeadLetterPolicy.maxRedeliveryCount`, the message is sent to the DLQ topic and ack this msg.


### Verifying this change
This change added tests and can be verified as follows:

1. Add DeadLetterQueueTest to verify Send to DLQ, according to the following scenarios(Cartesian product of the following conditions): 
- Producer batch [enabled, disable]
- Topic is [single, multi]
- Consumer sub type [Shared, Key_Shard]
- Trigger by [unack, ack_timeout]

2. Add `DeadLetterQueueTest.testInitSubscription` to cover init DLQ topic subscription: https://github.com/apache/pulsar/pull/13355

3. Add `DeadLetterQueueTest.testAutoSetDLQTopicName` to cover default DLQ topic name.

4. Add `DeadLetterQueueTest.testDLQWithSchema`  to cover producer and consumer with the schema scenario.

5. If a topic has a schema, and the consumer uses `AUTO_CONSUME` schema, and DLQTopic also has the same schema. In this case, the DLQ producer fails to create(IncompatibleSchema).  Refer to java client same issue: https://github.com/apache/pulsar/issues/9935.
**Solution**: Depending on #157, After this, DLQ producers use the `autoDownloadSchema` param when consumers use `AUTO_CONSUM`. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
