### PR TITLE
[fix] Avoid resource leakage of AckGroupingTracker

### DIFF
--- a/lib/AckGroupingTrackerEnabled.cc
+++ b/lib/AckGroupingTrackerEnabled.cc
@@ -51,6 +51,7 @@ AckGroupingTrackerEnabled::AckGroupingTrackerEnabled(ClientImplPtr clientPtr,
                                                      const HandlerBasePtr& handlerPtr, uint64_t consumerId,
                                                      long ackGroupingTimeMs, long ackGroupingMaxSize)
     : AckGroupingTracker(),
+      state_(NotStarted),
       handlerWeakPtr_(handlerPtr),
       consumerId_(consumerId),
       nextCumulativeAckMsgId_(MessageId::earliest()),
@@ -67,7 +68,10 @@ AckGroupingTrackerEnabled::AckGroupingTrackerEnabled(ClientImplPtr clientPtr,
                                                         << ackGroupingMaxSize);
 }
 
-void AckGroupingTrackerEnabled::start() { this->scheduleTimer(); }
+void AckGroupingTrackerEnabled::start() {
+    state_ = Ready;
+    this->scheduleTimer();
+}
 
 bool AckGroupingTrackerEnabled::isDuplicate(const MessageId& msgId) {
     {
@@ -110,6 +114,7 @@ void AckGroupingTrackerEnabled::addAcknowledgeCumulative(const MessageId& msgId)
 }
 
 void AckGroupingTrackerEnabled::close() {
+    state_ = Closed;
     this->flush();
     std::lock_guard<std::mutex> lock(this->mutexTimer_);
     if (this->timer_) {
@@ -164,6 +169,10 @@ void AckGroupingTrackerEnabled::flushAndClean() {
 }
 
 void AckGroupingTrackerEnabled::scheduleTimer() {
+    if (state_ != Ready) {
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(this->mutexTimer_);
     this->timer_ = this->executor_->createDeadlineTimer();
     this->timer_->expires_from_now(boost::posix_time::milliseconds(std::max(1L, this->ackGroupingTimeMs_)));

--- a/lib/AckGroupingTrackerEnabled.h
+++ b/lib/AckGroupingTrackerEnabled.h
@@ -71,15 +71,6 @@ class AckGroupingTrackerEnabled : public AckGroupingTracker {
     //! Method for scheduling grouping timer.
     void scheduleTimer();
 
-    //! State
-    enum State
-    {
-        NotStarted,
-        Ready,
-        Closed,
-    };
-    std::atomic<State> state_;
-
     //! The connection handler.
     HandlerBaseWeakPtr handlerWeakPtr_;
 

--- a/lib/AckGroupingTrackerEnabled.h
+++ b/lib/AckGroupingTrackerEnabled.h
@@ -21,6 +21,7 @@
 
 #include <pulsar/MessageId.h>
 
+#include <atomic>
 #include <boost/asio/deadline_timer.hpp>
 #include <cstdint>
 #include <mutex>
@@ -70,6 +71,9 @@ class AckGroupingTrackerEnabled : public AckGroupingTracker {
    protected:
     //! Method for scheduling grouping timer.
     void scheduleTimer();
+
+    //! State
+    std::atomic_bool isClosed_;
 
     //! The connection handler.
     HandlerBaseWeakPtr handlerWeakPtr_;

--- a/lib/AckGroupingTrackerEnabled.h
+++ b/lib/AckGroupingTrackerEnabled.h
@@ -71,6 +71,15 @@ class AckGroupingTrackerEnabled : public AckGroupingTracker {
     //! Method for scheduling grouping timer.
     void scheduleTimer();
 
+    //! State
+    enum State
+    {
+        NotStarted,
+        Ready,
+        Closed,
+    };
+    std::atomic<State> state_;
+
     //! The connection handler.
     HandlerBaseWeakPtr handlerWeakPtr_;
 

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -1212,6 +1212,9 @@ void ConsumerImpl::closeAsync(ResultCallback originalCallback) {
 const std::string& ConsumerImpl::getName() const { return consumerStr_; }
 
 void ConsumerImpl::shutdown() {
+    if (ackGroupingTrackerPtr_) {
+        ackGroupingTrackerPtr_->close();
+    }
     incomingMessages_.clear();
     possibleSendToDeadLetterTopicMessages_.clear();
     resetCnx();


### PR DESCRIPTION
### Motivation

Avoid resource leakage of AckGroupingTracker.

The result of AckGroupingTracker leakage is waste of cpu. In our case, after a large number (30w+) of consumer creation failures, pulsar client io threads use 99% cpu when no operations.

There are two problems about the leakage:
* In the current code, if consumer creation failed, ConsumerImpl::ackGroupingTrackerPtr_ will not close.
* AckGroupingTrackerEnabled has race condition between close and reschedule, and may continue reschedule after close.

### Modifications

* ConsumerImpl: close ackGroupingTrackerPtr_ when shutdown
* AckGroupingTrackerEnabled: add state, and check state before reschedule

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Can verify this change by adding a log and using a test program. The leakage resources are hold in boost::asio::io_service and seems not easy to write a unit test to verify.

The test program trys to trigger AckGroupingTracker leakage. If there is a leak, will print a lot of test log 'reschedule AckGroupingTrackerEnabled'. 

Add a test log:
```
void AckGroupingTrackerEnabled::scheduleTimer() {
    // ......
    this->timer_->async_wait([this, self](const boost::system::error_code& ec) -> void {
        if (!ec) {
            this->flush();
            this->scheduleTimer();
            LOG_INFO("reschedule AckGroupingTrackerEnabled");  // add a log when reschedule
        }
    });
}
```

Test program:
```
int main() {
    Client client("pulsar://localhost:6650");

    Consumer consumer;
    ConsumerConfiguration config;
    config.setConsumerType(ConsumerType::ConsumerExclusive);
    config.setAckGroupingTimeMs(1);

    // create exclusive consumer
    Result result = client.subscribe("persistent://public/default/my-topic", "consumer-1", config, consumer);
    if (result != ResultOk) {
        LOG_ERROR("Failed to subscribe: " << result);
        return -1;
    }

    // create other consumer, will fail
    for (int i = 0; i < 1000; ++i) {
        Result result =
            client.subscribe("persistent://public/default/my-topic", "consumer-1", config, consumer);
        assert(result != ResultOk);
        (void)result;
    }

    consumer.close();

    LOG_INFO("sleep, should not have reschedule logs below");
    std::this_thread::sleep_for(std::chrono::seconds(60));

    client.close();
    return 0;
}
```

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
Bug fix only.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
