### PR TITLE
Format .c suffix file.

### DIFF
--- a/build-support/run_clang_format.py
+++ b/build-support/run_clang_format.py
@@ -46,7 +46,7 @@ for source_dir in SOURCE_DIRS:
     for directory, subdirs, files in os.walk(source_dir):
         for name in files:
             name = os.path.join(directory, name)
-            if not (name.endswith('.h') or name.endswith('.cc')):
+            if not (name.endswith('.h') or name.endswith('.cc') or name.endswith('.c')):
                 continue
 
             excluded = False

--- a/examples/SampleAsyncConsumerCApi.c
+++ b/examples/SampleAsyncConsumerCApi.c
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#include <stdio.h>
 #include <pulsar/c/client.h>
+#include <stdio.h>
 
 static void receive_callback(pulsar_result result, pulsar_message_t *message, void *ctx) {
     pulsar_consumer_t *consumer = (pulsar_consumer_t *)ctx;

--- a/examples/SampleConsumerCApi.c
+++ b/examples/SampleConsumerCApi.c
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#include <stdio.h>
 #include <pulsar/c/client.h>
+#include <stdio.h>
 
 int main() {
     pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
@@ -28,7 +28,8 @@ int main() {
     pulsar_consumer_configuration_set_consumer_type(consumer_conf, pulsar_ConsumerShared);
 
     pulsar_consumer_t *consumer;
-    pulsar_result res = pulsar_client_subscribe(client, "my-topic", "my-subscrition", consumer_conf, &consumer);
+    pulsar_result res =
+        pulsar_client_subscribe(client, "my-topic", "my-subscrition", consumer_conf, &consumer);
     if (res != pulsar_result_Ok) {
         printf("Failed to create subscribe to topic: %s\n", pulsar_result_str(res));
         return 1;
@@ -43,7 +44,7 @@ int main() {
         }
 
         printf("Received message with payload: '%.*s'\n", pulsar_message_get_length(message),
-               (const char*)pulsar_message_get_data(message));
+               (const char *)pulsar_message_get_data(message));
 
         pulsar_consumer_acknowledge(consumer, message);
         pulsar_message_free(message);

--- a/examples/SampleConsumerListenerCApi.c
+++ b/examples/SampleConsumerListenerCApi.c
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-#include <stdio.h>
 #include <pulsar/c/client.h>
+#include <stdio.h>
 
-static void listener_callback(pulsar_consumer_t* consumer, pulsar_message_t* message, void* ctx) {
+static void listener_callback(pulsar_consumer_t *consumer, pulsar_message_t *message, void *ctx) {
     printf("Received message with payload: '%.*s'\n", pulsar_message_get_length(message),
-           (const char*)pulsar_message_get_data(message));
+           (const char *)pulsar_message_get_data(message));
 
     pulsar_consumer_acknowledge(consumer, message);
     pulsar_message_free(message);
@@ -37,7 +37,8 @@ int main() {
     pulsar_consumer_configuration_set_message_listener(consumer_conf, listener_callback, NULL);
 
     pulsar_consumer_t *consumer;
-    pulsar_result res = pulsar_client_subscribe(client, "my-topic", "my-subscrition", consumer_conf, &consumer);
+    pulsar_result res =
+        pulsar_client_subscribe(client, "my-topic", "my-subscrition", consumer_conf, &consumer);
     if (res != pulsar_result_Ok) {
         printf("Failed to create subscribe to topic: %s\n", pulsar_result_str(res));
         return 1;

--- a/examples/SampleProducerCApi.c
+++ b/examples/SampleProducerCApi.c
@@ -18,18 +18,17 @@
  */
 
 #include <pulsar/c/client.h>
-
 #include <stdio.h>
 #include <string.h>
 
 int main() {
-    pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
+    pulsar_client_configuration_t* conf = pulsar_client_configuration_create();
     pulsar_client_configuration_set_memory_limit(conf, 64 * 1024 * 1024);
-    pulsar_client_t *client = pulsar_client_create("pulsar://localhost:6650", conf);
+    pulsar_client_t* client = pulsar_client_create("pulsar://localhost:6650", conf);
 
     pulsar_producer_configuration_t* producer_conf = pulsar_producer_configuration_create();
     pulsar_producer_configuration_set_batching_enabled(producer_conf, 1);
-    pulsar_producer_t *producer;
+    pulsar_producer_t* producer;
 
     pulsar_result err = pulsar_client_create_producer(client, "my-topic", producer_conf, &producer);
     if (err != pulsar_result_Ok) {

--- a/examples/SampleReaderCApi.c
+++ b/examples/SampleReaderCApi.c
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#include <stdio.h>
 #include <pulsar/c/client.h>
+#include <stdio.h>
 
 int main() {
     pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
@@ -27,8 +27,8 @@ int main() {
     pulsar_reader_configuration_t *reader_conf = pulsar_reader_configuration_create();
 
     pulsar_reader_t *reader;
-    pulsar_result res = pulsar_client_create_reader(client, "my-topic", pulsar_message_id_earliest(), reader_conf,
-                                                    &reader);
+    pulsar_result res =
+        pulsar_client_create_reader(client, "my-topic", pulsar_message_id_earliest(), reader_conf, &reader);
     if (res != pulsar_result_Ok) {
         printf("Failed to create reader: %s\n", pulsar_result_str(res));
         return 1;
@@ -43,7 +43,7 @@ int main() {
         }
 
         printf("Received message with payload: '%.*s'\n", pulsar_message_get_length(message),
-               (const char*)pulsar_message_get_data(message));
+               (const char *)pulsar_message_get_data(message));
 
         pulsar_message_free(message);
     }


### PR DESCRIPTION
### Motivation

Currently, the .c suffix file is not formatted by `clang-format`.

### Modifications
- `clang-format` support format .c suffix file.
- Correct the current .c file style.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
