### PR TITLE
Fix broken main branch that failed to build the wireshark dissector on macOS

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install deps (macOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
         run:
-          brew install wireshark protobuf
+          brew install pkg-config wireshark protobuf
 
       - name: Build wireshark plugin
         run: |


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar-client-cpp/actions/runs/4220713571/jobs/7327254536

It failed because `pkg-config` is not installed by default after the upgrade of `macos-12` GitHub runner image.

Here is a fix from the upstream: https://github.com/actions/runner-images/pull/7125

### Modifications

Install the `pkg-config` dependency.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
