### PR TITLE
[feat] Support AUTO_PUBLISH schema.

### DIFF
--- a/include/pulsar/Result.h
+++ b/include/pulsar/Result.h
@@ -92,6 +92,8 @@ enum Result
     ResultMemoryBufferIsFull,  /// Client-wide memory limit has been reached
 
     ResultInterrupted,  /// Interrupted while waiting to dequeue
+
+    ResultNotFound  /// The generic was not found
 };
 
 // Return string representation of result code

--- a/include/pulsar/Schema.h
+++ b/include/pulsar/Schema.h
@@ -134,6 +134,8 @@ enum SchemaType
 // Return string representation of result code
 PULSAR_PUBLIC const char *strSchemaType(SchemaType schemaType);
 
+PULSAR_PUBLIC SchemaType enumSchemaType(std::string schemaTypeStr);
+
 class SchemaInfoImpl;
 
 typedef std::map<std::string, std::string> StringMap;
@@ -195,7 +197,6 @@ class PULSAR_PUBLIC SchemaInfo {
    private:
     typedef std::shared_ptr<SchemaInfoImpl> SchemaInfoImplPtr;
     SchemaInfoImplPtr impl_;
-    static constexpr uint32_t INVALID_SIZE = 0xFFFFFFFF;
 };
 
 }  // namespace pulsar

--- a/lib/BinaryProtoLookupService.h
+++ b/lib/BinaryProtoLookupService.h
@@ -20,6 +20,7 @@
 #define _PULSAR_BINARY_LOOKUP_SERVICE_HEADER_
 
 #include <pulsar/Authentication.h>
+#include <pulsar/Schema.h>
 
 #include <mutex>
 
@@ -32,6 +33,7 @@ class ConnectionPool;
 class LookupDataResult;
 class ServiceNameResolver;
 using NamespaceTopicsPromisePtr = std::shared_ptr<Promise<Result, NamespaceTopicsPtr>>;
+using GetSchemaPromisePtr = std::shared_ptr<Promise<Result, boost::optional<SchemaInfo>>>;
 
 class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
    public:
@@ -44,6 +46,8 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
     Future<Result, LookupDataResultPtr> getPartitionMetadataAsync(const TopicNamePtr& topicName) override;
 
     Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) override;
+
+    Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override;
 
    private:
     std::mutex mutex_;
@@ -67,6 +71,9 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
     void sendGetTopicsOfNamespaceRequest(const std::string& nsName, Result result,
                                          const ClientConnectionWeakPtr& clientCnx,
                                          NamespaceTopicsPromisePtr promise);
+
+    void sendGetSchemaRequest(const std::string& topiName, Result result,
+                              const ClientConnectionWeakPtr& clientCnx, GetSchemaPromisePtr promise);
 
     void getTopicsOfNamespaceListener(Result result, NamespaceTopicsPtr topicsPtr,
                                       NamespaceTopicsPromisePtr promise);

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -1308,6 +1308,52 @@ void ClientConnection::handleIncomingCommand(BaseCommand& incomingCmd) {
                     break;
                 }
 
