### PR TITLE
Fix broken main branch by providing correct getBitSet implementation

### DIFF
--- a/lib/AckGroupingTracker.cc
+++ b/lib/AckGroupingTracker.cc
@@ -31,7 +31,8 @@ DECLARE_LOG_OBJECT();
 
 inline void sendAck(ClientConnectionPtr cnx, uint64_t consumerId, const MessageId& msgId,
                     CommandAck_AckType ackType) {
-    const auto& bitSet = Commands::getMessageIdImpl(msgId)->getBitSet();
+    const auto& bitSet =
+        Commands::getMessageIdImpl(msgId)->getBitSet(ackType == CommandAck_AckType_Individual);
     auto cmd = Commands::newAck(consumerId, msgId.ledgerId(), msgId.entryId(), bitSet, ackType, -1);
     cnx->sendCommand(cmd);
     LOG_DEBUG("ACK request is sent for message - [" << msgId.ledgerId() << ", " << msgId.entryId() << "]");

--- a/lib/BatchMessageAcker.h
+++ b/lib/BatchMessageAcker.h
@@ -37,13 +37,15 @@ class BatchMessageAcker {
     // by deserializing from raw bytes.
     virtual bool ackIndividual(int32_t) { return false; }
     virtual bool ackCumulative(int32_t) { return false; }
+    virtual const BitSet& getBitSet() noexcept {
+        static BitSet emptyBitSet;
+        return emptyBitSet;
+    }
 
     bool shouldAckPreviousMessageId() noexcept {
         bool expectedValue = false;
         return prevBatchCumulativelyAcked_.compare_exchange_strong(expectedValue, true);
     }
-
-    const BitSet& getBitSet() const noexcept { return bitSet_; }
 
    private:
     // When a batched message is acknowledged cumulatively, the previous message id will be acknowledged
@@ -79,6 +81,8 @@ class BatchMessageAckerImpl : public BatchMessageAcker {
         bitSet_.clear(0, batchIndex + 1);
         return bitSet_.isEmpty();
     }
+
+    const BitSet& getBitSet() const noexcept { return bitSet_; }
 
    private:
     BitSet bitSet_;

--- a/lib/BatchMessageAcker.h
+++ b/lib/BatchMessageAcker.h
@@ -37,7 +37,7 @@ class BatchMessageAcker {
     // by deserializing from raw bytes.
     virtual bool ackIndividual(int32_t) { return false; }
     virtual bool ackCumulative(int32_t) { return false; }
-    virtual const BitSet& getBitSet() noexcept {
+    virtual const BitSet& getBitSet() const noexcept {
         static BitSet emptyBitSet;
         return emptyBitSet;
     }
@@ -82,7 +82,7 @@ class BatchMessageAckerImpl : public BatchMessageAcker {
         return bitSet_.isEmpty();
     }
 
-    const BitSet& getBitSet() const noexcept { return bitSet_; }
+    const BitSet& getBitSet() const noexcept override { return bitSet_; }
 
    private:
     BitSet bitSet_;

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -450,7 +450,7 @@ SharedBuffer Commands::newMultiMessageAck(uint64_t consumerId, const std::set<Me
         auto newMsgId = ack->add_message_id();
         newMsgId->set_ledgerid(msgId.ledgerId());
         newMsgId->set_entryid(msgId.entryId());
-        for (auto x : getMessageIdImpl(msgId)->getBitSet()) {
+        for (auto x : getMessageIdImpl(msgId)->getBitSet(true)) {
             newMsgId->add_ack_set(x);
         }
     }

--- a/lib/MessageIdImpl.h
+++ b/lib/MessageIdImpl.h
@@ -46,7 +46,7 @@ class MessageIdImpl {
     const std::string& getTopicName() { return *topicName_; }
     void setTopicName(const std::string& topicName) { topicName_ = &topicName; }
 
-    virtual const BitSet& getBitSet() const noexcept {
+    virtual const BitSet& getBitSet(bool individual) const noexcept {
         static const BitSet emptyBitSet;
         return emptyBitSet;
     }


### PR DESCRIPTION
### Motivation

Currently the main branch is broken by the concurrent merge of https://github.com/apache/pulsar-client-cpp/pull/153 and https://github.com/apache/pulsar-client-cpp/pull/151. It's because when a batched message id is constructed from deserialization, there is no `getBitSet` implementation of the internal acker.

### Modifications

Add a `bool` parameter to `MessageIdImpl::getBitSet` to indicate whether the message ID is batched. The logic is similar with

https://github.com/apache/pulsar/blob/299bd70fdfa023768e94a8ee4347d39337b6cbd4/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java#L325-L327

and

https://github.com/apache/pulsar/blob/299bd70fdfa023768e94a8ee4347d39337b6cbd4/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java#L345-L347

Add a `testMessageIdFromBuild` to test the acknowledgment for a message ID without an acker could succeed for a consumer that enables batch index ACK.

### TODO

In future, https://github.com/apache/pulsar/pull/19031 might be migrated into the C++ client to fix the consumer that disables batch index ACK.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
