### PR TITLE
[fix] Use ClientConfiguration::getTlsTrustCertsFilePath for the OAuth2 flow

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -31,6 +31,7 @@
 #include "ProducerImpl.h"
 #include "PulsarApi.pb.h"
 #include "Url.h"
+#include "auth/InitialAuthData.h"
 #include "checksum/ChecksumProvider.h"
 
 DECLARE_LOG_OBJECT()
@@ -225,7 +226,8 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
         std::string tlsCertificates = clientConfiguration.getTlsCertificateFilePath();
         std::string tlsPrivateKey = clientConfiguration.getTlsPrivateKeyFilePath();
 
-        AuthenticationDataPtr authData;
+        auto authData = std::dynamic_pointer_cast<AuthenticationDataProvider>(
+            std::make_shared<InitialAuthData>(clientConfiguration.getTlsTrustCertsFilePath()));
         if (authentication_->getAuthData(authData) == ResultOk && authData->hasDataForTls()) {
             tlsCertificates = authData->getTlsCertificates();
             tlsPrivateKey = authData->getTlsPrivateKey();

--- a/lib/auth/AuthOauth2.h
+++ b/lib/auth/AuthOauth2.h
@@ -60,12 +60,17 @@ class ClientCredentialFlow : public Oauth2Flow {
     ParamMap generateParamMap() const;
     std::string getTokenEndPoint() const;
 
+    void setTlsTrustCertsFilePath(const std::string& tlsTrustCertsFilePath) {
+        tlsTrustCertsFilePath_ = tlsTrustCertsFilePath;
+    }
+
    private:
     std::string tokenEndPoint_;
     const std::string issuerUrl_;
     const KeyFile keyFile_;
     const std::string audience_;
     const std::string scope_;
+    std::string tlsTrustCertsFilePath_;
     std::once_flag initializeOnce_;
 };
 

--- a/lib/auth/InitialAuthData.h
+++ b/lib/auth/InitialAuthData.h
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <pulsar/Authentication.h>
+
+namespace pulsar {
+
+class ClientConfiguration;
+
+struct InitialAuthData : public AuthenticationDataProvider {
+    const std::string tlsTrustCertsFilePath_;
+
+    InitialAuthData(const std::string& tlsTrustCertsFilePath)
+        : tlsTrustCertsFilePath_(tlsTrustCertsFilePath) {}
+
+    bool hasDataForHttp() override { return false; }
+    std::string getHttpHeaders() override { return ""; }
+    bool hasDataFromCommand() override { return false; }
+    std::string getCommandData() override { return ""; }
+};
+
+}  // namespace pulsar


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/184

### Motivation

`ClientConfiguration::getTlsTrustCertsFilePath` is only used for HTTP service URL lookup and the TLS handshake, but not used for the OAuth2 client credentials flow. If the issuer URL or the OAuth2 authorization server requires the CA cert, the CA cert can only be loaded from a specific path, which is determined by how to build the C++ client. e.g. it's `/etc/ssl/certs/ca-certificates.crt` when libcurl is built in Debian-based Linux distros and `/etc/pki/tls/certs/ca-bundle.crt` in RedHat-based Linux distros. A typical issue is that the Pulsar Python wheels are built in a [RedHat-based Linux image](https://github.com/pypa/manylinux), if they are installed in a Debian-based Linux distro, users can only fix this issue by copying the `ca-certificats.cert` into `/etc/pki/tls/certs/ca-bundle.crt`, while it should have been configured by the `tls_trust_certs_file_path` config.

### Modifications

Add a `AuthenticationDataProvider` implementation `InitialAuthData`, which holds the CA cert path. Then, in `AuthOauth2::getAuthData`, retrieve the path and pass it to the `ClientCredentialFlow` for HTTP requests performed by libcurl.

This solution is API and ABI compatible.

### Verifications

It's hard to add the test in CI because we need an OAuth2 server configured with the CA configured.

Follow the **How to reproduce** section in
https://github.com/apache/pulsar-client-cpp/issues/184#issuecomment-1420509146 to reproduce this issue. Apply this patch and build the `libpulsar.so` with `LINK_STATIC=ON`, then copy the `libpulsar.so` into the docker container (under `/app/lib`).

Run `./a.out` directly, you will still see the `AuthenticationError`. However, if you added the path of `libpulsar.so` to the `LD_LIBRARY_PATH`:

```bash
export LD_LIBRARY_PATH=/app/lib
./a.out
```

No error will happen. You can also replace the `/lib/libpulsar.so` with the `libpulsar.so` built from source.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
