### PR TITLE
[fix] Handle exceptions when creating timers when fd limit is reached

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ add_custom_target(format ${BUILD_SUPPORT_DIR}/run_clang_format.py
         ${PROJECT_SOURCE_DIR}/perf
         ${PROJECT_SOURCE_DIR}/examples
         ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/unix
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/wireshark)
 
@@ -435,5 +436,6 @@ add_custom_target(check-format ${BUILD_SUPPORT_DIR}/run_clang_format.py
         ${PROJECT_SOURCE_DIR}/perf
         ${PROJECT_SOURCE_DIR}/examples
         ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/unix
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/wireshark)

--- a/lib/ExecutorService.h
+++ b/lib/ExecutorService.h
@@ -49,9 +49,12 @@ class PULSAR_PUBLIC ExecutorService : public std::enable_shared_from_this<Execut
     ExecutorService(const ExecutorService &) = delete;
     ExecutorService &operator=(const ExecutorService &) = delete;
 
+    // throws std::runtime_error if failed
     SocketPtr createSocket();
     static TlsSocketPtr createTlsSocket(SocketPtr &socket, boost::asio::ssl::context &ctx);
+    // throws std::runtime_error if failed
     TcpResolverPtr createTcpResolver();
+    // throws std::runtime_error if failed
     DeadlineTimerPtr createDeadlineTimer();
     void postWork(std::function<void(void)> task);
 
@@ -67,12 +70,6 @@ class PULSAR_PUBLIC ExecutorService : public std::enable_shared_from_this<Execut
      */
     IOService io_service_;
 
-    /*
-     * work will not let io_service.run() return even after it has finished work
-     * it will keep it running in the background so we don't have to take care of it
-     */
-    IOService::work work_{io_service_};
-
     std::atomic_bool closed_{false};
     std::mutex mutex_;
     std::condition_variable cond_;
@@ -81,6 +78,14 @@ class PULSAR_PUBLIC ExecutorService : public std::enable_shared_from_this<Execut
     ExecutorService();
 
     void start();
+
+    void restart() {
+        close();
+        closed_ = false;
+        ioServiceDone_ = false;
+        io_service_.restart();
+        start();
+    }
 };
 
 using ExecutorServicePtr = ExecutorService::SharedPtr;

--- a/lib/ExecutorService.h
+++ b/lib/ExecutorService.h
@@ -73,19 +73,13 @@ class PULSAR_PUBLIC ExecutorService : public std::enable_shared_from_this<Execut
     std::atomic_bool closed_{false};
     std::mutex mutex_;
     std::condition_variable cond_;
-    std::atomic_bool ioServiceDone_{false};
+    bool ioServiceDone_{false};
 
     ExecutorService();
 
     void start();
 
-    void restart() {
-        close();
-        closed_ = false;
-        ioServiceDone_ = false;
-        io_service_.restart();
-        start();
-    }
+    void restart();
 };
 
 using ExecutorServicePtr = ExecutorService::SharedPtr;

--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -439,26 +439,40 @@ void PartitionedProducerImpl::handleGetPartitions(Result result,
             LOG_INFO("new partition count: " << newNumPartitions);
             topicMetadata_.reset(new TopicMetadataImpl(newNumPartitions));
 
+            std::vector<ProducerImplPtr> producers;
+            auto lazy = conf_.getLazyStartPartitionedProducers() &&
+                        conf_.getAccessMode() == ProducerConfiguration::Shared;
             for (unsigned int i = currentNumPartitions; i < newNumPartitions; i++) {
-                auto lazy = conf_.getLazyStartPartitionedProducers() &&
-                            conf_.getAccessMode() == ProducerConfiguration::Shared;
-                auto producer = newInternalProducer(i, lazy);
-
+                ProducerImplPtr producer;
+                try {
+                    producer = newInternalProducer(i, lazy);
+                } catch (const std::runtime_error& e) {
+                    LOG_ERROR("Failed to create producer for partition " << i << ": " << e.what());
+                    producers.clear();
+                    break;
+                }
+                producers.emplace_back(producer);
+            }
+            if (producers.empty()) {
+                runPartitionUpdateTask();
+                return;
+            }
+            for (unsigned int i = 0; i < producers.size(); i++) {
+                auto&& producer = producers[i];
+                producers_.emplace_back(producer);
                 if (!lazy) {
                     producer->start();
                 }
-                producers_.push_back(producer);
             }
             producersLock.unlock();
             // `runPartitionUpdateTask()` will be called in `handleSinglePartitionProducerCreated()`
             interceptors_->onPartitionsChange(getTopic(), newNumPartitions);
-            return;
+            runPartitionUpdateTask();
         }
     } else {
         LOG_WARN("Failed to getPartitionMetadata: " << strResult(result));
+        runPartitionUpdateTask();
     }
