### PR TITLE
[fix][build] Hide non-exported symbols from the dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.13)
 
 project (pulsar-cpp)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake_modules")
@@ -290,7 +290,7 @@ if (NOT APPLE AND NOT MSVC)
     # Hide all non-exported symbols to avoid conflicts
     add_compile_options(-fvisibility=hidden) 
     if (CMAKE_COMPILER_IS_GNUCC)
-        add_compile_options(-Wl,--exclude-libs,ALL)
+        add_link_options(-Wl,--exclude-libs=ALL)
     endif ()
 endif ()
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Pulsar C++ client uses [doxygen](https://www.doxygen.nl) to build API documents.
 ## Requirements
 
 * A C++ compiler that supports C++11, like GCC >= 4.8
-* CMake >= 3.4
+* CMake >= 3.13
 * [Boost](http://www.boost.org/)
 * [Protocol Buffer](https://developers.google.com/protocol-buffers/) >= 3
 * [libcurl](https://curl.se/libcurl/)


### PR DESCRIPTION
### Motivation

Currently the released libraries don't hide the symbols from the dependencies, it can be verified by the following steps on Ubuntu:

```bash
curl -O -L https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.1.0/deb-x86_64/apache-pulsar-client.deb
apt install ./apache-pulsar-client.deb
nm -D /usr/lib/libpulsar.so | grep curl
```

You will see lots of symbols from libcurl are included in `libpulsar.so`:

```
0000000000709f50 T curl_easy_cleanup
000000000070a000 T curl_easy_duphandle
...
```

The root cause is that `-Wl,--exclude-libs,ALL` is added as the compile option, but it should work as a link option.

### Modifications

Use `add_link_options` to add `-Wl,--exclude-libs=ALL` as the link option. It seems that `=ALL` should be correct but `,ALL` also works.