### PR TITLE
[feat] Add `onNegativeAcksSend` to the consumer interceptor

### DIFF
--- a/include/pulsar/ConsumerInterceptor.h
+++ b/include/pulsar/ConsumerInterceptor.h
@@ -24,6 +24,8 @@
 #include <pulsar/Result.h>
 #include <pulsar/defines.h>
 
+#include <set>
+
 namespace pulsar {
 
 class Consumer;
@@ -101,6 +103,16 @@ class PULSAR_PUBLIC ConsumerInterceptor {
      */
     virtual void onAcknowledgeCumulative(const Consumer& consumer, Result result,
                                          const MessageId& messageID) = 0;
+
+    /**
+     * This method will be called when a redelivery from a negative acknowledge occurs.
+     *
+     * <p>Any exception thrown by this method will be ignored by the caller.
+     *
+     * @param consumer the consumer which contains the interceptor
+     * @param messageIds the set of message ids to negative ack
+     */
+    virtual void onNegativeAcksSend(const Consumer& consumer, const std::set<MessageId>& messageIds) = 0;
 };
 
 typedef std::shared_ptr<ConsumerInterceptor> ConsumerInterceptorPtr;

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -199,6 +199,10 @@ void ConsumerImpl::start() {
 
 void ConsumerImpl::beforeConnectionChange(ClientConnection& cnx) { cnx.removeConsumer(consumerId_); }
 
+void ConsumerImpl::onNegativeAcksSend(const std::set<MessageId>& messageIds) {
+    interceptors_->onNegativeAcksSend(Consumer(shared_from_this()), messageIds);
+}
+
 void ConsumerImpl::connectionOpened(const ClientConnectionPtr& cnx) {
     if (state_ == Closed) {
         LOG_DEBUG(getName() << "connectionOpened : Consumer is already closed");

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -136,6 +136,7 @@ class ConsumerImpl : public ConsumerImplBase {
 
     virtual bool isReadCompacted();
     void beforeConnectionChange(ClientConnection& cnx) override;
+    void onNegativeAcksSend(const std::set<MessageId>& messageIds);
 
    protected:
     // overrided methods from HandlerBase

--- a/lib/ConsumerInterceptors.cc
+++ b/lib/ConsumerInterceptors.cc
@@ -64,6 +64,18 @@ void ConsumerInterceptors::onAcknowledgeCumulative(const Consumer &consumer, Res
     }
 }
 
+void ConsumerInterceptors::onNegativeAcksSend(const Consumer &consumer,
+                                              const std::set<MessageId> &messageIds) const {
+    for (const ConsumerInterceptorPtr &interceptor : interceptors_) {
+        try {
+            interceptor->onNegativeAcksSend(consumer, messageIds);
+        } catch (const std::exception &e) {
+            LOG_WARN("Error executing interceptor onNegativeAcksSend callback for topic: "
+                     << consumer.getTopic() << ", exception: " << e.what());
+        }
+    }
+}
+
 void ConsumerInterceptors::close() {
     State state = Ready;
     if (!state_.compare_exchange_strong(state, Closing)) {

--- a/lib/ConsumerInterceptors.h
+++ b/lib/ConsumerInterceptors.h
@@ -22,6 +22,7 @@
 #include <pulsar/ConsumerInterceptor.h>
 
 #include <atomic>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -38,6 +39,8 @@ class ConsumerInterceptors {
     void onAcknowledge(const Consumer& consumer, Result result, const MessageId& messageID) const;
 
     void onAcknowledgeCumulative(const Consumer& consumer, Result result, const MessageId& messageID) const;
+
+    void onNegativeAcksSend(const Consumer& consumer, const std::set<MessageId>& messageIds) const;
 
    private:
     enum State

--- a/lib/NegativeAcksTracker.cc
+++ b/lib/NegativeAcksTracker.cc
@@ -80,6 +80,7 @@ void NegativeAcksTracker::handleTimer(const boost::system::error_code &ec) {
     }
 
     if (!messagesToRedeliver.empty()) {
+        consumer_.onNegativeAcksSend(messagesToRedeliver);
         consumer_.redeliverUnacknowledgedMessages(messagesToRedeliver);
     }
     scheduleTimer();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

This PR is the C++ implementation of https://github.com/apache/pulsar/pull/3962

### Modifications

* Add `onNegativeAcksSend` to the consumer interceptor

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
