### PR TITLE
[feat] Support pattern subscribe non-persistent topic.

### DIFF
--- a/include/pulsar/ConsumerConfiguration.h
+++ b/include/pulsar/ConsumerConfiguration.h
@@ -27,6 +27,7 @@
 #include <pulsar/InitialPosition.h>
 #include <pulsar/KeySharedPolicy.h>
 #include <pulsar/Message.h>
+#include <pulsar/RegexSubscriptionMode.h>
 #include <pulsar/Result.h>
 #include <pulsar/Schema.h>
 #include <pulsar/TypedMessage.h>
@@ -382,6 +383,19 @@ class PULSAR_PUBLIC ConsumerConfiguration {
      * @return the time duration for the PatternMultiTopicsConsumer performs a pattern auto discovery
      */
     int getPatternAutoDiscoveryPeriod() const;
+
+    /**
+     * Determines which topics this consumer should be subscribed to - Persistent, Non-Persistent, or
+     * AllTopics. Only used with pattern subscriptions.
+     *
+     * @param regexSubscriptionMode The default value is `PersistentOnly`.
+     */
+    ConsumerConfiguration& setRegexSubscriptionMode(RegexSubscriptionMode regexSubscriptionMode);
+
+    /**
+     * @return the regex subscription mode for the pattern consumer.
+     */
+    RegexSubscriptionMode getRegexSubscriptionMode() const;
 
     /**
      * The default value is `InitialPositionLatest`.

--- a/include/pulsar/RegexSubscriptionMode.h
+++ b/include/pulsar/RegexSubscriptionMode.h
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef PULSAR_CPP_REGEX_SUB_MODE_H
+#define PULSAR_CPP_REGEX_SUB_MODE_H
+
+namespace pulsar {
+enum RegexSubscriptionMode
+{
+    /**
+     * Only subscribe to persistent topics.
+     */
+    PersistentOnly = 0,
+
+    /**
+     * Only subscribe to non-persistent topics.
+     */
+    NonPersistentOnly = 1,
+
+    /**
+     * Subscribe to both persistent and non-persistent topics.
+     */
+    AllTopics = 2
+};
+}
+
+#endif  // PULSAR_CPP_REGEX_SUB_MODE_H

--- a/lib/BinaryProtoLookupService.h
+++ b/lib/BinaryProtoLookupService.h
@@ -49,7 +49,9 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
 
     Future<Result, LookupDataResultPtr> getPartitionMetadataAsync(const TopicNamePtr& topicName) override;
 
-    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) override;
+    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(
+        const NamespaceNamePtr& nsName,
+        CommandGetTopicsOfNamespace_Mode mode = CommandGetTopicsOfNamespace_Mode_PERSISTENT) override;
 
     Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override;
 
@@ -75,8 +77,8 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
                                        const ClientConnectionWeakPtr& clientCnx,
                                        LookupDataResultPromisePtr promise);
 