-
-    runPartitionUpdateTask();
 }
 
 bool PartitionedProducerImpl::isConnected() const {

--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -465,9 +465,9 @@ void PartitionedProducerImpl::handleGetPartitions(Result result,
                 }
             }
             producersLock.unlock();
-            // `runPartitionUpdateTask()` will be called in `handleSinglePartitionProducerCreated()`
             interceptors_->onPartitionsChange(getTopic(), newNumPartitions);
-            runPartitionUpdateTask();
+            // `runPartitionUpdateTask()` will be called in `handleSinglePartitionProducerCreated()`
+            return;
         }
     } else {
         LOG_WARN("Failed to getPartitionMetadata: " << strResult(result));

--- a/lib/PeriodicTask.cc
+++ b/lib/PeriodicTask.cc
@@ -18,8 +18,6 @@
  */
 #include "PeriodicTask.h"
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 namespace pulsar {
 
 void PeriodicTask::start() {
@@ -29,8 +27,8 @@ void PeriodicTask::start() {
     state_ = Ready;
     if (periodMs_ >= 0) {
         std::weak_ptr<PeriodicTask> weakSelf{shared_from_this()};
-        timer_.expires_from_now(boost::posix_time::millisec(periodMs_));
-        timer_.async_wait([weakSelf](const ErrorCode& ec) {
+        timer_->expires_from_now(boost::posix_time::millisec(periodMs_));
+        timer_->async_wait([weakSelf](const ErrorCode& ec) {
             auto self = weakSelf.lock();
             if (self) {
                 self->handleTimeout(ec);
@@ -45,7 +43,7 @@ void PeriodicTask::stop() noexcept {
         return;
     }
     ErrorCode ec;
-    timer_.cancel(ec);
+    timer_->cancel(ec);
     state_ = Pending;
 }
 
@@ -59,8 +57,8 @@ void PeriodicTask::handleTimeout(const ErrorCode& ec) {
     // state_ may be changed in handleTimeout, so we check state_ again
     if (state_ == Ready) {
         auto self = shared_from_this();
-        timer_.expires_from_now(boost::posix_time::millisec(periodMs_));
-        timer_.async_wait([this, self](const ErrorCode& ec) { handleTimeout(ec); });
+        timer_->expires_from_now(boost::posix_time::millisec(periodMs_));
+        timer_->async_wait([this, self](const ErrorCode& ec) { handleTimeout(ec); });
     }
 }
 

--- a/lib/PeriodicTask.h
+++ b/lib/PeriodicTask.h
@@ -18,12 +18,7 @@
  */
 #pragma once
 
-#include <atomic>
-#include <boost/asio/deadline_timer.hpp>
-#include <boost/asio/io_service.hpp>
-#include <cstdint>
-#include <functional>
-#include <memory>
+#include "ExecutorService.h"
 
 namespace pulsar {
 
@@ -51,7 +46,8 @@ class PeriodicTask : public std::enable_shared_from_this<PeriodicTask> {
         Closing
     };
 
-    PeriodicTask(boost::asio::io_service& ioService, int periodMs) : timer_(ioService), periodMs_(periodMs) {}
+    PeriodicTask(ExecutorService& executor, int periodMs)
+        : timer_(executor.createDeadlineTimer()), periodMs_(periodMs) {}
 
     void start();
 
@@ -64,7 +60,7 @@ class PeriodicTask : public std::enable_shared_from_this<PeriodicTask> {
 
    private:
     std::atomic<State> state_{Pending};
-    boost::asio::deadline_timer timer_;
+    DeadlineTimerPtr timer_;
     const int periodMs_;
     CallbackType callback_{trivialCallback};
 

--- a/lib/ProducerImpl.h
+++ b/lib/ProducerImpl.h
@@ -38,6 +38,7 @@ namespace pulsar {
 class BatchMessageContainerBase;
 class ClientImpl;
 using ClientImplPtr = std::shared_ptr<ClientImpl>;
+using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
 class MessageCrypto;
 using MessageCryptoPtr = std::shared_ptr<MessageCrypto>;
 class ProducerImpl;
@@ -172,13 +173,13 @@ class ProducerImpl : public HandlerBase,
     int64_t msgSequenceGenerator_;
 
     std::unique_ptr<BatchMessageContainerBase> batchMessageContainer_;
-    boost::asio::deadline_timer batchTimer_;
+    DeadlineTimerPtr batchTimer_;
     PendingFailures batchMessageAndSend(const FlushCallback& flushCallback = nullptr);
 
     volatile int64_t lastSequenceIdPublished_;
     std::string schemaVersion_;
 
-    boost::asio::deadline_timer sendTimer_;
+    DeadlineTimerPtr sendTimer_;
     void handleSendTimeout(const boost::system::error_code& err);
     using DurationType = typename boost::asio::deadline_timer::duration_type;
     void asyncWaitSendTimeout(DurationType expiryTime);

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -25,6 +25,8 @@ cd $ROOT_DIR
 
 pushd tests
 
+./ConnectionFailTest
+
 export RETRY_FAILED="${RETRY_FAILED:-1}"
 
 if [ -f /gtest-parallel ]; then

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,3 +59,8 @@ add_executable(pulsar-tests ${TEST_SOURCES} ${PROTO_SOURCES})
 target_include_directories(pulsar-tests PRIVATE ${PROJECT_SOURCE_DIR}/lib ${AUTOGEN_DIR}/lib)
 
 target_link_libraries(pulsar-tests ${CLIENT_LIBS} pulsarStatic $<$<CONFIG:Debug>:${GMOCKD_LIBRARY_PATH}> $<$<CONFIG:Debug>:${GTESTD_LIBRARY_PATH}> $<$<NOT:$<CONFIG:Debug>>:${GMOCK_LIBRARY_PATH}> $<$<NOT:$<CONFIG:Debug>>:${GTEST_LIBRARY_PATH}>)
+
+if (UNIX)
+    add_executable(ConnectionFailTest unix/ConnectionFailTest.cc HttpHelper.cc)
+    target_link_libraries(ConnectionFailTest ${CLIENT_LIBS} pulsarStatic ${GTEST_LIBRARY_PATH})
+endif ()

--- a/tests/PeriodicTaskTest.cc
+++ b/tests/PeriodicTaskTest.cc
@@ -35,7 +35,7 @@ TEST(PeriodicTaskTest, testCountdownTask) {
 
     std::atomic_int count{5};
 
-    auto task = std::make_shared<PeriodicTask>(executor->getIOService(), 200);
+    auto task = std::make_shared<PeriodicTask>(*executor, 200);
     task->setCallback([task, &count](const PeriodicTask::ErrorCode& ec) {
         if (--count <= 0) {
             task->stop();
@@ -64,7 +64,7 @@ TEST(PeriodicTaskTest, testCountdownTask) {
 TEST(PeriodicTaskTest, testNegativePeriod) {
     auto executor = ExecutorService::create();
 
-    auto task = std::make_shared<PeriodicTask>(executor->getIOService(), -1);
+    auto task = std::make_shared<PeriodicTask>(*executor, -1);
     std::atomic_bool callbackTriggered{false};
     task->setCallback([&callbackTriggered](const PeriodicTask::ErrorCode& ec) { callbackTriggered = true; });
 

--- a/tests/unix/ConnectionFailTest.cc
+++ b/tests/unix/ConnectionFailTest.cc
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/Client.h>
+#include <sys/resource.h>
+#include <time.h>
+
+#include "../HttpHelper.h"
+
+using namespace pulsar;
+
+class ConnectionFailTest : public ::testing::TestWithParam<int> {
+   public:
+    void SetUp() override {
+        struct rlimit limit;
+        ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &limit), 0);
+        maxFdCount_ = limit.rlim_max;
+        int numPartitions = GetParam();
+        topic_ = "test-connection-fail-" + std::to_string(numPartitions) + std::to_string(time(nullptr));
+        if (numPartitions > 0) {
+            int res = makePutRequest(
+                "http://localhost:8080/admin/v2/persistent/public/default/" + topic_ + "/partitions",
+                std::to_string(numPartitions));
+            ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
+        }
+    }
+
+    void TearDown() override { client_.close(); }
+
+   protected:
+    Client client_{"pulsar://localhost:6650"};
+    std::string topic_;
+    int maxFdCount_;
+
+    void updateFdLimit(int fdLimit) {
+        struct rlimit limit;
+        limit.rlim_cur = fdLimit;
+        limit.rlim_max = maxFdCount_;
+        ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &limit), 0);
+        std::cout << "Updated fd limit to " << limit.rlim_cur << std::endl;
+    }
+};
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+TEST_P(ConnectionFailTest, test) {
+    int fdLimit = 1;
+    for (; fdLimit < 100; fdLimit++) {
+        updateFdLimit(fdLimit);
+
+        Producer producer;
+        auto result = client_.createProducer(topic_, producer);
+        ASSERT_TRUE(result == ResultOk || result == ResultConnectError);
+        if (result == ResultConnectError) {
+            continue;
+        }
+
+        Consumer consumer;
+        result = client_.subscribe(topic_, "sub", consumer);
+        ASSERT_TRUE(result == ResultOk || result == ResultConnectError);
+        if (result == ResultConnectError) {
+            continue;
+        }
+
+        Reader reader;
+        result = client_.createReader(topic_, MessageId::earliest(), {}, reader);
+        ASSERT_TRUE(result == ResultOk || result == ResultConnectError);
+        if (result == ResultOk) {
+            break;
+        }
+    }
+    std::cout << "Create producer, consumer and reader successfully when fdLimit is " << fdLimit << std::endl;
+    ASSERT_TRUE(fdLimit < 100);
+}
+
+INSTANTIATE_TEST_SUITE_P(Unix, ConnectionFailTest, ::testing::Values(0, 5));


### PR DESCRIPTION
Fixes #202

### Motivation

When a `deadline_timer` is constructed, `boost::system::system_error` would be thrown if the fd limit is reached. In this case, the following APIs would fail with exception instead of returning a `Result`:
- `createProducer`
- `subscribe`
- `createReader`

P.S. This behavior is not documented in Boost's documents.

Generally, we should not allow exceptions being thrown from those APIs because we return a `Result` to indicate the error. In addition, these exceptions cannot be caught by the wrapper of other languages.

There is a similar issue: https://github.com/apache/pulsar/issues/14582. However, https://github.com/apache/pulsar/pull/14587 only fixes the case when creating a `socket`. The exception from the constructor of `deadline_timer` is not processed.

### Modifications

Handle the exceptions when creating a socket or timer from `ExecutorService` to restart this executor, then propagate a `std::runtime_error`. Don't allow creating a timer directly from `io_service` so that exceptions can be handled well.

In addition, catch the `runtime_error` when:
- Creating a producer (`ProducerImpl` and `PartitionedProducerImpl`)
- Creating a consumer (`ConsumerImpl` and `MultiTopicsConsumerImpl`)
- Creating a reader (`ReaderImpl`)

because the constructors of them all create at least one timer.

### Verifications

Add `tests/unix/ConnectionFailTest.cc` for Unix systems because `setrlimit` is a POSIX API. It covers the cases when the fd limit is not enough to create a producer, a consumer and a reader.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