+                case BaseCommand::GET_SCHEMA_RESPONSE: {
+                    const auto& response = incomingCmd.getschemaresponse();
+                    LOG_DEBUG(cnxString_ << "Received GetSchemaResponse from server. req_id: "
+                                         << response.request_id());
+                    Lock lock(mutex_);
+                    PendingGetSchemaMap::iterator it = pendingGetSchemaRequests_.find(response.request_id());
+                    if (it != pendingGetSchemaRequests_.end()) {
+                        Promise<Result, boost::optional<SchemaInfo>> getSchemaPromise = it->second;
+                        pendingGetSchemaRequests_.erase(it);
+                        lock.unlock();
+
+                        if (response.has_error_code()) {
+                            if (response.error_code() == proto::TopicNotFound) {
+                                getSchemaPromise.setValue(boost::none);
+                            } else {
+                                Result result = getResult(response.error_code(), response.error_message());
+                                LOG_WARN(cnxString_ << "Received error GetSchemaResponse from server "
+                                                    << result
+                                                    << (response.has_error_message()
+                                                            ? (" (" + response.error_message() + ")")
+                                                            : "")
+                                                    << " -- req_id: " << response.request_id());
+                                getSchemaPromise.setFailed(result);
+                            }
+                            return;
+                        }
+
+                        auto schema = response.schema();
+                        auto properMap = schema.properties();
+                        StringMap properties;
+                        for (auto kv = properMap.begin(); kv != properMap.end(); ++kv) {
+                            properties[kv->key()] = kv->value();
+                        }
+                        SchemaInfo schemaInfo(static_cast<SchemaType>(schema.type()), "",
+                                              schema.schema_data(), properties);
+                        getSchemaPromise.setValue(schemaInfo);
+                    } else {
+                        lock.unlock();
+                        LOG_WARN(
+                            "GetSchemaResponse command - Received unknown request id from "
+                            "server: "
+                            << response.request_id());
+                    }
+                    break;
+                }
+
                 default: {
                     LOG_WARN(cnxString_ << "Received invalid message from server");
                     close();
@@ -1701,6 +1747,23 @@ Future<Result, NamespaceTopicsPtr> ClientConnection::newGetTopicsOfNamespace(con
     pendingGetNamespaceTopicsRequests_.insert(std::make_pair(requestId, promise));
     lock.unlock();
     sendCommand(Commands::newGetTopicsOfNamespace(nsName, requestId));
+    return promise.getFuture();
+}
+
+Future<Result, boost::optional<SchemaInfo>> ClientConnection::newGetSchema(const std::string& topicName,
+                                                                           uint64_t requestId) {
+    Lock lock(mutex_);
+    Promise<Result, boost::optional<SchemaInfo>> promise;
+    if (isClosed()) {
+        lock.unlock();
+        LOG_ERROR(cnxString_ << "Client is not connected to the broker");
+        promise.setFailed(ResultNotConnected);
+        return promise.getFuture();
+    }
+
+    pendingGetSchemaRequests_.insert(std::make_pair(requestId, promise));
+    lock.unlock();
+    sendCommand(Commands::newGetSchema(topicName, requestId));
     return promise.getFuture();
 }
 

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -168,6 +168,9 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     Future<Result, NamespaceTopicsPtr> newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId);
 
+    Future<Result, boost::optional<SchemaInfo>> newGetSchema(const std::string& topicName,
+                                                             uint64_t requestId);
+
    private:
     struct PendingRequestData {
         Promise<Result, ResponseData> promise;
@@ -319,6 +322,9 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     typedef std::map<long, Promise<Result, NamespaceTopicsPtr>> PendingGetNamespaceTopicsMap;
     PendingGetNamespaceTopicsMap pendingGetNamespaceTopicsRequests_;
+
+    typedef std::map<long, Promise<Result, boost::optional<SchemaInfo>>> PendingGetSchemaMap;
+    PendingGetSchemaMap pendingGetSchemaRequests_;
 
     mutable std::mutex mutex_;
     typedef std::unique_lock<std::mutex> Lock;

--- a/lib/ClientImpl.cc
+++ b/lib/ClientImpl.cc
@@ -159,9 +159,28 @@ void ClientImpl::createProducerAsync(const std::string& topic, ProducerConfigura
             return;
         }
     }
