### PR TITLE
[fix] Fix missing schema related function definitions

### DIFF
--- a/lib/c/c_Message.cc
+++ b/lib/c/c_Message.cc
@@ -127,3 +127,9 @@ const char *pulsar_message_get_topic_name(pulsar_message_t *message) {
 int pulsar_message_get_redelivery_count(pulsar_message_t *message) {
     return message->message.getRedeliveryCount();
 }
+
+const char *pulsar_message_get_schemaVersion(pulsar_message_t *message) {
+    return message->message.getSchemaVersion().c_str();
+}
+
+int pulsar_message_has_schema_version(pulsar_message_t *message) { return message->message.hasSchemaVersion(); }

--- a/lib/c/c_Message.cc
+++ b/lib/c/c_Message.cc
@@ -132,4 +132,6 @@ const char *pulsar_message_get_schemaVersion(pulsar_message_t *message) {
     return message->message.getSchemaVersion().c_str();
 }
 
-int pulsar_message_has_schema_version(pulsar_message_t *message) { return message->message.hasSchemaVersion(); }
+int pulsar_message_has_schema_version(pulsar_message_t *message) {
+    return message->message.hasSchemaVersion();
+}


### PR DESCRIPTION
### Modifications

Add missing function definitions for `pulsar_message_has_schema_version` and `pulsar_message_get_schemaVersion`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
