### PR TITLE
Fix Wireshark build

### DIFF
--- a/wireshark/CMakeLists.txt
+++ b/wireshark/CMakeLists.txt
@@ -60,9 +60,9 @@ include_directories(${LIB_AUTOGEN_DIR})
 set(PROTO_SOURCES ${LIB_AUTOGEN_DIR}/PulsarApi.pb.cc ${LIB_AUTOGEN_DIR}/PulsarApi.pb.h)
 ADD_CUSTOM_COMMAND(
         OUTPUT ${PROTO_SOURCES}
-        COMMAND ${PROTOC_PATH} -I ../../pulsar-common/src/main/proto ../../pulsar-common/src/main/proto/PulsarApi.proto --cpp_out=${LIB_AUTOGEN_DIR}
+        COMMAND ${PROTOC_PATH} -I ../proto ../proto/PulsarApi.proto --cpp_out=${LIB_AUTOGEN_DIR}
         DEPENDS
-        ../../pulsar-common/src/main/proto/PulsarApi.proto
+        ../proto/PulsarApi.proto
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 link_libraries(${Protobuf_LIBRARIES})
 

--- a/wireshark/README.md
+++ b/wireshark/README.md
@@ -70,7 +70,6 @@ $ sudo apt install wireshark-dev
 Compile the dissector.
 
 ```shell
-cd pulsar-client-cpp
 cmake -DBUILD_WIRESHARK=ON .
 make pulsar-dissector
 ```
@@ -91,18 +90,18 @@ You can see the location of personal plugins, which is important for the next st
 
 Example
 
-Wireshark 3.6.0 on macOS
+Wireshark 4.0.3 on macOS
 
 ```shell
-~/.local/lib/wireshark/plugins/3-6/
+~/.local/lib/wireshark/plugins/4-0/
 ```
 
 ### Copy Wireshark dissector to appropriate location
 
 ```shell
-mkdir -p ~/.local/lib/wireshark/plugins/3-6/epan
-cd pulsar-client-cpp/wireshark
-cp pulsar-dissector.so ~/.local/lib/wireshark/plugins/3-6/epan
+mkdir -p ~/.local/lib/wireshark/plugins/4-0/epan
+cd wireshark
+cp pulsar-dissector.so ~/.local/lib/wireshark/plugins/4-0/epan
 ```
 
 ### Complete installation

--- a/wireshark/pulsarDissector.cc
+++ b/wireshark/pulsarDissector.cc
@@ -16,15 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <config.h>
 #include <epan/column-utils.h>
 #include <epan/dissectors/packet-tcp.h>
-#include <epan/expert.h>
 #include <epan/packet.h>
-#include <epan/prefs.h>
 #include <epan/proto.h>
 #include <epan/value_string.h>
 #include <glib.h>
+#include <ws_version.h>
 #include <wsutil/nstime.h>
 
 #include "PulsarApi.pb.h"
@@ -1055,6 +1053,14 @@ static int dissect_pulsar_message(tvbuff_t* tvb, packet_info* pinfo, proto_tree*
             break;
         case BaseCommand::TC_CLIENT_CONNECT_RESPONSE:
             break;
+        case BaseCommand::WATCH_TOPIC_LIST:
+            break;
+        case BaseCommand::WATCH_TOPIC_LIST_SUCCESS:
+            break;
+        case BaseCommand::WATCH_TOPIC_UPDATE:
+            break;
+        case BaseCommand::WATCH_TOPIC_LIST_CLOSE:
+            break;
     }
 
     return maxOffset;
@@ -1210,8 +1216,8 @@ void proto_register_pulsar() {
 extern "C" {
 
 extern __attribute__((unused)) WS_DLL_PUBLIC_DEF const gchar plugin_version[] = VERSION;
-extern __attribute__((unused)) WS_DLL_PUBLIC_DEF const int plugin_want_major = VERSION_MAJOR;
-extern __attribute__((unused)) WS_DLL_PUBLIC_DEF const int plugin_want_minor = VERSION_MINOR;
+extern __attribute__((unused)) WS_DLL_PUBLIC_DEF const int plugin_want_major = WIRESHARK_VERSION_MAJOR;
+extern __attribute__((unused)) WS_DLL_PUBLIC_DEF const int plugin_want_minor = WIRESHARK_VERSION_MINOR;
 
 WS_DLL_PUBLIC void plugin_register(void);
 


### PR DESCRIPTION
* Fixes #181
* Fixes #179
* Fixes #180

### Motivation

The Pulsar Wireshark plugin has not been maintained for a long time, 
the Pulsar protobuf command and Wireshark header file have been updated.

### Modifications
1. Fix protobuf file path
2. Fix the Wireshark header
3. Fix README base path

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
