### PR TITLE
[fix] Fix wireshark plugin build on macOS

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install deps (macOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
         run:
-          brew install wireshark protobuf
+          brew install glib wireshark protobuf
 
       - name: Build wireshark plugin
         run: |


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar-client-cpp/actions/runs/4220713571/jobs/7327254536

### Modifications

Install the `glib` dependnecy.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
