### PR TITLE
[feat] Support ExclusiveWithFencing producer access mode.

### DIFF
--- a/include/pulsar/ProducerConfiguration.h
+++ b/include/pulsar/ProducerConfiguration.h
@@ -94,7 +94,13 @@ class PULSAR_PUBLIC ProducerConfiguration {
         /**
          * Producer creation is pending until it can acquire exclusive access.
          */
-        WaitForExclusive = 2
+        WaitForExclusive = 2,
+
+        /**
+         * Acquire exclusive access for the producer. Any existing producer will be removed and
+         * invalidated immediately.
+         */
+        ExclusiveWithFencing = 3
     };
 
     ProducerConfiguration();

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -361,6 +361,8 @@ TEST(ProducerTest, testExclusiveWithFencingProducer) {
                                    latch.countdown();
                                    producer2 = producer;
                                });
+    // wait for all the Producers to be enqueued in order to prevent races
+    sleep(1);
 
     // producer3 will create success.
     Producer producer3;
@@ -387,6 +389,7 @@ TEST(ProducerTest, testExclusiveWithFencingProducer) {
                                    producer4 = producer;
                                    latch2.countdown();
                                });
+    ASSERT_EQ(ResultProducerNotInitialized, producer4.send(MessageBuilder().setContent("content").build()));
 
     // When producer3 is close, producer4 will be create success
     producer3.close();


### PR DESCRIPTION
### Motivation
#95

### Modifications

- Support ExclusiveWithFencing producer access mode.

### Verifying this change
- Add `testExclusiveWithFencingProducer ` to cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