-    void sendGetTopicsOfNamespaceRequest(const std::string& nsName, Result result,
-                                         const ClientConnectionWeakPtr& clientCnx,
+    void sendGetTopicsOfNamespaceRequest(const std::string& nsName, CommandGetTopicsOfNamespace_Mode mode,
+                                         Result result, const ClientConnectionWeakPtr& clientCnx,
                                          NamespaceTopicsPromisePtr promise);
 
     void sendGetSchemaRequest(const std::string& topiName, Result result,

--- a/lib/BinaryProtoLookupService.h
+++ b/lib/BinaryProtoLookupService.h
@@ -50,8 +50,7 @@ class PULSAR_PUBLIC BinaryProtoLookupService : public LookupService {
     Future<Result, LookupDataResultPtr> getPartitionMetadataAsync(const TopicNamePtr& topicName) override;
 
     Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(
-        const NamespaceNamePtr& nsName,
-        CommandGetTopicsOfNamespace_Mode mode = CommandGetTopicsOfNamespace_Mode_PERSISTENT) override;
+        const NamespaceNamePtr& nsName, CommandGetTopicsOfNamespace_Mode mode) override;
 
     Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override;
 

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -1293,8 +1293,8 @@ Future<Result, GetLastMessageIdResponse> ClientConnection::newGetLastMessageId(u
     return promise.getFuture();
 }
 
-Future<Result, NamespaceTopicsPtr> ClientConnection::newGetTopicsOfNamespace(const std::string& nsName,
-                                                                             uint64_t requestId) {
+Future<Result, NamespaceTopicsPtr> ClientConnection::newGetTopicsOfNamespace(
+    const std::string& nsName, CommandGetTopicsOfNamespace_Mode mode, uint64_t requestId) {
     Lock lock(mutex_);
     Promise<Result, NamespaceTopicsPtr> promise;
     if (isClosed()) {
@@ -1306,7 +1306,7 @@ Future<Result, NamespaceTopicsPtr> ClientConnection::newGetTopicsOfNamespace(con
 
     pendingGetNamespaceTopicsRequests_.insert(std::make_pair(requestId, promise));
     lock.unlock();
-    sendCommand(Commands::newGetTopicsOfNamespace(nsName, requestId));
+    sendCommand(Commands::newGetTopicsOfNamespace(nsName, mode, requestId));
     return promise.getFuture();
 }
 

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -181,7 +181,9 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     Future<Result, GetLastMessageIdResponse> newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
 
-    Future<Result, NamespaceTopicsPtr> newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId);
+    Future<Result, NamespaceTopicsPtr> newGetTopicsOfNamespace(const std::string& nsName,
+                                                               CommandGetTopicsOfNamespace_Mode mode,
+                                                               uint64_t requestId);
 
     Future<Result, boost::optional<SchemaInfo>> newGetSchema(const std::string& topicName,
                                                              uint64_t requestId);

--- a/lib/ClientImpl.h
+++ b/lib/ClientImpl.h
@@ -28,6 +28,7 @@
 #include "Future.h"
 #include "LookupDataResult.h"
 #include "MemoryLimitController.h"
+#include "ProtoApiEnums.h"
 #include "ServiceNameResolver.h"
 #include "SynchronizedHashMap.h"
 
@@ -151,8 +152,10 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
     void handleClose(Result result, SharedInt remaining, ResultCallback callback);
 
     void createPatternMultiTopicsConsumer(const Result result, const NamespaceTopicsPtr topics,
-                                          const std::string& regexPattern, const std::string& consumerName,
-                                          const ConsumerConfiguration& conf, SubscribeCallback callback);
+                                          const std::string& regexPattern,
+                                          CommandGetTopicsOfNamespace_Mode mode,
+                                          const std::string& consumerName, const ConsumerConfiguration& conf,
+                                          SubscribeCallback callback);
 
     enum State
     {

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -609,12 +609,14 @@ SharedBuffer Commands::newGetLastMessageId(uint64_t consumerId, uint64_t request
     return buffer;
 }
 
-SharedBuffer Commands::newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId) {
+SharedBuffer Commands::newGetTopicsOfNamespace(const std::string& nsName,
+                                               CommandGetTopicsOfNamespace_Mode mode, uint64_t requestId) {
     BaseCommand cmd;
     cmd.set_type(BaseCommand::GET_TOPICS_OF_NAMESPACE);
     CommandGetTopicsOfNamespace* getTopics = cmd.mutable_gettopicsofnamespace();
     getTopics->set_request_id(requestId);
     getTopics->set_namespace_(nsName);
+    getTopics->set_mode(static_cast<proto::CommandGetTopicsOfNamespace_Mode>(mode));
 
     const SharedBuffer buffer = writeMessageWithSize(cmd);
     cmd.clear_gettopicsofnamespace();

--- a/lib/Commands.h
+++ b/lib/Commands.h
@@ -156,7 +156,8 @@ class Commands {
     static SharedBuffer newSeek(uint64_t consumerId, uint64_t requestId, const MessageId& messageId);
     static SharedBuffer newSeek(uint64_t consumerId, uint64_t requestId, uint64_t timestamp);
     static SharedBuffer newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
-    static SharedBuffer newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId);
+    static SharedBuffer newGetTopicsOfNamespace(const std::string& nsName,
+                                                CommandGetTopicsOfNamespace_Mode mode, uint64_t requestId);
 
     static bool peerSupportsGetLastMessageId(int32_t peerVersion);
     static bool peerSupportsActiveConsumerListener(int32_t peerVersion);

--- a/lib/ConsumerConfiguration.cc
+++ b/lib/ConsumerConfiguration.cc
@@ -317,4 +317,14 @@ ConsumerConfiguration& ConsumerConfiguration::setAckReceiptEnabled(bool ackRecei
 
 bool ConsumerConfiguration::isAckReceiptEnabled() const { return impl_->ackReceiptEnabled; }
 
+ConsumerConfiguration& ConsumerConfiguration::setRegexSubscriptionMode(
+    RegexSubscriptionMode regexSubscriptionMode) {
+    impl_->regexSubscriptionMode = regexSubscriptionMode;
+    return *this;
+}
+
+RegexSubscriptionMode ConsumerConfiguration::getRegexSubscriptionMode() const {
+    return impl_->regexSubscriptionMode;
+}
+
 }  // namespace pulsar

--- a/lib/ConsumerConfigurationImpl.h
+++ b/lib/ConsumerConfigurationImpl.h
@@ -48,6 +48,8 @@ struct ConsumerConfigurationImpl {
     BatchReceivePolicy batchReceivePolicy{};
     DeadLetterPolicy deadLetterPolicy;
     int patternAutoDiscoveryPeriod{60};
+    RegexSubscriptionMode regexSubscriptionMode{RegexSubscriptionMode::PersistentOnly};
+
     bool replicateSubscriptionStateEnabled{false};
     std::map<std::string, std::string> properties;
     std::map<std::string, std::string> subscriptionProperties;

--- a/lib/HTTPLookupService.h
+++ b/lib/HTTPLookupService.h
@@ -79,7 +79,9 @@ class HTTPLookupService : public LookupService, public std::enable_shared_from_t
 
     Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override;
 
-    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) override;
+    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(
+        const NamespaceNamePtr& nsName,
+        CommandGetTopicsOfNamespace_Mode mode = CommandGetTopicsOfNamespace_Mode_PERSISTENT) override;
 };
 }  // namespace pulsar
 

--- a/lib/HTTPLookupService.h
+++ b/lib/HTTPLookupService.h
@@ -80,8 +80,7 @@ class HTTPLookupService : public LookupService, public std::enable_shared_from_t
     Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override;
 
     Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(
-        const NamespaceNamePtr& nsName,
-        CommandGetTopicsOfNamespace_Mode mode = CommandGetTopicsOfNamespace_Mode_PERSISTENT) override;
+        const NamespaceNamePtr& nsName, CommandGetTopicsOfNamespace_Mode mode) override;
 };
 }  // namespace pulsar
 

