### PR TITLE
[feat] PIP 107: Introduce chunk message ID

### DIFF
--- a/include/pulsar/Message.h
+++ b/include/pulsar/Message.h
@@ -188,8 +188,7 @@ class PULSAR_PUBLIC Message {
     MessageImplPtr impl_;
 
     Message(MessageImplPtr& impl);
-    Message(const proto::CommandMessage& msg, proto::MessageMetadata& data, SharedBuffer& payload,
-            int32_t partition);
+    Message(const MessageId& messageId, proto::MessageMetadata& metadata, SharedBuffer& payload);
     /// Used for Batch Messages
     Message(const MessageId& messageId, proto::MessageMetadata& metadata, SharedBuffer& payload,
             proto::SingleMessageMetadata& singleMetadata, const std::string& topicName);

--- a/include/pulsar/MessageId.h
+++ b/include/pulsar/MessageId.h
@@ -108,6 +108,7 @@ class PULSAR_PUBLIC MessageId {
     friend class PulsarFriend;
     friend class NegativeAcksTracker;
     friend class MessageIdBuilder;
+    friend class ChunkMessageIdImpl;
 
     friend PULSAR_PUBLIC std::ostream& operator<<(std::ostream& s, const MessageId& messageId);
 

--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -19,12 +19,14 @@
 
 #pragma once
 
+#include <pulsar/MessageId.h>
+
 #include "MessageIdImpl.h"
 
 namespace pulsar {
 class ChunkMessageIdImpl;
 typedef std::shared_ptr<ChunkMessageIdImpl> ChunkMessageIdImplPtr;
-class ChunkMessageIdImpl : public MessageIdImpl {
+class ChunkMessageIdImpl : public MessageIdImpl, public std::enable_shared_from_this<ChunkMessageIdImpl> {
    public:
     ChunkMessageIdImpl() : firstChunkMsgId_(std::make_shared<MessageIdImpl>()) {}
 
@@ -36,9 +38,9 @@ class ChunkMessageIdImpl : public MessageIdImpl {
         this->partition_ = msgId.partition();
     }
 
-    std::shared_ptr<MessageIdImpl> getFirstChunkMessageId() { return firstChunkMsgId_; }
+    std::shared_ptr<const MessageIdImpl> getFirstChunkMessageId() const { return firstChunkMsgId_; }
 
-    static MessageId buildMessageId(const ChunkMessageIdImplPtr& msgIdImpl) { return MessageId{msgIdImpl}; }
+    MessageId build() { return MessageId{std::dynamic_pointer_cast<MessageIdImpl>(shared_from_this())}; }
 
    private:
     std::shared_ptr<MessageIdImpl> firstChunkMsgId_;

--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -36,9 +36,9 @@ class ChunkMessageIdImpl : public MessageIdImpl {
         this->partition_ = msgId.partition();
     }
 
-    MessageId getFirstChunkMessageId() { return MessageId{firstChunkMsgId_}; }
+    std::shared_ptr<MessageIdImpl> getFirstChunkMessageId() { return firstChunkMsgId_; }
 
-    static MessageId buildMessageId(ChunkMessageIdImplPtr& msgIdImpl) { return MessageId{msgIdImpl}; }
+    static MessageId buildMessageId(const ChunkMessageIdImplPtr& msgIdImpl) { return MessageId{msgIdImpl}; }
 
    private:
     std::shared_ptr<MessageIdImpl> firstChunkMsgId_;

--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -26,13 +26,9 @@ class ChunkMessageIdImpl;
 typedef std::shared_ptr<ChunkMessageIdImpl> ChunkMessageIdImplPtr;
 class ChunkMessageIdImpl : public MessageIdImpl {
    public:
-    ChunkMessageIdImpl() {}
-//    ChunkMessageIdImpl(const MessageIdImpl& firstChunkMsgId, const MessageIdImpl& lastChunkMsgId)
-//        : MessageIdImpl(lastChunkMsgId), firstChunkMsgId_(firstChunkMsgId) {}
+    ChunkMessageIdImpl() : firstChunkMsgId_(std::make_shared<MessageIdImpl>()) {}
 
-    void setFirstChunkMessageId(const MessageId& msgId) {
-        *firstChunkMsgId_.impl_ = *msgId.impl_;
-    }
+    void setFirstChunkMessageId(const MessageId& msgId) { *firstChunkMsgId_ = *msgId.impl_; }
 
     void setLastChunkMessageId(const MessageId& msgId) {
         this->ledgerId_ = msgId.ledgerId();
@@ -40,13 +36,11 @@ class ChunkMessageIdImpl : public MessageIdImpl {
         this->partition_ = msgId.partition();
     }
 
-    const MessageId& getFirstChunkMessageId() const { return firstChunkMsgId_; }
+    MessageId getFirstChunkMessageId() { return MessageId{firstChunkMsgId_}; }
 
-    static MessageId buildMessageId(ChunkMessageIdImplPtr& msgIdImpl) {
-        return MessageId{msgIdImpl};
-    }
+    static MessageId buildMessageId(ChunkMessageIdImplPtr& msgIdImpl) { return MessageId{msgIdImpl}; }
 
    private:
-    MessageId firstChunkMsgId_;
+    std::shared_ptr<MessageIdImpl> firstChunkMsgId_;
 };
 }  // namespace pulsar

--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "MessageIdImpl.h"
+
+namespace pulsar {
+class ChunkMessageIdImpl;
+typedef std::shared_ptr<ChunkMessageIdImpl> ChunkMessageIdImplPtr;
+class ChunkMessageIdImpl : public MessageIdImpl {
+   public:
+    ChunkMessageIdImpl() {}
+//    ChunkMessageIdImpl(const MessageIdImpl& firstChunkMsgId, const MessageIdImpl& lastChunkMsgId)
+//        : MessageIdImpl(lastChunkMsgId), firstChunkMsgId_(firstChunkMsgId) {}
+
+    void setFirstChunkMessageId(const MessageId& msgId) {
+        *firstChunkMsgId_.impl_ = *msgId.impl_;
+    }
+
+    void setLastChunkMessageId(const MessageId& msgId) {
+        this->ledgerId_ = msgId.ledgerId();
+        this->entryId_ = msgId.entryId();
+        this->partition_ = msgId.partition();
+    }
+
+    const MessageId& getFirstChunkMessageId() const { return firstChunkMsgId_; }
+
+    static MessageId buildMessageId(ChunkMessageIdImplPtr& msgIdImpl) {
+        return MessageId{msgIdImpl};
+    }
+
+   private:
+    MessageId firstChunkMsgId_;
+};
+}  // namespace pulsar

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -436,7 +436,7 @@ boost::optional<SharedBuffer> ConsumerImpl::processMessageChunk(const SharedBuff
     ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
     chunkMsgId->setFirstChunkMessageId(chunkedMsgCtx.getChunkedMessageIds().front());
     chunkMsgId->setLastChunkMessageId(chunkedMsgCtx.getChunkedMessageIds().back());
-    messageId = ChunkMessageIdImpl::buildMessageId(chunkMsgId);
+    messageId = chunkMsgId->build();
 
     LOG_DEBUG("Chunked message completed chunkId: " << chunkId << ", ChunkedMessageCtx: " << chunkedMsgCtx
                                                     << ", sequenceId: " << metadata.sequence_id());

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -27,6 +27,7 @@
 #include "AckGroupingTrackerEnabled.h"
 #include "BatchMessageAcker.h"
 #include "BatchedMessageIdImpl.h"
+#include "ChunkMessageIdImpl.h"
 #include "ClientConnection.h"
 #include "ClientImpl.h"
 #include "Commands.h"
@@ -375,9 +376,9 @@ void ConsumerImpl::triggerCheckExpiredChunkedTimer() {
 
 boost::optional<SharedBuffer> ConsumerImpl::processMessageChunk(const SharedBuffer& payload,
                                                                 const proto::MessageMetadata& metadata,
-                                                                const MessageId& messageId,
                                                                 const proto::MessageIdData& messageIdData,
-                                                                const ClientConnectionPtr& cnx) {
+                                                                const ClientConnectionPtr& cnx,
+                                                                MessageId& messageId) {
     const auto chunkId = metadata.chunk_id();
     const auto uuid = metadata.uuid();
     LOG_DEBUG("Process message chunk (chunkId: " << chunkId << ", uuid: " << uuid
@@ -432,6 +433,11 @@ boost::optional<SharedBuffer> ConsumerImpl::processMessageChunk(const SharedBuff
         return boost::none;
     }
 
+    ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
+    chunkMsgId->setFirstChunkMessageId(chunkedMsgCtx.getChunkedMessageIds().front());
+    chunkMsgId->setLastChunkMessageId(chunkedMsgCtx.getChunkedMessageIds().back());
+    messageId = ChunkMessageIdImpl::buildMessageId(chunkMsgId);
+
     LOG_DEBUG("Chunked message completed chunkId: " << chunkId << ", ChunkedMessageCtx: " << chunkedMsgCtx
                                                     << ", sequenceId: " << metadata.sequence_id());
 
@@ -472,11 +478,12 @@ void ConsumerImpl::messageReceived(const ClientConnectionPtr& cnx, const proto::
         }
     }
 
+    const auto& messageIdData = msg.message_id();
+    auto messageId = MessageIdBuilder::from(messageIdData).batchIndex(-1).build();
+
     // Only a non-batched messages can be a chunk
     if (!metadata.has_num_messages_in_batch() && isChunkedMessage) {
-        const auto& messageIdData = msg.message_id();
-        auto messageId = MessageIdBuilder::from(messageIdData).build();
-        auto optionalPayload = processMessageChunk(payload, metadata, messageId, messageIdData, cnx);
+        auto optionalPayload = processMessageChunk(payload, metadata, messageIdData, cnx, messageId);
         if (optionalPayload) {
             payload = optionalPayload.value();
         } else {
@@ -484,7 +491,7 @@ void ConsumerImpl::messageReceived(const ClientConnectionPtr& cnx, const proto::
         }
     }
 
-    Message m(msg, metadata, payload, partitionIndex_);
+    Message m(messageId, metadata, payload);
     m.impl_->cnx_ = cnx.get();
     m.impl_->setTopicName(topic_);
     m.impl_->setRedeliveryCount(msg.redelivery_count());

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -298,18 +298,18 @@ class ConsumerImpl : public ConsumerImplBase {
      *
      * @param payload the payload of a chunk
      * @param metadata the message metadata
-     * @param messageId
      * @param messageIdData
      * @param cnx
+     * @param messageId
      *
      * @return the concatenated payload if chunks are concatenated into a completed message payload
      *   successfully, else Optional::empty()
      */
     boost::optional<SharedBuffer> processMessageChunk(const SharedBuffer& payload,
                                                       const proto::MessageMetadata& metadata,
-                                                      const MessageId& messageId,
                                                       const proto::MessageIdData& messageIdData,
-                                                      const ClientConnectionPtr& cnx);
+                                                      const ClientConnectionPtr& cnx,
+                                                      MessageId& messageId);
 
     friend class PulsarFriend;
 

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -308,8 +308,7 @@ class ConsumerImpl : public ConsumerImplBase {
     boost::optional<SharedBuffer> processMessageChunk(const SharedBuffer& payload,
                                                       const proto::MessageMetadata& metadata,
                                                       const proto::MessageIdData& messageIdData,
-                                                      const ClientConnectionPtr& cnx,
-                                                      MessageId& messageId);
+                                                      const ClientConnectionPtr& cnx, MessageId& messageId);
 
     friend class PulsarFriend;
 

--- a/lib/Message.cc
+++ b/lib/Message.cc
@@ -69,10 +69,9 @@ Message::Message() : impl_() {}
 
 Message::Message(MessageImplPtr& impl) : impl_(impl) {}
 
-Message::Message(const proto::CommandMessage& msg, proto::MessageMetadata& metadata, SharedBuffer& payload,
-                 int32_t partition)
+Message::Message(const MessageId& messageId, proto::MessageMetadata& metadata, SharedBuffer& payload)
     : impl_(std::make_shared<MessageImpl>()) {
-    impl_->messageId = MessageIdBuilder::from(msg.message_id()).batchIndex(-1).build();
+    impl_->messageId = messageId;
     impl_->metadata = metadata;
     impl_->payload = payload;
 }

--- a/lib/MessageId.cc
+++ b/lib/MessageId.cc
@@ -98,7 +98,7 @@ MessageId MessageId::deserialize(const std::string& serializedMessageId) {
         ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
         chunkMsgId->setFirstChunkMessageId(MessageIdBuilder::from(idData.first_chunk_message_id()).build());
         chunkMsgId->setLastChunkMessageId(msgId);
-        return ChunkMessageIdImpl::buildMessageId(chunkMsgId);
+        return chunkMsgId->build();
     }
 
     return msgId;

--- a/lib/MessageId.cc
+++ b/lib/MessageId.cc
@@ -70,15 +70,14 @@ void MessageId::serialize(std::string& result) const {
     }
 
     auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(impl_);
-    if(chunkMsgId) {
-        auto* firstChunkIdData = new proto::MessageIdData();
+    if (chunkMsgId) {
+        proto::MessageIdData& firstChunkIdData = *idData.mutable_first_chunk_message_id();
         auto firstChunkId = chunkMsgId->getFirstChunkMessageId();
-        firstChunkIdData->set_ledgerid(firstChunkId->ledgerId_);
-        firstChunkIdData->set_entryid(firstChunkId->entryId_);
-        if(chunkMsgId->partition_!=-1){
-            firstChunkIdData->set_partition(firstChunkId->partition_);
+        firstChunkIdData.set_ledgerid(firstChunkId->ledgerId_);
+        firstChunkIdData.set_entryid(firstChunkId->entryId_);
+        if (chunkMsgId->partition_ != -1) {
+            firstChunkIdData.set_partition(firstChunkId->partition_);
         }
-        idData.set_allocated_first_chunk_message_id(firstChunkIdData);
     }
 
     idData.SerializeToString(&result);
@@ -95,7 +94,7 @@ MessageId MessageId::deserialize(const std::string& serializedMessageId) {
 
     MessageId msgId = MessageIdBuilder::from(idData).build();
 
-    if(idData.has_first_chunk_message_id()) {
+    if (idData.has_first_chunk_message_id()) {
         ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
         chunkMsgId->setFirstChunkMessageId(MessageIdBuilder::from(idData.first_chunk_message_id()).build());
         chunkMsgId->setLastChunkMessageId(msgId);
@@ -117,10 +116,10 @@ int32_t MessageId::batchSize() const { return impl_->batchSize_; }
 
 PULSAR_PUBLIC std::ostream& operator<<(std::ostream& s, const pulsar::MessageId& messageId) {
     auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(messageId.impl_);
-    if(chunkMsgId) {
+    if (chunkMsgId) {
         auto firstId = chunkMsgId->getFirstChunkMessageId();
-        s << '(' << firstId->ledgerId_ << ',' << firstId->entryId_ << ','
-          << firstId->partition_ << ',' << firstId->batchIndex_ << ");";
+        s << '(' << firstId->ledgerId_ << ',' << firstId->entryId_ << ',' << firstId->partition_ << ','
+          << firstId->batchIndex_ << ");";
     }
     s << '(' << messageId.impl_->ledgerId_ << ',' << messageId.impl_->entryId_ << ','
       << messageId.impl_->partition_ << ',' << messageId.impl_->batchIndex_ << ')';

--- a/lib/OpSendMsg.h
+++ b/lib/OpSendMsg.h
@@ -24,6 +24,7 @@
 
 #include <boost/date_time/posix_time/ptime.hpp>
 
+#include "ChunkMessageIdImpl.h"
 #include "PulsarApi.pb.h"
 #include "SharedBuffer.h"
 #include "TimeUtils.h"
@@ -40,6 +41,7 @@ struct OpSendMsg {
     uint32_t messagesCount_;
     uint64_t messagesSize_;
     std::vector<std::function<void(Result)>> trackerCallbacks_;
+    ChunkMessageIdImplPtr chunkedMessageId_;
 
     OpSendMsg() = default;
 

--- a/lib/OpSendMsg.h
+++ b/lib/OpSendMsg.h
@@ -47,8 +47,8 @@ struct OpSendMsg {
 
     OpSendMsg(const proto::MessageMetadata& metadata, const SharedBuffer& payload,
               const SendCallback& sendCallback, uint64_t producerId, uint64_t sequenceId, int sendTimeoutMs,
-              uint32_t messagesCount, uint64_t messagesSize)
-        : metadata_(metadata),  // the copy happens here because OpSendMsg of chunks are constructed with the
+              uint32_t messagesCount, uint64_t messagesSize, ChunkMessageIdImplPtr chunkedMessageId = nullptr)
+        : metadata_(metadata),  // the copy happens here because OpSendMsg of chunks are constructed with
                                 // a shared metadata object
           payload_(payload),
           sendCallback_(sendCallback),
@@ -56,7 +56,8 @@ struct OpSendMsg {
           sequenceId_(sequenceId),
           timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)),
           messagesCount_(messagesCount),
-          messagesSize_(messagesSize) {}
+          messagesSize_(messagesSize),
+          chunkedMessageId_(chunkedMessageId) {}
 
     void complete(Result result, const MessageId& messageId) const {
         if (sendCallback_) {

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -881,7 +881,7 @@ bool ProducerImpl::ackReceived(uint64_t sequenceId, MessageId& rawMessageId) {
             op.chunkedMessageId_->setFirstChunkMessageId(messageId);
         } else if (op.metadata_.chunk_id() == op.metadata_.num_chunks_from_msg() - 1) {
             op.chunkedMessageId_->setLastChunkMessageId(messageId);
-            messageId = ChunkMessageIdImpl::buildMessageId(op.chunkedMessageId_);
+            messageId = op.chunkedMessageId_->build();
         }
     }
 

--- a/tests/MessageChunkingTest.cc
+++ b/tests/MessageChunkingTest.cc
@@ -270,16 +270,22 @@ TEST(ChunkMessageIdTest, testSetChunkMessageId) {
         msgId = ChunkMessageIdImpl::buildMessageId(chunkMsgId);
         // Test the destructor of the underlying message id should also work for the generated messageId.
     }
-    ASSERT_EQ(msgId.ledgerId(), 4);
-    ASSERT_EQ(msgId.entryId(), 5);
-    ASSERT_EQ(msgId.partition(), 6);
 
-    auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(PulsarFriend::getMessageIdImpl(msgId));
+    std::string msgIdData;
+    msgId.serialize(msgIdData);
+    MessageId deserializedMsgId = MessageId::deserialize(msgIdData);
+
+    ASSERT_EQ(deserializedMsgId.ledgerId(), 4);
+    ASSERT_EQ(deserializedMsgId.entryId(), 5);
+    ASSERT_EQ(deserializedMsgId.partition(), 6);
+
+    auto chunkMsgId =
+        std::dynamic_pointer_cast<ChunkMessageIdImpl>(PulsarFriend::getMessageIdImpl(deserializedMsgId));
     ASSERT_TRUE(chunkMsgId);
     auto firstChunkMsgId = chunkMsgId->getFirstChunkMessageId();
-    ASSERT_EQ(firstChunkMsgId.ledgerId(), 1);
-    ASSERT_EQ(firstChunkMsgId.entryId(), 2);
-    ASSERT_EQ(firstChunkMsgId.partition(), 3);
+    ASSERT_EQ(firstChunkMsgId->ledgerId_, 1);
+    ASSERT_EQ(firstChunkMsgId->entryId_, 2);
+    ASSERT_EQ(firstChunkMsgId->partition_, 3);
 }
 
 // The CI env is Ubuntu 16.04, the gtest-dev version is 1.8.0 that doesn't have INSTANTIATE_TEST_SUITE_P

--- a/tests/MessageChunkingTest.cc
+++ b/tests/MessageChunkingTest.cc
@@ -320,7 +320,7 @@ TEST(ChunkMessageIdTest, testSetChunkMessageId) {
         ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
         chunkMsgId->setFirstChunkMessageId(MessageIdBuilder().ledgerId(1).entryId(2).partition(3).build());
         chunkMsgId->setLastChunkMessageId(MessageIdBuilder().ledgerId(4).entryId(5).partition(6).build());
-        msgId = ChunkMessageIdImpl::buildMessageId(chunkMsgId);
+        msgId = chunkMsgId->build();
         // Test the destructor of the underlying message id should also work for the generated messageId.
     }
 

--- a/tests/MessageChunkingTest.cc
+++ b/tests/MessageChunkingTest.cc
@@ -18,6 +18,7 @@
  */
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
+#include <pulsar/MessageIdBuilder.h>
 
 #include <ctime>
 #include <random>
@@ -116,6 +117,8 @@ TEST_P(MessageChunkingTest, testEndToEnd) {
     for (int i = 0; i < numMessages; i++) {
         MessageId messageId;
         ASSERT_EQ(ResultOk, producer.send(MessageBuilder().setContent(largeMessage).build(), messageId));
+        auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(PulsarFriend::getMessageIdImpl(messageId));
+        ASSERT_TRUE(chunkMsgId);
         LOG_INFO("Send " << i << " to " << messageId);
         sendMessageIds.emplace_back(messageId);
     }
@@ -264,16 +267,16 @@ TEST(ChunkMessageIdTest, testSetChunkMessageId) {
         msgId = ChunkMessageIdImpl::buildMessageId(chunkMsgId);
         // Test the destructor of the underlying message id should also work for the generated messageId.
     }
-    ASSERT_EQ(msgId.ledgerId(), 1);
-    ASSERT_EQ(msgId.entryId(), 2);
-    ASSERT_EQ(msgId.partition(), 3);
+    ASSERT_EQ(msgId.ledgerId(), 4);
+    ASSERT_EQ(msgId.entryId(), 5);
+    ASSERT_EQ(msgId.partition(), 6);
 
     auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(PulsarFriend::getMessageIdImpl(msgId));
     ASSERT_TRUE(chunkMsgId);
     auto firstChunkMsgId = chunkMsgId->getFirstChunkMessageId();
-    ASSERT_EQ(firstChunkMsgId.ledgerId(), 4);
-    ASSERT_EQ(firstChunkMsgId.entryId(), 5);
-    ASSERT_EQ(firstChunkMsgId.partition(), 6);
+    ASSERT_EQ(firstChunkMsgId.ledgerId(), 1);
+    ASSERT_EQ(firstChunkMsgId.entryId(), 2);
+    ASSERT_EQ(firstChunkMsgId.partition(), 3);
 }
 
 // The CI env is Ubuntu 16.04, the gtest-dev version is 1.8.0 that doesn't have INSTANTIATE_TEST_SUITE_P

--- a/tests/MessageChunkingTest.cc
+++ b/tests/MessageChunkingTest.cc
@@ -131,7 +131,10 @@ TEST_P(MessageChunkingTest, testEndToEnd) {
         ASSERT_EQ(msg.getDataAsString(), largeMessage);
         ASSERT_EQ(msg.getMessageId().batchIndex(), -1);
         ASSERT_EQ(msg.getMessageId().batchSize(), 0);
-        receivedMessageIds.emplace_back(msg.getMessageId());
+        auto messageId = msg.getMessageId();
+        auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(PulsarFriend::getMessageIdImpl(messageId));
+        ASSERT_TRUE(chunkMsgId);
+        receivedMessageIds.emplace_back(messageId);
     }
     ASSERT_EQ(receivedMessageIds, sendMessageIds);
     ASSERT_EQ(receivedMessageIds.front().ledgerId(), receivedMessageIds.front().ledgerId());

--- a/tests/MessageChunkingTest.cc
+++ b/tests/MessageChunkingTest.cc
@@ -255,6 +255,27 @@ TEST_P(MessageChunkingTest, testMaxPendingChunkMessages) {
     consumer.close();
 }
 
+TEST(ChunkMessageIdTest, testSetChunkMessageId) {
+    MessageId msgId;
+    {
+        ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
+        chunkMsgId->setFirstChunkMessageId(MessageIdBuilder().ledgerId(1).entryId(2).partition(3).build());
+        chunkMsgId->setLastChunkMessageId(MessageIdBuilder().ledgerId(4).entryId(5).partition(6).build());
+        msgId = ChunkMessageIdImpl::buildMessageId(chunkMsgId);
+        // Test the destructor of the underlying message id should also work for the generated messageId.
+    }
+    ASSERT_EQ(msgId.ledgerId(), 1);
+    ASSERT_EQ(msgId.entryId(), 2);
+    ASSERT_EQ(msgId.partition(), 3);
+
+    auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(PulsarFriend::getMessageIdImpl(msgId));
+    ASSERT_TRUE(chunkMsgId);
+    auto firstChunkMsgId = chunkMsgId->getFirstChunkMessageId();
+    ASSERT_EQ(firstChunkMsgId.ledgerId(), 4);
+    ASSERT_EQ(firstChunkMsgId.entryId(), 5);
+    ASSERT_EQ(firstChunkMsgId.partition(), 6);
+}
+
 // The CI env is Ubuntu 16.04, the gtest-dev version is 1.8.0 that doesn't have INSTANTIATE_TEST_SUITE_P
 INSTANTIATE_TEST_CASE_P(Pulsar, MessageChunkingTest,
                         ::testing::Values(CompressionNone, CompressionLZ4, CompressionZLib, CompressionZSTD,

--- a/tests/PulsarFriend.h
+++ b/tests/PulsarFriend.h
@@ -180,9 +180,7 @@ class PulsarFriend {
 
     static proto::MessageMetadata& getMessageMetadata(Message& message) { return message.impl_->metadata; }
 
-    static std::shared_ptr<MessageIdImpl> getMessageIdImpl(MessageId& msgId) {
-        return msgId.impl_;
-    }
+    static std::shared_ptr<MessageIdImpl> getMessageIdImpl(MessageId& msgId) { return msgId.impl_; }
 };
 }  // namespace pulsar
 

--- a/tests/PulsarFriend.h
+++ b/tests/PulsarFriend.h
@@ -179,6 +179,10 @@ class PulsarFriend {
     }
 
     static proto::MessageMetadata& getMessageMetadata(Message& message) { return message.impl_->metadata; }
+
+    static std::shared_ptr<MessageIdImpl> getMessageIdImpl(MessageId& msgId) {
+        return msgId.impl_;
+    }
 };
 }  // namespace pulsar
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes #79


### Motivation

This is the C++ implementation for https://github.com/apache/pulsar/issues/12402

### Modifications

* Add ChunkMessageIdImpl
* Return ChunkMessageId when the Producer produces the chunk message or when the consumer consumes the chunk message.
* In cosumer.seek, use the first chunk message-id of the chunk message-id. This will solve the problem caused by seeking chunk messages. This is also the impact of this PIP on the original business logic.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