-    lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
-        std::bind(&ClientImpl::handleCreateProducer, shared_from_this(), std::placeholders::_1,
-                  std::placeholders::_2, topicName, conf, callback));
+
+    if (conf.getSchema().getSchemaType() == AUTO_PUBLISH) {
+        auto self = shared_from_this();
+        auto confPtr = std::make_shared<ProducerConfiguration>(conf);
+        lookupServicePtr_->getSchema(topicName).addListener(
+            [self, topicName, confPtr, callback](Result res, boost::optional<SchemaInfo> topicSchema) {
+                if (res != ResultOk) {
+                    callback(res, Producer());
+                }
+                if (topicSchema) {
+                    confPtr->setSchema(topicSchema.get());
+                }
+
+                self->lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
+                    std::bind(&ClientImpl::handleCreateProducer, self, std::placeholders::_1,
+                              std::placeholders::_2, topicName, *confPtr, callback));
+            });
+    } else {
+        lookupServicePtr_->getPartitionMetadataAsync(topicName).addListener(
+            std::bind(&ClientImpl::handleCreateProducer, shared_from_this(), std::placeholders::_1,
+                      std::placeholders::_2, topicName, conf, callback));
+    }
 }
 
 void ClientImpl::handleCreateProducer(const Result result, const LookupDataResultPtr partitionMetadata,

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -157,6 +157,21 @@ SharedBuffer Commands::newLookup(const std::string& topic, const bool authoritat
     return buffer;
 }
 
+SharedBuffer Commands::newGetSchema(const std::string& topic, uint64_t requestId) {
+    static BaseCommand cmd;
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+    cmd.set_type(BaseCommand::GET_SCHEMA);
+
+    auto getSchema = cmd.mutable_getschema();
+    getSchema->set_topic(topic);
+    getSchema->set_request_id(requestId);
+
+    const SharedBuffer buffer = writeMessageWithSize(cmd);
+    cmd.clear_getschema();
+    return buffer;
+}
+
 SharedBuffer Commands::newConsumerStats(uint64_t consumerId, uint64_t requestId) {
     static BaseCommand cmd;
     static std::mutex mutex;
@@ -846,5 +861,6 @@ bool Commands::peerSupportsMultiMessageAcknowledgement(int32_t peerVersion) {
 bool Commands::peerSupportsJsonSchemaAvroFormat(int32_t peerVersion) { return peerVersion >= proto::v13; }
 
 bool Commands::peerSupportsGetOrCreateSchema(int32_t peerVersion) { return peerVersion >= proto::v15; }
+
 }  // namespace pulsar
 /* namespace pulsar */

--- a/lib/Commands.h
+++ b/lib/Commands.h
@@ -85,6 +85,8 @@ class Commands {
     static SharedBuffer newLookup(const std::string& topic, const bool authoritative, uint64_t requestId,
                                   const std::string& listenerName);
 
+    static SharedBuffer newGetSchema(const std::string& topic, uint64_t requestId);
+
     static PairSharedBuffer newSend(SharedBuffer& headers, proto::BaseCommand& cmd, uint64_t producerId,
                                     uint64_t sequenceId, ChecksumType checksumType,
                                     const proto::MessageMetadata& metadata, const SharedBuffer& payload);

--- a/lib/HTTPLookupService.h
+++ b/lib/HTTPLookupService.h
@@ -28,6 +28,7 @@ namespace pulsar {
 class ServiceNameResolver;
 using NamespaceTopicsPromise = Promise<Result, NamespaceTopicsPtr>;
 using NamespaceTopicsPromisePtr = std::shared_ptr<NamespaceTopicsPromise>;
+using GetSchemaPromise = Promise<Result, boost::optional<SchemaInfo>>;
 
 class HTTPLookupService : public LookupService, public std::enable_shared_from_this<HTTPLookupService> {
     class CurlInitializer {
@@ -62,6 +63,7 @@ class HTTPLookupService : public LookupService, public std::enable_shared_from_t
 
     void handleLookupHTTPRequest(LookupPromise, const std::string, RequestType);
     void handleNamespaceTopicsHTTPRequest(NamespaceTopicsPromise promise, const std::string completeUrl);
+    void handleGetSchemaHTTPRequest(GetSchemaPromise promise, const std::string completeUrl);
 
     Result sendHTTPRequest(std::string completeUrl, std::string& responseData);
 
@@ -71,6 +73,8 @@ class HTTPLookupService : public LookupService, public std::enable_shared_from_t
     LookupResultFuture getBroker(const TopicName& topicName) override;
 
     Future<Result, LookupDataResultPtr> getPartitionMetadataAsync(const TopicNamePtr&) override;
+
+    Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override;
 
     Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) override;
 };

--- a/lib/LookupService.h
+++ b/lib/LookupService.h
@@ -21,6 +21,7 @@
 
 #include <pulsar/Result.h>
 
+#include <boost/optional.hpp>
 #include <memory>
 #include <ostream>
 #include <vector>
@@ -71,6 +72,14 @@ class LookupService {
      * Returns all the topics name for a given namespace.
      */
     virtual Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) = 0;
+
+    /**
+     * returns current SchemaInfo {@link SchemaInfo} for a given topic.
+     *
+     * @param topicName topic-name
+     * @return SchemaInfo
+     */
+    virtual Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) = 0;
 
     virtual ~LookupService() {}
 };

--- a/lib/Result.cc
+++ b/lib/Result.cc
@@ -40,6 +40,9 @@ const char* strResult(Result result) {
         case ResultTimeout:
             return "TimeOut";
 
+        case ResultNotFound:
+            return "ResultNotFound";
+
         case ResultLookupError:
             return "LookupError";
 

--- a/lib/RetryableLookupService.h
+++ b/lib/RetryableLookupService.h
@@ -66,6 +66,12 @@ class RetryableLookupService : public LookupService,
             [this, nsName] { return lookupService_->getTopicsOfNamespaceAsync(nsName); });
     }
 
+    Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override {
+        return executeAsync<boost::optional<SchemaInfo>>(
+            "get-schema" + topicName->toString(),
+            [this, topicName] { return lookupService_->getSchema(topicName); });
+    }
+
     template <typename T>
     Future<Result, T> executeAsync(const std::string& key, std::function<Future<Result, T>()> f) {
         Promise<Result, T> promise;

--- a/lib/SchemaUtils.h
+++ b/lib/SchemaUtils.h
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef SCHEMA_UTILS_HPP_
+#define SCHEMA_UTILS_HPP_
+
+#include "SharedBuffer.h"
+
+namespace pulsar {
+
+static constexpr uint32_t INVALID_SIZE = 0xFFFFFFFF;
+static const std::string KEY_SCHEMA_NAME = "key.schema.name";
+static const std::string KEY_SCHEMA_TYPE = "key.schema.type";
+static const std::string KEY_SCHEMA_PROPS = "key.schema.properties";
+static const std::string VALUE_SCHEMA_NAME = "value.schema.name";
+static const std::string VALUE_SCHEMA_TYPE = "value.schema.type";
+static const std::string VALUE_SCHEMA_PROPS = "value.schema.properties";
+static const std::string KV_ENCODING_TYPE = "kv.encoding.type";
+
+/**
+ * Merge keySchemaData and valueSchemaData.
+ * @return
+ */
+static std::string mergeKeyValueSchema(const std::string& keySchemaData, const std::string& valueSchemaData) {
+    uint32_t keySize = keySchemaData.size();
+    uint32_t valueSize = valueSchemaData.size();
+
+    auto buffSize = sizeof keySize + keySize + sizeof valueSize + valueSize;
+    SharedBuffer buffer = SharedBuffer::allocate(buffSize);
+    buffer.writeUnsignedInt(keySize == 0 ? INVALID_SIZE : static_cast<uint32_t>(keySize));
+    buffer.write(keySchemaData.c_str(), static_cast<uint32_t>(keySize));
+    buffer.writeUnsignedInt(valueSize == 0 ? INVALID_SIZE : static_cast<uint32_t>(valueSize));
+    buffer.write(valueSchemaData.c_str(), static_cast<uint32_t>(valueSize));
+
+    return std::string(buffer.data(), buffSize);
+}
+
+}  // namespace pulsar
+
+#endif /* SCHEMA_UTILS_HPP_ */

--- a/test-conf/standalone-ssl.conf
+++ b/test-conf/standalone-ssl.conf
@@ -50,6 +50,9 @@ brokerShutdownTimeoutMs=3000
 # Enable backlog quota check. Enforces action on topic when the quota is reached
 backlogQuotaCheckEnabled=true
 
+# Disable schema validation: If a producer doesn’t carry a schema, the producer is allowed to connect to the topic and produce data.
+isSchemaValidationEnforced=true
+
 # How often to check for topics that have reached the quota
 backlogQuotaCheckIntervalInSeconds=60
 


### PR DESCRIPTION
Master Issue: apache/pulsar/pull/2685

### Motivation

Implementing AUTO_PUBLISH schema solves the following problems:
1. If a schema exists in a topic, but the producer does not know it. He still wanted to send data to the topic. (The scenario in which the DLQ sends a message: Please refer #139 **[Verifying this change][5]**)

2. For clients based on C++ implementations(Node and Python), these client supports help users serialize and deserialize.
They can use this `AUTO_PUBLISH` schema feature to implement the same semantics as Java clients.


### Modifications
- When creating a producer with `AUTO_PUBLISH` schema, try to get the schema of that topic and use it.
- Support `getSchema` on `LookupService`(HTTP and Binary).


### Verifying this change

  - Add `LookupServiceTest` unit test to cover `getSchema` logic.
  - Add `SchemaTest.testAutoPublicSchema` unit test to cover creating producer success when the topic has a schema.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