--- a/lib/LookupService.h
+++ b/lib/LookupService.h
@@ -29,6 +29,7 @@
 
 #include "Future.h"
 #include "LookupDataResult.h"
+#include "ProtoApiEnums.h"
 
 namespace pulsar {
 using NamespaceTopicsPtr = std::shared_ptr<std::vector<std::string>>;
@@ -72,7 +73,9 @@ class LookupService {
      *
      * Returns all the topics name for a given namespace.
      */
-    virtual Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) = 0;
+    virtual Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(
+        const NamespaceNamePtr& nsName,
+        CommandGetTopicsOfNamespace_Mode mode = CommandGetTopicsOfNamespace_Mode_PERSISTENT) = 0;
 
     /**
      * returns current SchemaInfo {@link SchemaInfo} for a given topic.

--- a/lib/LookupService.h
+++ b/lib/LookupService.h
@@ -74,8 +74,7 @@ class LookupService {
      * Returns all the topics name for a given namespace.
      */
     virtual Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(
-        const NamespaceNamePtr& nsName,
-        CommandGetTopicsOfNamespace_Mode mode = CommandGetTopicsOfNamespace_Mode_PERSISTENT) = 0;
+        const NamespaceNamePtr& nsName, CommandGetTopicsOfNamespace_Mode mode) = 0;
 
     /**
      * returns current SchemaInfo {@link SchemaInfo} for a given topic.

--- a/lib/MultiTopicsConsumerImpl.h
+++ b/lib/MultiTopicsConsumerImpl.h
@@ -180,6 +180,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
     FRIEND_TEST(ConsumerTest, testMultiTopicsConsumerUnAckedMessageRedelivery);
     FRIEND_TEST(ConsumerTest, testPartitionedConsumerUnAckedMessageRedelivery);
     FRIEND_TEST(ConsumerTest, testAcknowledgeCumulativeWithPartition);
+    FRIEND_TEST(ConsumerTest, testPatternSubscribeTopic);
 };
 
 typedef std::shared_ptr<MultiTopicsConsumerImpl> MultiTopicsConsumerImplPtr;

--- a/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/lib/PatternMultiTopicsConsumerImpl.cc
@@ -28,13 +28,15 @@ DECLARE_LOG_OBJECT()
 using namespace pulsar;
 
 PatternMultiTopicsConsumerImpl::PatternMultiTopicsConsumerImpl(
-    ClientImplPtr client, const std::string pattern, const std::vector<std::string>& topics,
-    const std::string& subscriptionName, const ConsumerConfiguration& conf,
-    const LookupServicePtr lookupServicePtr_, const ConsumerInterceptorsPtr interceptors)
+    ClientImplPtr client, const std::string pattern, CommandGetTopicsOfNamespace_Mode getTopicsMode,
+    const std::vector<std::string>& topics, const std::string& subscriptionName,
+    const ConsumerConfiguration& conf, const LookupServicePtr lookupServicePtr_,
+    const ConsumerInterceptorsPtr interceptors)
     : MultiTopicsConsumerImpl(client, topics, subscriptionName, TopicName::get(pattern), conf,
                               lookupServicePtr_, interceptors),
       patternString_(pattern),
-      pattern_(PULSAR_REGEX_NAMESPACE::regex(pattern)),
+      pattern_(PULSAR_REGEX_NAMESPACE::regex(TopicName::removeDomain(pattern))),
+      getTopicsMode_(getTopicsMode),
       autoDiscoveryTimer_(client->getIOExecutorProvider()->get()->createDeadlineTimer()),
       autoDiscoveryRunning_(false) {
     namespaceName_ = TopicName::get(pattern)->getNamespaceName();
@@ -75,7 +77,7 @@ void PatternMultiTopicsConsumerImpl::autoDiscoveryTimerTask(const boost::system:
     // already get namespace from pattern.
     assert(namespaceName_);
 
-    lookupServicePtr_->getTopicsOfNamespaceAsync(namespaceName_)
+    lookupServicePtr_->getTopicsOfNamespaceAsync(namespaceName_, getTopicsMode_)
         .addListener(std::bind(&PatternMultiTopicsConsumerImpl::timerGetTopicsOfNamespace, this,
                                std::placeholders::_1, std::placeholders::_2));
 }
@@ -193,10 +195,10 @@ void PatternMultiTopicsConsumerImpl::onTopicsRemoved(NamespaceTopicsPtr removedT
 NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsPatternFilter(
     const std::vector<std::string>& topics, const PULSAR_REGEX_NAMESPACE::regex& pattern) {
     NamespaceTopicsPtr topicsResultPtr = std::make_shared<std::vector<std::string>>();
-
-    for (std::vector<std::string>::const_iterator itr = topics.begin(); itr != topics.end(); itr++) {
-        if (PULSAR_REGEX_NAMESPACE::regex_match(*itr, pattern)) {
-            topicsResultPtr->push_back(*itr);
+    for (const auto& it : topics) {
+        auto topic = TopicName::removeDomain(it);
+        if (PULSAR_REGEX_NAMESPACE::regex_match(topic, pattern)) {
+            topicsResultPtr->push_back(std::move(it));
         }
     }
     return topicsResultPtr;

--- a/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/lib/PatternMultiTopicsConsumerImpl.cc
@@ -195,10 +195,10 @@ void PatternMultiTopicsConsumerImpl::onTopicsRemoved(NamespaceTopicsPtr removedT
 NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsPatternFilter(
     const std::vector<std::string>& topics, const PULSAR_REGEX_NAMESPACE::regex& pattern) {
     NamespaceTopicsPtr topicsResultPtr = std::make_shared<std::vector<std::string>>();
-    for (const auto& it : topics) {
-        auto topic = TopicName::removeDomain(it);
+    for (const auto& topicStr : topics) {
+        auto topic = TopicName::removeDomain(topicStr);
         if (PULSAR_REGEX_NAMESPACE::regex_match(topic, pattern)) {
-            topicsResultPtr->push_back(std::move(it));
+            topicsResultPtr->push_back(std::move(topicStr));
         }
     }
     return topicsResultPtr;

--- a/lib/PatternMultiTopicsConsumerImpl.h
+++ b/lib/PatternMultiTopicsConsumerImpl.h
@@ -48,6 +48,7 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
     // when subscribe, client will first get all topics that match given pattern.
     // `topics` contains the topics that match `patternString`.
     PatternMultiTopicsConsumerImpl(ClientImplPtr client, const std::string patternString,
+                                   CommandGetTopicsOfNamespace_Mode getTopicsMode,
                                    const std::vector<std::string>& topics,
                                    const std::string& subscriptionName, const ConsumerConfiguration& conf,
                                    const LookupServicePtr lookupServicePtr_,
@@ -57,7 +58,7 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
 
     void autoDiscoveryTimerTask(const boost::system::error_code& err);
 
-    // filter input `topics` with given `pattern`, return matched topics
+    // filter input `topics` with given `pattern`, return matched topics. Do not match topic domain.
     static NamespaceTopicsPtr topicsPatternFilter(const std::vector<std::string>& topics,
                                                   const PULSAR_REGEX_NAMESPACE::regex& pattern);
 
@@ -72,6 +73,7 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
    private:
     const std::string patternString_;
     const PULSAR_REGEX_NAMESPACE::regex pattern_;
+    const CommandGetTopicsOfNamespace_Mode getTopicsMode_;
     typedef std::shared_ptr<boost::asio::deadline_timer> TimerPtr;
     TimerPtr autoDiscoveryTimer_;
     bool autoDiscoveryRunning_;

--- a/lib/ProtoApiEnums.h
+++ b/lib/ProtoApiEnums.h
@@ -49,6 +49,11 @@ constexpr int CommandSubscribe_SubType_Shared = 1;
 constexpr int CommandSubscribe_SubType_Failover = 2;
 constexpr int CommandSubscribe_SubType_Key_Shared = 3;
 
+using CommandGetTopicsOfNamespace_Mode = int;
+constexpr int CommandGetTopicsOfNamespace_Mode_PERSISTENT = 0;
+constexpr int CommandGetTopicsOfNamespace_Mode_NON_PERSISTENT = 1;
+constexpr int CommandGetTopicsOfNamespace_Mode_ALL = 2;
+
 using CommandAck_ValidationError = int;
 constexpr CommandAck_ValidationError CommandAck_ValidationError_UncompressedSizeCorruption = 0;
 constexpr CommandAck_ValidationError CommandAck_ValidationError_DecompressionError = 1;

--- a/lib/RetryableLookupService.h
+++ b/lib/RetryableLookupService.h
@@ -60,10 +60,12 @@ class RetryableLookupService : public LookupService,
             [this, topicName] { return lookupService_->getPartitionMetadataAsync(topicName); });
     }
 
-    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) override {
+    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(
+        const NamespaceNamePtr& nsName,
+        CommandGetTopicsOfNamespace_Mode mode = CommandGetTopicsOfNamespace_Mode_PERSISTENT) override {
         return executeAsync<NamespaceTopicsPtr>(
             "get-topics-of-namespace-" + nsName->toString(),
-            [this, nsName] { return lookupService_->getTopicsOfNamespaceAsync(nsName); });
+            [this, nsName, mode] { return lookupService_->getTopicsOfNamespaceAsync(nsName, mode); });
     }
 
     Future<Result, boost::optional<SchemaInfo>> getSchema(const TopicNamePtr& topicName) override {

--- a/lib/RetryableLookupService.h
+++ b/lib/RetryableLookupService.h
@@ -61,8 +61,7 @@ class RetryableLookupService : public LookupService,
     }
 
     Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(
-        const NamespaceNamePtr& nsName,
-        CommandGetTopicsOfNamespace_Mode mode = CommandGetTopicsOfNamespace_Mode_PERSISTENT) override {
+        const NamespaceNamePtr& nsName, CommandGetTopicsOfNamespace_Mode mode) override {
         return executeAsync<NamespaceTopicsPtr>(
             "get-topics-of-namespace-" + nsName->toString(),
             [this, nsName, mode] { return lookupService_->getTopicsOfNamespaceAsync(nsName, mode); });

--- a/lib/TopicName.cc
+++ b/lib/TopicName.cc
@@ -256,4 +256,16 @@ int TopicName::getPartitionIndex(const std::string& topic) {
 
 NamespaceNamePtr TopicName::getNamespaceName() { return namespaceName_; }
 
+std::string TopicName::removeDomain(const std::string& topicName) {
+    auto index = topicName.find("://");
+    if (index != std::string::npos) {
+        return topicName.substr(index + 3, topicName.length());
+    }
+    return topicName;
+}
+
+bool TopicName::containsDomain(const std::string& topicName) {
+    return topicName.find("://") != std::string::npos;
+}
+
 }  // namespace pulsar

--- a/lib/TopicName.h
+++ b/lib/TopicName.h
@@ -67,6 +67,8 @@ class PULSAR_PUBLIC TopicName : public ServiceUnitId {
     static std::shared_ptr<TopicName> get(const std::string& topicName);
     bool operator==(const TopicName& other);
     static std::string getEncodedName(const std::string& nameBeforeEncoding);
+    static std::string removeDomain(const std::string& topicName);
+    static bool containsDomain(const std::string& topicName);
     std::string getTopicPartitionName(unsigned int partition) const;
     static int getPartitionIndex(const std::string& topic);
 

--- a/test-conf/standalone-ssl.conf
+++ b/test-conf/standalone-ssl.conf
@@ -19,6 +19,10 @@
 
 ### --- General broker settings --- ###
 
+# Disable system topic
+systemTopicEnabled=false
+topicLevelPoliciesEnabled=false
+
 # Zookeeper quorum connection string
 zookeeperServers=
 

--- a/tests/LookupServiceTest.cc
+++ b/tests/LookupServiceTest.cc
@@ -101,8 +101,10 @@ static void testMultiAddresses(LookupService& lookupService) {
     results.clear();
     for (int i = 0; i < numRequests; i++) {
         NamespaceTopicsPtr data;
-        const auto result =
-            lookupService.getTopicsOfNamespaceAsync(TopicName::get("topic")->getNamespaceName()).get(data);
+        const auto result = lookupService
+                                .getTopicsOfNamespaceAsync(TopicName::get("topic")->getNamespaceName(),
+                                                           CommandGetTopicsOfNamespace_Mode_PERSISTENT)
+                                .get(data);
         LOG_INFO("getTopicsOfNamespaceAsync [" << i << "] " << result);
         results.emplace_back(result);
     }
@@ -147,7 +149,8 @@ TEST(LookupServiceTest, testRetry) {
     LOG_INFO("getPartitionMetadataAsync returns " << lookupDataResultPtr->getPartitions() << " partitions");
 
     PulsarFriend::setServiceUrlIndex(serviceNameResolver, 0);
-    auto future3 = lookupService->getTopicsOfNamespaceAsync(topicNamePtr->getNamespaceName());
+    auto future3 = lookupService->getTopicsOfNamespaceAsync(topicNamePtr->getNamespaceName(),
+                                                            CommandGetTopicsOfNamespace_Mode_PERSISTENT);
     NamespaceTopicsPtr namespaceTopicsPtr;
     ASSERT_EQ(ResultOk, future3.get(namespaceTopicsPtr));
     LOG_INFO("getTopicPartitionName Async returns " << namespaceTopicsPtr->size() << " topics");
@@ -208,7 +211,8 @@ TEST(LookupServiceTest, testTimeout) {
     afterMethod("getPartitionMetadataAsync");
 
     beforeMethod();
-    auto future3 = lookupService->getTopicsOfNamespaceAsync(topicNamePtr->getNamespaceName());
+    auto future3 = lookupService->getTopicsOfNamespaceAsync(topicNamePtr->getNamespaceName(),
+                                                            CommandGetTopicsOfNamespace_Mode_PERSISTENT);
     NamespaceTopicsPtr namespaceTopicsPtr;
     ASSERT_EQ(ResultTimeout, future3.get(namespaceTopicsPtr));
     afterMethod("getTopicsOfNamespaceAsync");

--- a/tests/TopicNameTest.cc
+++ b/tests/TopicNameTest.cc
@@ -191,3 +191,20 @@ TEST(TopicNameTest, testPartitionIndex) {
         ASSERT_EQ(topicName->getPartitionIndex(), partition);
     }
 }
+
+TEST(TopicNameTest, testRemoveDomain) {
+    auto topicName1 = "persistent://public/default/test-topic";
+    ASSERT_EQ("public/default/test-topic", TopicName::removeDomain(topicName1));
+
+    auto topicName2 = "non-persistent://public/default/test-topic";
+    ASSERT_EQ("public/default/test-topic", TopicName::removeDomain(topicName2));
+
+    auto topicName3 = "public/default/test-topic";
+    ASSERT_EQ(topicName3, TopicName::removeDomain(topicName2));
+}
+
+TEST(TopicNameTest, testContainsDomain) {
+    ASSERT_TRUE(TopicName::containsDomain("persistent://public/default/test-topic"));
+    ASSERT_TRUE(TopicName::containsDomain("non-persistent://public/default/test-topic"));
+    ASSERT_FALSE(TopicName::containsDomain("public/default/test-topic"));
+}


### PR DESCRIPTION
Master Issue: #204 

### Motivation

The current default only lookup persistent topics on the namespace, We need to add `RegexSubscriptionMode` to control the lookup topics type.

The Java client relate impl refer: https://github.com/apache/pulsar/pull/2025

### Modifications
- Add `RegexSubscriptionMode` to support pattern subscribe `all/persistent only/non-persistent-only` topic.
- Disable system topic. 

### Verifying this change
- `TopicNameTest.testRemoveDomain` to cover the newly added `TopicName::removeDomain` method.
- `TopicNameTest.testContainsDomain` to cover the newly added `TopicName::containsDomain` method.
- Refactor `LookupServiceTest.basicGetNamespaceTopics` method to cover more get topics cases.
- `ConsumerTest.testPatternSubscribeTopic` to cover use pattern subscribe to `persistent topic`, `non-persistent topic`, and `all topic`.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
