### PR TITLE
Fix broken main branch caused by wrong getBitSet method

### DIFF
--- a/lib/BatchMessageAcker.h
+++ b/lib/BatchMessageAcker.h
@@ -43,7 +43,10 @@ class BatchMessageAcker {
         return prevBatchCumulativelyAcked_.compare_exchange_strong(expectedValue, true);
     }
 
-    const BitSet& getBitSet() const noexcept { return bitSet_; }
+    virtual const BitSet& getBitSet() const noexcept {
+        static BitSet emptyBitSet;
+        return emptyBitSet;
+    }
 
    private:
     // When a batched message is acknowledged cumulatively, the previous message id will be acknowledged
@@ -79,6 +82,8 @@ class BatchMessageAckerImpl : public BatchMessageAcker {
         bitSet_.clear(0, batchIndex + 1);
         return bitSet_.isEmpty();
     }
+
+    const BitSet& getBitSet() const noexcept override { return bitSet_; }
 
    private:
     BitSet bitSet_;


### PR DESCRIPTION
### Motivation

Currently the main branch is broken by the concurrent merge of https://github.com/apache/pulsar-client-cpp/pull/153 and https://github.com/apache/pulsar-client-cpp/pull/151.

### Modifications

Add a dummy `getBitSet` implementation to `BatchMessageAcker` and the correct implementation for `BatchMessageAckerImpl`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
