### PR TITLE
[fix][doc] CMake is added to the Homebrew Mac Installation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ perf/perfConsumer
 #### Install all dependencies:
 
 ```shell
-brew install openssl protobuf boost boost-python3 googletest zstd snappy
+brew install cmake openssl protobuf boost boost-python3 googletest zstd snappy
 ```
 
 #### Compile Pulsar client library:


### PR DESCRIPTION
### Motivation

To match the Ubuntu and Windows documentation, I think it makes sense to include cmake in the Homebrew installation line, much like its included in the apt install line for Ubuntu in the README.

### Modifications

Added cmake to the README for Homebrew installation

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
