### PR TITLE
[feat] Support batch index acknowledgment

### DIFF
--- a/include/pulsar/ConsumerConfiguration.h
+++ b/include/pulsar/ConsumerConfiguration.h
@@ -553,6 +553,23 @@ class PULSAR_PUBLIC ConsumerConfiguration {
      */
     bool isStartMessageIdInclusive() const;
 
+    /**
+     * Enable the batch index acknowledgment.
+     *
+     * It should be noted that this option can only work when the broker side also enables the batch index
+     * acknowledgment. See the `acknowledgmentAtBatchIndexLevelEnabled` config in `broker.conf`.
+     *
+     * Default: false
+     *
+     * @param enabled whether to enable the batch index acknowledgment
+     */
+    ConsumerConfiguration& setBatchIndexAckEnabled(bool enabled);
+
+    /**
+     * The associated getter of setBatchingEnabled
+     */
+    bool isBatchIndexAckEnabled() const;
+
     friend class PulsarWrapper;
 
    private:

--- a/lib/AckGroupingTracker.cc
+++ b/lib/AckGroupingTracker.cc
@@ -19,9 +19,11 @@
 
 #include "AckGroupingTracker.h"
 
+#include "BitSet.h"
 #include "ClientConnection.h"
 #include "Commands.h"
 #include "LogUtils.h"
+#include "MessageIdImpl.h"
 
 namespace pulsar {
 
@@ -29,7 +31,8 @@ DECLARE_LOG_OBJECT();
 
 inline void sendAck(ClientConnectionPtr cnx, uint64_t consumerId, const MessageId& msgId,
                     CommandAck_AckType ackType) {
-    auto cmd = Commands::newAck(consumerId, msgId.ledgerId(), msgId.entryId(), ackType, -1);
+    const auto& bitSet = Commands::getMessageIdImpl(msgId)->getBitSet();
+    auto cmd = Commands::newAck(consumerId, msgId.ledgerId(), msgId.entryId(), bitSet, ackType, -1);
     cnx->sendCommand(cmd);
     LOG_DEBUG("ACK request is sent for message - [" << msgId.ledgerId() << ", " << msgId.entryId() << "]");
 }

--- a/lib/BatchMessageAcker.h
+++ b/lib/BatchMessageAcker.h
@@ -59,6 +59,8 @@ class BatchMessageAcker {
         return prevBatchCumulativelyAcked_.compare_exchange_strong(expectedValue, true);
     }
 
+    const BitSet& getBitSet() const noexcept { return bitSet_; }
+
    private:
     BitSet bitSet_;
     // When a batched message is acknowledged cumulatively, the previous message id will be acknowledged

--- a/lib/BatchedMessageIdImpl.h
+++ b/lib/BatchedMessageIdImpl.h
@@ -41,6 +41,8 @@ class BatchedMessageIdImpl : public MessageIdImpl {
 
     bool shouldAckPreviousMessageId() const { return acker_->shouldAckPreviousMessageId(); }
 
+    const BitSet& getBitSet() const noexcept override { return acker_->getBitSet(); }
+
     MessageId getPreviousMessageId() {
         return MessageIdBuilder().ledgerId(ledgerId_).entryId(entryId_ - 1).partition(partition_).build();
     }

--- a/lib/BitSet.h
+++ b/lib/BitSet.h
@@ -39,6 +39,8 @@ class BitSet {
 
     BitSet(int32_t numBits) : words_((numBits / 64) + ((numBits % 64 == 0) ? 0 : 1)) { assert(numBits > 0); }
 
+    BitSet(Data&& words) : words_(std::move(words)), wordsInUse_(words_.size()) {}
+
     // Support range loop like:
     // ```c++
     // BitSet bitSet(129);
@@ -54,6 +56,15 @@ class BitSet {
      * @return boolean indicating whether this {@code BitSet} is empty
      */
     bool isEmpty() const noexcept { return wordsInUse_ == 0; }
+
+    /**
+     * Returns the value of the bit with the specific index. The value is {@code true} if the bit with the
+     * index {@code bitIndex} is currently set in this {@code BitSet}; otherwise, the result is {@code false}.
+     *
+     * @param  bitIndex   the bit index
+     * @return the value of the bit with the specified index
+     */
+    bool get(int32_t bitIndex) const;
 
     /**
      * Sets the bits from the specified {@code fromIndex} (inclusive) to the
@@ -163,6 +174,12 @@ class BitSet {
         return (x >> safeShiftCount(sizeof(x) * 8, n));
     }
 };
+
+inline bool BitSet::get(int32_t bitIndex) const {
+    assert(bitIndex >= 0);
+    auto wordIndex_ = wordIndex(bitIndex);
+    return (wordIndex_ < wordsInUse_) && ((words_[wordIndex_] & (1L << bitIndex)) != 0);
+}
 
 inline void BitSet::set(int32_t fromIndex, int32_t toIndex) {
     assert(fromIndex < toIndex && fromIndex >= 0 && toIndex >= 0);

--- a/lib/Commands.h
+++ b/lib/Commands.h
@@ -39,6 +39,7 @@ class BatchMessageAcker;
 using BatchMessageAckerPtr = std::shared_ptr<BatchMessageAcker>;
 class MessageIdImpl;
 using MessageIdImplPtr = std::shared_ptr<MessageIdImpl>;
+class BitSet;
 
 namespace proto {
 class BaseCommand;
@@ -112,7 +113,7 @@ class Commands {
                                     bool userProvidedProducerName, bool encrypted,
                                     ProducerAccessMode accessMode, boost::optional<uint64_t> topicEpoch);
 
-    static SharedBuffer newAck(uint64_t consumerId, int64_t ledgerId, int64_t entryId,
+    static SharedBuffer newAck(uint64_t consumerId, int64_t ledgerId, int64_t entryId, const BitSet& ackSet,
                                CommandAck_AckType ackType, CommandAck_ValidationError validationError);
     static SharedBuffer newMultiMessageAck(uint64_t consumerId, const std::set<MessageId>& msgIds);
 

--- a/lib/ConsumerConfiguration.cc
+++ b/lib/ConsumerConfiguration.cc
@@ -287,4 +287,11 @@ const BatchReceivePolicy& ConsumerConfiguration::getBatchReceivePolicy() const {
     return impl_->batchReceivePolicy;
 }
 
+ConsumerConfiguration& ConsumerConfiguration::setBatchIndexAckEnabled(bool enabled) {
+    impl_->batchIndexAckEnabled = enabled;
+    return *this;
+}
+
+bool ConsumerConfiguration::isBatchIndexAckEnabled() const { return impl_->batchIndexAckEnabled; }
+
 }  // namespace pulsar

--- a/lib/ConsumerConfigurationImpl.h
+++ b/lib/ConsumerConfigurationImpl.h
@@ -56,6 +56,7 @@ struct ConsumerConfigurationImpl {
     bool autoAckOldestChunkedMessageOnQueueFull{false};
     bool startMessageIdInclusive{false};
     long expireTimeOfIncompleteChunkedMessageMs{60000};
+    bool batchIndexAckEnabled{false};
 };
 }  // namespace pulsar
 #endif /* LIB_CONSUMERCONFIGURATIONIMPL_H_ */

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -48,6 +48,7 @@ typedef std::shared_ptr<Backoff> BackoffPtr;
 
 class AckGroupingTracker;
 using AckGroupingTrackerPtr = std::shared_ptr<AckGroupingTracker>;
+class BitSet;
 class ConsumerStatsBase;
 using ConsumerStatsBasePtr = std::shared_ptr<ConsumerStatsBase>;
 class UnAckedMessageTracker;
@@ -158,7 +159,7 @@ class ConsumerImpl : public ConsumerImplBase {
     void increaseAvailablePermits(const ClientConnectionPtr& currentCnx, int delta = 1);
     void drainIncomingMessageQueue(size_t count);
     uint32_t receiveIndividualMessagesFromBatch(const ClientConnectionPtr& cnx, Message& batchedMessage,
-                                                int redeliveryCount);
+                                                const BitSet& ackSet, int redeliveryCount);
     bool isPriorBatchIndex(int32_t idx);
     bool isPriorEntryIndex(int64_t idx);
     void brokerConsumerStatsListener(Result, BrokerConsumerStatsImpl, BrokerConsumerStatsCallback);

--- a/lib/MessageIdImpl.h
+++ b/lib/MessageIdImpl.h
@@ -22,6 +22,8 @@
 #include <cstdint>
 #include <string>
 
+#include "BitSet.h"
+
 namespace pulsar {
 
 class MessageIdImpl {
@@ -43,6 +45,11 @@ class MessageIdImpl {
 
     const std::string& getTopicName() { return *topicName_; }
     void setTopicName(const std::string& topicName) { topicName_ = &topicName; }
+
+    virtual const BitSet& getBitSet() const noexcept {
+        static const BitSet emptyBitSet;
+        return emptyBitSet;
+    }
 
    private:
     const std::string* topicName_ = nullptr;

--- a/lib/MessageIdUtil.h
+++ b/lib/MessageIdUtil.h
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#pragma once
+
 #include <pulsar/MessageId.h>
 #include <pulsar/MessageIdBuilder.h>
 

--- a/test-conf/standalone-ssl.conf
+++ b/test-conf/standalone-ssl.conf
@@ -307,3 +307,6 @@ maxMessageSize=1024000
 
 # Disable consistent hashing to fix flaky `KeySharedConsumerTest#testMultiTopics`.
 subscriptionKeySharedUseConsistentHashing=false
+
+# Enable batch index ACK
+acknowledgmentAtBatchIndexLevelEnabled=true

--- a/tests/AcknowledgeTest.cc
+++ b/tests/AcknowledgeTest.cc
@@ -26,7 +26,9 @@
 #include "ConsumerWrapper.h"
 #include "HttpHelper.h"
 #include "PulsarFriend.h"
+#include "lib/Latch.h"
 #include "lib/LogUtils.h"
+#include "lib/MessageIdUtil.h"
 
 DECLARE_LOG_OBJECT()
 
@@ -185,30 +187,119 @@ TEST_F(AcknowledgeTest, testBatchedMessageId) {
 
     Message msg;
     // ack 2 messages of the batch that has 3 messages
-    consumers[0].acknowledgeAndRedeliver({0, 2}, CommandAck_AckType_Individual);
-    ASSERT_EQ(consumers[0].receive(msg), ResultOk);
+    consumers[0].acknowledgeAndRedeliver({0, 2}, AckType::INDIVIDUAL);
+    ASSERT_EQ(consumers[0].getConsumer().receive(msg, 1000), ResultOk);
     EXPECT_EQ(msg.getMessageId(), consumers[0].messageIdList()[0]);
     ASSERT_EQ(consumers[0].getNumAcked(CommandAck_AckType_Individual), 0);
 
     // ack the whole batch
-    consumers[1].acknowledgeAndRedeliver({0, 1, 2}, CommandAck_AckType_Individual);
-    ASSERT_EQ(consumers[1].receive(msg), ResultOk);
+    consumers[1].acknowledgeAndRedeliver({0, 1, 2}, AckType::INDIVIDUAL);
+    ASSERT_EQ(consumers[1].getConsumer().receive(msg, 1000), ResultOk);
     EXPECT_EQ(msg.getMessageId(), consumers[1].messageIdList()[batchingMaxMessages]);
     ASSERT_EQ(consumers[1].getNumAcked(CommandAck_AckType_Individual), 3);
 
     // ack cumulatively the previous message id
-    consumers[2].acknowledgeAndRedeliver({batchingMaxMessages, batchingMaxMessages + 1},
-                                         CommandAck_AckType_Cumulative);
-    ASSERT_EQ(consumers[2].receive(msg), ResultOk);
+    consumers[2].acknowledgeAndRedeliver({batchingMaxMessages, batchingMaxMessages + 1}, AckType::CUMULATIVE);
+    ASSERT_EQ(consumers[2].getConsumer().receive(msg, 1000), ResultOk);
     EXPECT_EQ(msg.getMessageId(), consumers[2].messageIdList()[batchingMaxMessages]);
     // the previous message id will only be acknowledged once
     ASSERT_EQ(consumers[2].getNumAcked(CommandAck_AckType_Cumulative), 1);
 
     // the whole 2nd batch is acknowledged
-    consumers[3].acknowledgeAndRedeliver({batchingMaxMessages + 2}, CommandAck_AckType_Cumulative);
-    ASSERT_EQ(consumers[3].receive(msg), ResultOk);
+    consumers[3].acknowledgeAndRedeliver({batchingMaxMessages + 2}, AckType::CUMULATIVE);
+    ASSERT_EQ(consumers[3].getConsumer().receive(msg, 1000), ResultOk);
     EXPECT_EQ(msg.getMessageId(), consumers[3].messageIdList()[batchingMaxMessages * 2]);
     ASSERT_EQ(consumers[3].getNumAcked(CommandAck_AckType_Cumulative), 1);
+}
+
+TEST_F(AcknowledgeTest, testBatchIndexAck) {
+    Client client(lookupUrl);
+    const std::string topic = "test-batch-index-ack-" + unique_str();
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(
+                            topic,
+                            ProducerConfiguration().setBatchingMaxMessages(100).setBatchingMaxPublishDelayMs(
+                                3600 * 1000 /* 1h */),
+                            producer));
+    std::vector<ConsumerWrapper> consumers{3};
+    for (size_t i = 0; i < consumers.size(); i++) {
+        consumers[i].initialize(client, topic, "sub-" + std::to_string(i), true /* enable batch index ack */);
+    }
+    constexpr int numMessages = 5;
+    for (int i = 0; i < numMessages; i++) {
+        producer.sendAsync(MessageBuilder().setContent("msg-" + std::to_string(i)).build(), nullptr);
+    }
+    producer.flush();
+    for (int i = 0; i < consumers.size(); i++) {
+        consumers[i].receiveAtMost(numMessages);
+        if (i >= 0) {
+            ASSERT_EQ(consumers[0].messageIdList(), consumers[i].messageIdList());
+        }
+    }
+    auto msgIds = consumers[0].messageIdList();
+
+    consumers[0].acknowledgeAndRestart({0, 2, 4}, AckType::INDIVIDUAL);
+    consumers[0].receiveAtMost(2);
+    ASSERT_EQ(subMessageIdList(msgIds, {1, 3}), consumers[0].messageIdList());
+
+    consumers[1].acknowledgeAndRestart({0, 3}, AckType::INDIVIDUAL_LIST);
+    consumers[1].receiveAtMost(3);
+    ASSERT_EQ(subMessageIdList(msgIds, {1, 2, 4}), consumers[1].messageIdList());
+
+    consumers[2].acknowledgeAndRestart({3}, AckType::CUMULATIVE);
+    consumers[2].receiveAtMost(1);
+    ASSERT_EQ(subMessageIdList(msgIds, {4}), consumers[2].messageIdList());
+}
+
+TEST_F(AcknowledgeTest, testMixedCumulativeAck) {
+    Client client(lookupUrl);
+    const std::string topic = "test-mixed-cumulative-ack-" + unique_str();
+
+    auto sendBatch = [&](int numMessages) {
+        Producer producer;
+        auto conf =
+            ProducerConfiguration().setBatchingMaxMessages(100).setBatchingMaxPublishDelayMs(3600 * 1000);
+        ASSERT_EQ(ResultOk, client.createProducer(topic, conf, producer));
+        Latch latch{numMessages};
+        for (int i = 0; i < numMessages; i++) {
+            producer.sendAsync(MessageBuilder().setContent("msg-" + std::to_string(i)).build(),
+                               [&latch](Result, const MessageId&) { latch.countdown(); });
+        }
+        producer.flush();
+        ASSERT_TRUE(latch.wait(std::chrono::seconds(3)));
+    };
+    auto sendNonBatch = [&](const std::string& msg) {
+        Producer producer;
+        auto conf = ProducerConfiguration().setBatchingEnabled(false);
+        ASSERT_EQ(ResultOk, client.createProducer(topic, conf, producer));
+        producer.send(MessageBuilder().setContent(msg).build());
+        producer.close();
+    };
+
+    ConsumerWrapper consumer;
+    consumer.initialize(client, topic, "sub", true);
+    sendNonBatch("msg");
+    sendBatch(5);
+    consumer.receiveAtMost(6);
+
+    // Acknowledge the 1st MessageId, which is a MessageIdImpl
+    auto msgIds = consumer.messageIdList();
+    ASSERT_TRUE(msgIds[0].batchIndex() < 0);
+    consumer.acknowledgeAndRestart({0}, AckType::CUMULATIVE);
+    consumer.receiveAtMost(5);
+    ASSERT_EQ(subMessageIdList(msgIds, {1, 2, 3, 4, 5}), consumer.messageIdList());
+
+    // Acknowledge the 3rd MessageId, which is a BatchedMessageIdImpl
+    ASSERT_EQ(consumer.messageIdList()[2].batchIndex(), 2);
+    consumer.acknowledgeAndRestart({2}, AckType::CUMULATIVE);
+    consumer.receiveAtMost(2);
+    ASSERT_EQ(subMessageIdList(msgIds, {4, 5}), consumer.messageIdList());
+
+    consumer.getConsumer().acknowledgeCumulative(discardBatch(consumer.messageIdList()[0]));
+    consumer.getConsumer().close();
+    consumer.initialize(client, topic, "sub", true);
+    Message msg;
+    ASSERT_EQ(ResultTimeout, consumer.getConsumer().receive(msg, 1000));
 }
 
 INSTANTIATE_TEST_SUITE_P(BasicEndToEndTest, AcknowledgeTest, testing::Values(100, 0));

--- a/tests/BitSetTest.cc
+++ b/tests/BitSetTest.cc
@@ -62,6 +62,13 @@ TEST(BitSetTest, testSet) {
     // range contains one word
     bitSet.set(3, 29);
     ASSERT_EQ(toLongVector(bitSet), std::vector<uint64_t>{0x1ffffff8});
+    for (int i = 0; i < 64 * 5 + 1; i++) {
+        if (i >= 3 && i < 29) {
+            ASSERT_TRUE(bitSet.get(i));
+        } else {
+            ASSERT_FALSE(bitSet.get(i));
+        }
+    }
 
     // range contains multiple words
     bitSet.set(64 * 2 + 11, 64 * 4 + 19);

--- a/tests/ConsumerConfigurationTest.cc
+++ b/tests/ConsumerConfigurationTest.cc
@@ -65,6 +65,7 @@ TEST(ConsumerConfigurationTest, testDefaultConfig) {
     ASSERT_EQ(conf.getBatchReceivePolicy().getMaxNumMessages(), -1);
     ASSERT_EQ(conf.getBatchReceivePolicy().getMaxNumBytes(), 10 * 1024 * 1024);
     ASSERT_EQ(conf.getBatchReceivePolicy().getTimeoutMs(), 100);
+    ASSERT_EQ(conf.isBatchIndexAckEnabled(), false);
 }
 
 TEST(ConsumerConfigurationTest, testCustomConfig) {
@@ -160,6 +161,9 @@ TEST(ConsumerConfigurationTest, testCustomConfig) {
     ASSERT_EQ(conf.getBatchReceivePolicy().getMaxNumMessages(), 10);
     ASSERT_EQ(conf.getBatchReceivePolicy().getMaxNumBytes(), 10);
     ASSERT_EQ(conf.getBatchReceivePolicy().getTimeoutMs(), 100);
+
+    conf.setBatchIndexAckEnabled(true);
+    ASSERT_EQ(conf.isBatchIndexAckEnabled(), true);
 }
 
 TEST(ConsumerConfigurationTest, testReadCompactPersistentExclusive) {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/87

### Modifications

- Add an consumer configuration `setBatchIndexAckEnabled` to enable the batch index ACK. When it's enabled, passing the original `MessageId` instead of the `MessageIdImpl` that trunks the batch index to the ACK grouping tracker.
- Since now a `BatchedMessageIdImpl` could be accepted in the ACK grouping tracker, fix the compare logic.
- Support passing a `BitSet` in `Commands::newAck` and get the internal `BitSet` from `MessageId` in `Commands::newMultiMessageAck`.
- Skip the acknowledged batch indexes when receiving batched messages in `ConsumerImpl::receiveIndividualMessagesFromBatch`.

### Verifications

Modify `BitSetTest.testSet` to verify the `BitSet::get` method added in this commit.

Add `AcknowledgeTest.testBatchIndexAck` to test batch index ACK for all types of acknowledgment:
- Individual ACK for a single message
- Individual ACK for a list of messages
- Cumulative ACK

Add `AcknowledgeTest.testMixedCumulativeAck` to test the new compare logic between `BatchedMessageIdImpl` and `MessageIdImpl` works for cumulative ACK.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
