### PR TITLE
[improve] Refactor client version format

### DIFF
--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -266,7 +266,7 @@ SharedBuffer Commands::newConnect(const AuthenticationPtr& authentication, const
     BaseCommand cmd;
     cmd.set_type(BaseCommand::CONNECT);
     CommandConnect* connect = cmd.mutable_connect();
-    connect->set_client_version(PULSAR_VERSION_STR);
+    connect->set_client_version(std::string("Pulsar-C++-v") + PULSAR_VERSION_STR);
     connect->set_auth_method_name(authentication->getAuthMethodName());
     connect->set_protocol_version(ProtocolVersion_MAX);
 
@@ -294,7 +294,7 @@ SharedBuffer Commands::newAuthResponse(const AuthenticationPtr& authentication, 
     BaseCommand cmd;
     cmd.set_type(BaseCommand::AUTH_RESPONSE);
     CommandAuthResponse* authResponse = cmd.mutable_authresponse();
-    authResponse->set_client_version(PULSAR_VERSION_STR);
+    authResponse->set_client_version(std::string("Pulsar-C++-v") + PULSAR_VERSION_STR);
 
     AuthData* authData = authResponse->mutable_response();
     authData->set_auth_method_name(authentication->getAuthMethodName());

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -294,7 +294,7 @@ SharedBuffer Commands::newAuthResponse(const AuthenticationPtr& authentication, 
     BaseCommand cmd;
     cmd.set_type(BaseCommand::AUTH_RESPONSE);
     CommandAuthResponse* authResponse = cmd.mutable_authresponse();
-    authResponse->set_client_version(std::string("Pulsar-C++-v") + PULSAR_VERSION_STR);
+    authResponse->set_client_version(std::string("Pulsar-CPP-v") + PULSAR_VERSION_STR);
 
     AuthData* authData = authResponse->mutable_response();
     authData->set_auth_method_name(authentication->getAuthMethodName());

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -266,7 +266,7 @@ SharedBuffer Commands::newConnect(const AuthenticationPtr& authentication, const
     BaseCommand cmd;
     cmd.set_type(BaseCommand::CONNECT);
     CommandConnect* connect = cmd.mutable_connect();
-    connect->set_client_version(std::string("Pulsar-C++-v") + PULSAR_VERSION_STR);
+    connect->set_client_version(std::string("Pulsar-CPP-v") + PULSAR_VERSION_STR);
     connect->set_auth_method_name(authentication->getAuthMethodName());
     connect->set_protocol_version(ProtocolVersion_MAX);
 

--- a/tests/ClientTest.cc
+++ b/tests/ClientTest.cc
@@ -313,7 +313,7 @@ TEST(ClientTest, testCloseClient) {
 
 TEST(ClientTest, testClientVersion) {
     const std::string topic = "testClientVersion" + std::to_string(time(nullptr));
-    const std::string expectedVersion = std::string("Pulsar-C++-v") + PULSAR_VERSION_STR;
+    const std::string expectedVersion = std::string("Pulsar-CPP-v") + PULSAR_VERSION_STR;
 
     Client client(lookupUrl);
 

--- a/tests/ClientTest.cc
+++ b/tests/ClientTest.cc
@@ -18,6 +18,7 @@
  */
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
+#include <pulsar/Version.h>
 
 #include <chrono>
 #include <future>
@@ -34,6 +35,7 @@ DECLARE_LOG_OBJECT()
 using namespace pulsar;
 
 static std::string lookupUrl = "pulsar://localhost:6650";
+static std::string adminUrl = "http://localhost:8080/";
 
 TEST(ClientTest, testChecksumComputation) {
     std::string data = "test";
@@ -307,4 +309,35 @@ TEST(ClientTest, testCloseClient) {
         }
         client.close();
     }
+}
+
+TEST(ClientTest, testClientVersion) {
+    const std::string topic = "testClientVersion" + std::to_string(time(nullptr));
+    const std::string expectedVersion = std::string("Pulsar-C++-v") + PULSAR_VERSION_STR;
+
+    Client client(lookupUrl);
+
+    std::string responseData;
+
+    Producer producer;
+    Result result = client.createProducer(topic, producer);
+    ASSERT_EQ(ResultOk, result);
+    int res =
+        makeGetRequest(adminUrl + "admin/v2/persistent/public/default/" + topic + "/stats", responseData);
+    ASSERT_TRUE(res == 200) << "res: " << res;
+
+    ASSERT_TRUE(responseData.find(expectedVersion) != std::string::npos);
+    producer.close();
+
+    responseData.clear();
+    Consumer consumer;
+    result = client.subscribe(topic, "consumer-1", consumer);
+    ASSERT_EQ(ResultOk, result);
+    res = makeGetRequest(adminUrl + "admin/v2/persistent/public/default/" + topic + "/stats", responseData);
+    ASSERT_TRUE(res == 200) << "res: " << res;
+
+    ASSERT_TRUE(responseData.find(expectedVersion) != std::string::npos);
+    consumer.close();
+
+    client.close();
 }

--- a/tests/HttpHelper.h
+++ b/tests/HttpHelper.h
@@ -24,5 +24,6 @@
 int makePutRequest(const std::string& url, const std::string& body);
 int makePostRequest(const std::string& url, const std::string& body);
 int makeDeleteRequest(const std::string& url);
+int makeGetRequest(const std::string& url, const std::string& responseData);
 
 #endif /* end of include guard: HTTP_HELPER */


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

Currently,  the `client_version ` only shows the version information. And clients in different languages use their own separate version numbers. This can lead to conflict. For example, the java client 2.10.2 uses the same value `2.10.2` as the C++ client 2.10.2. And C++ client 3.0.0 may conflict with the future java client 3.0.0. The information of `client_version` is incomplete. We could not determine what language(or specific library) the client uses. This raises inconvenience for debugging.

This PR adopts a new client version format for the C++ client.

Please see the discussion: https://lists.apache.org/thread/n59k537fhthjnzkfxtc2p4zk4l0cv3mp
### Modifications
* Change the client version value to `Pulsar-C++-vXXX`

<!-- Describe the modifications you've done. -->

### Verifying this change

This change added tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
