### PR TITLE
[fix] Use sudo when executing `apt-get install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cd pulsar-client-cpp
 #### Install all dependencies:
 
 ```shell
-sudo apt-get update -y && apt-get install -y g++ cmake libssl-dev libcurl4-openssl-dev \
+sudo apt-get update -y && sudo apt-get install -y g++ cmake libssl-dev libcurl4-openssl-dev \
                 libprotobuf-dev libboost-all-dev libgtest-dev libgmock-dev \
                 protobuf-compiler
 ```


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



### Motivation

When we execute the command according to the README, it will fail with lack of privilege to execute.

### Modifications

* Use sudo when executing `apt-get install` in the README

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
