### PR TITLE
[fix] Fix MessageId serialization when it's a batched message

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -57,7 +57,7 @@ jobs:
           sudo curl -o /gtest-parallel https://raw.githubusercontent.com/google/gtest-parallel/master/gtest_parallel.py 
 
       - name: CMake
-        run: cmake . -DBUILD_PERF_TOOLS=ON
+        run: cmake . -DCMAKE_BUILD_TYPE=Debug -DBUILD_PERF_TOOLS=ON
 
       - name: Check formatting
         run: make check-format

--- a/lib/BatchMessageAcker.h
+++ b/lib/BatchMessageAcker.h
@@ -32,6 +32,7 @@ using BatchMessageAckerPtr = std::shared_ptr<BatchMessageAcker>;
 
 class BatchMessageAcker {
    public:
+    virtual ~BatchMessageAcker() {}
     // Return false for these methods so that batch index ACK will be falled back to if the acker is created
     // by deserializing from raw bytes.
     virtual bool ackIndividual(int32_t) { return false; }

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -636,7 +636,7 @@ uint32_t ConsumerImpl::receiveIndividualMessagesFromBatch(const ClientConnection
 
     int skippedMessages = 0;
 
-    auto acker = BatchMessageAcker::create(batchSize);
+    auto acker = BatchMessageAckerImpl::create(batchSize);
     for (int i = 0; i < batchSize; i++) {
         // This is a cheap copy since message contains only one shared pointer (impl_)
         Message msg = Commands::deSerializeSingleMessageInBatch(batchedMessage, i, batchSize, acker);

--- a/lib/MessageBatch.cc
+++ b/lib/MessageBatch.cc
@@ -47,7 +47,7 @@ MessageBatch& MessageBatch::parseFrom(const SharedBuffer& payload, uint32_t batc
     impl_->metadata.set_num_messages_in_batch(batchSize);
     batch_.clear();
 
-    auto acker = BatchMessageAcker::create(batchSize);
+    auto acker = BatchMessageAckerImpl::create(batchSize);
     for (int i = 0; i < batchSize; ++i) {
         batch_.push_back(Commands::deSerializeSingleMessageInBatch(batchMessage_, i, batchSize, acker));
     }

--- a/lib/MessageId.cc
+++ b/lib/MessageId.cc
@@ -69,6 +69,10 @@ void MessageId::serialize(std::string& result) const {
         idData.set_batch_index(impl_->batchIndex_);
     }
 
+    if (impl_->batchSize_ != 0) {
+        idData.set_batch_size(impl_->batchSize_);
+    }
+
     auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(impl_);
     if (chunkMsgId) {
         proto::MessageIdData& firstChunkIdData = *idData.mutable_first_chunk_message_id();

--- a/lib/MessageIdBuilder.cc
+++ b/lib/MessageIdBuilder.cc
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <assert.h>
 #include <pulsar/MessageIdBuilder.h>
 
+#include "BatchedMessageIdImpl.h"
 #include "MessageIdImpl.h"
 #include "PulsarApi.pb.h"
 
@@ -42,8 +42,11 @@ MessageIdBuilder MessageIdBuilder::from(const proto::MessageIdData& messageIdDat
 }
 
 MessageId MessageIdBuilder::build() const {
-    assert(impl_->batchIndex_ < 0 || (impl_->batchSize_ > impl_->batchIndex_));
-    return MessageId{impl_};
+    if (impl_->batchIndex_ >= 0 && impl_->batchSize_ > 0) {
+        return MessageId{std::make_shared<BatchedMessageIdImpl>(*impl_, BatchMessageAckerImpl::create(0))};
+    } else {
+        return MessageId{impl_};
+    }
 }
 
 MessageIdBuilder& MessageIdBuilder::ledgerId(int64_t ledgerId) {


### PR DESCRIPTION
### Motivation

The serialization and deserialization of `MessageId` became wrong after https://github.com/apache/pulsar-client-cpp/pull/132.
1. The batch size is not serialized.
2. `BatchedMessageIdImpl` could never be deserialized.

The wrong behaviors could lead to a result that all MessageId objects created from deserialization does not have a batch size, which might make `ReaderTest.testReaderOnSpecificMessageWithBatches` fail when the cmake build type is `Debug`. What's worse is that a MessageId created from deserialization is always treated as a `MessageIdImpl`, on which the acknowledgment will have wrong behavior.

### Modifications

Serialize the batch size if it's valid. In deserialization, create a `BatchedMessageIdImpl` when the batch index and the batch size are valid as a batched message.

There is a problem that if a `MessageId` is created from deserialization, it cannot share a `BatchMessageAcker` with other `MessageId` objects. In this case, create a fake `BatchMessageAcker` that returns false for both `ackIndividual` and `ackCumulative` methods. It will make acknowledgment always fail but will fall back to batch index ACK if batch index ACK is enabled.

Add the `-DCMAKE_BUILD_TYPE=Debug` for tests to enable assertions.