### PR TITLE
[fix] Fix log for connection disconnected expectedly

### DIFF
--- a/include/pulsar/Result.h
+++ b/include/pulsar/Result.h
@@ -92,6 +92,8 @@ enum Result
     ResultMemoryBufferIsFull,  /// Client-wide memory limit has been reached
 
     ResultInterrupted,  /// Interrupted while waiting to dequeue
+
+    ResultDisconnected,  /// Client connection has been disconnected
 };
 
 // Return string representation of result code

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -1596,7 +1596,7 @@ void ClientConnection::close(Result result) {
     }
 
     lock.unlock();
-    if (result != ResultDisconnected) {
+    if (result != ResultDisconnected && result != ResultRetryable) {
         LOG_ERROR(cnxString_ << "Connection closed with " << result);
     } else {
         LOG_INFO(cnxString_ << "Connection disconnected");

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -1596,7 +1596,11 @@ void ClientConnection::close(Result result) {
     }
 
     lock.unlock();
-    LOG_INFO(cnxString_ << "Connection closed with " << result);
+    if (result != ResultDisconnected) {
+        LOG_ERROR(cnxString_ << "Connection closed with " << result);
+    } else {
+        LOG_INFO(cnxString_ << "Connection disconnected");
+    }
 
     for (ProducersMap::iterator it = producers.begin(); it != producers.end(); ++it) {
         HandlerBase::handleDisconnection(result, shared_from_this(), it->second);

--- a/lib/ConnectionPool.cc
+++ b/lib/ConnectionPool.cc
@@ -53,7 +53,7 @@ bool ConnectionPool::close() {
         for (auto cnxIt = pool_.begin(); cnxIt != pool_.end(); cnxIt++) {
             ClientConnectionPtr cnx = cnxIt->second.lock();
             if (cnx) {
-                cnx->close();
+                cnx->close(ResultDisconnected);
             }
         }
         pool_.clear();

--- a/lib/Result.cc
+++ b/lib/Result.cc
@@ -165,6 +165,9 @@ const char* strResult(Result result) {
 
         case ResultInterrupted:
             return "ResultInterrupted";
+
+        case ResultDisconnected:
+            return "ResultDisconnected";
     };
     // NOTE : Do not add default case in the switch above. In future if we get new cases for
     // ServerError and miss them in the switch above we would like to get notified. Adding

--- a/tests/ClientTest.cc
+++ b/tests/ClientTest.cc
@@ -126,7 +126,7 @@ TEST(ClientTest, testConnectTimeout) {
     clientDefault.close();
 
     ASSERT_EQ(futureDefault.wait_for(std::chrono::milliseconds(10)), std::future_status::ready);
-    ASSERT_EQ(futureDefault.get(), ResultConnectError);
+    ASSERT_EQ(futureDefault.get(), ResultDisconnected);
 }
 
 TEST(ClientTest, testGetNumberOfReferences) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes #140

### Motivation

When running produce and consume, and the client calls close, it
shows `ConnectError` in the close method

```
[[127.0.0.1:43644](http://127.0.0.1:43644/) -> [127.0.0.1:6650](http://127.0.0.1:6650/)] Connection closed with
ConnectError
```

### Modifications

* Show `Connection disconnected` just like the java client did instead of `ConnectError` when the client disconnect successfully.
* Add error log for unexpected closed connection.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
