### PR TITLE
[fix] Use authoritative argument correctly in BinaryProtoLookupService::findBroker

### DIFF
--- a/lib/BinaryProtoLookupService.cc
+++ b/lib/BinaryProtoLookupService.cc
@@ -38,7 +38,7 @@ auto BinaryProtoLookupService::findBroker(const std::string& address, bool autho
     LOG_DEBUG("find broker from " << address << ", authoritative: " << authoritative << ", topic: " << topic);
     auto promise = std::make_shared<Promise<Result, LookupResult>>();
     // NOTE: we can use move capture for topic since C++14
-    cnxPool_.getConnectionAsync(address).addListener([this, promise, topic, address](
+    cnxPool_.getConnectionAsync(address).addListener([this, promise, topic, address, authoritative](
                                                          Result result,
                                                          const ClientConnectionWeakPtr& weakCnx) {
         if (result != ResultOk) {
@@ -52,7 +52,7 @@ auto BinaryProtoLookupService::findBroker(const std::string& address, bool autho
             return;
         }
         auto lookupPromise = std::make_shared<LookupDataResultPromise>();
-        cnx->newTopicLookup(topic, false, listenerName_, newRequestId(), lookupPromise);
+        cnx->newTopicLookup(topic, authoritative, listenerName_, newRequestId(), lookupPromise);
         lookupPromise->getFuture().addListener([this, cnx, promise, topic, address](
                                                    Result result, const LookupDataResultPtr& data) {
             if (result != ResultOk || !data) {


### PR DESCRIPTION
### Motivation

Use authoritative argument correctly in BinaryProtoLookupService::findBroker.

In the current code, authoritative field of lookup request is always false. When a bundle is not loaded by any broker, a lookup request with authoritative as false will not trigger broker to load the bundle, and lookup requests will loop between leader broker and the chosen broker. In this case, the lookup will not succeed and result in a large number of lookup requests to the broker as current c++ client do not have lookup redirect limit. If broker return failure after a large number of redirects, chains 
 of future will result in a large depth of function calls and may cause the stack to overflow.

https://github.com/apache/pulsar-client-cpp/blob/44f3b5240732a035395ec34b977301435dd0ec71/lib/BinaryProtoLookupService.cc#L55

### Modifications

Use authoritative argument.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial fix and not easy to test in standalone (need 2 or more broker).

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
bug fix only

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
