### PR TITLE
Fix event loop thread might exit unexpectedly

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -96,6 +96,9 @@ jobs:
       - name: Start Pulsar service
         run: ./pulsar-test-service-start.sh
 
+      - name: Run ConnectionFailTest
+        run: ./tests/ConnectionFailTest --gtest_repeat=20
+
       - name: Run unit tests
         run: RETRY_FAILED=3 ./run-unit-tests.sh
 

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -25,8 +25,6 @@ cd $ROOT_DIR
 
 pushd tests
 
-./ConnectionFailTest
-
 export RETRY_FAILED="${RETRY_FAILED:-1}"
 
 if [ -f /gtest-parallel ]; then


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/209

### Motivation

When the event loop thread is started from `ExecutorService::restart`, there is a chance that `io_service_.run(ec)` returns immediately. In this case, the `ClientConnection::resolver_` that was registered in the IO service could block forever in `async_resolve` method.

### Modifications

In the event loop thread, if the `io_service::run` method is not stopped by `ExecutorService::close`, just call `restart` and `run` again to avoid the event loop thread exits unexpectedly.

Run the `ConnectionFailTest` independently with `--gtest_repeat=20` to avoid it's still flaky.