### PR TITLE
Make stats timers thread safe to use

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -117,6 +117,7 @@ ConsumerImpl::ConsumerImpl(const ClientImplPtr client, const std::string& topic,
     } else {
         consumerStatsBasePtr_ = std::make_shared<ConsumerStatsDisabled>();
     }
+    consumerStatsBasePtr_->start();
 
     // Create msgCrypto
     if (conf.isEncryptionEnabled()) {

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -98,6 +98,7 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const TopicName& topicName,
     } else {
         producerStatsBasePtr_ = std::make_shared<ProducerStatsDisabled>();
     }
+    producerStatsBasePtr_->start();
 
     if (conf_.isEncryptionEnabled()) {
         std::ostringstream logCtxStream;

--- a/lib/stats/ConsumerStatsBase.h
+++ b/lib/stats/ConsumerStatsBase.h
@@ -27,6 +27,7 @@
 namespace pulsar {
 class ConsumerStatsBase {
    public:
+    virtual void start() {}
     virtual void receivedMessage(Message&, Result) = 0;
     virtual void messageAcknowledged(Result, CommandAck_AckType, uint32_t ackNums = 1) = 0;
     virtual ~ConsumerStatsBase() {}

--- a/lib/stats/ConsumerStatsImpl.cc
+++ b/lib/stats/ConsumerStatsImpl.cc
@@ -53,14 +53,15 @@ void ConsumerStatsImpl::flushAndReset(const boost::system::error_code& ec) {
     }
 
     Lock lock(mutex_);
-    ConsumerStatsImpl tmp = *this;
+    std::ostringstream oss;
+    oss << *this;
     numBytesRecieved_ = 0;
     receivedMsgMap_.clear();
     ackedMsgMap_.clear();
     lock.unlock();
 
     scheduleTimer();
-    LOG_INFO(tmp);
+    LOG_INFO(oss.str());
 }
 
 ConsumerStatsImpl::~ConsumerStatsImpl() { timer_->cancel(); }

--- a/lib/stats/ConsumerStatsImpl.cc
+++ b/lib/stats/ConsumerStatsImpl.cc
@@ -33,12 +33,8 @@ using Lock = std::unique_lock<std::mutex>;
 ConsumerStatsImpl::ConsumerStatsImpl(std::string consumerStr, ExecutorServicePtr executor,
                                      unsigned int statsIntervalInSeconds)
     : consumerStr_(consumerStr),
-      executor_(executor),
-      timer_(executor_->createDeadlineTimer()),
-      statsIntervalInSeconds_(statsIntervalInSeconds) {
-    timer_->expires_from_now(boost::posix_time::seconds(statsIntervalInSeconds_));
-    timer_->async_wait(std::bind(&pulsar::ConsumerStatsImpl::flushAndReset, this, std::placeholders::_1));
-}
+      timer_(executor->createDeadlineTimer()),
+      statsIntervalInSeconds_(statsIntervalInSeconds) {}
 
 ConsumerStatsImpl::ConsumerStatsImpl(const ConsumerStatsImpl& stats)
     : consumerStr_(stats.consumerStr_),
@@ -63,17 +59,13 @@ void ConsumerStatsImpl::flushAndReset(const boost::system::error_code& ec) {
     ackedMsgMap_.clear();
     lock.unlock();
 
-    timer_->expires_from_now(boost::posix_time::seconds(statsIntervalInSeconds_));
-    timer_->async_wait(std::bind(&pulsar::ConsumerStatsImpl::flushAndReset, this, std::placeholders::_1));
+    scheduleTimer();
     LOG_INFO(tmp);
 }
 
-ConsumerStatsImpl::~ConsumerStatsImpl() {
-    Lock lock(mutex_);
-    if (timer_) {
-        timer_->cancel();
-    }
-}
+ConsumerStatsImpl::~ConsumerStatsImpl() { timer_->cancel(); }
+
+void ConsumerStatsImpl::start() { scheduleTimer(); }
 
 void ConsumerStatsImpl::receivedMessage(Message& msg, Result res) {
     Lock lock(mutex_);
@@ -89,6 +81,18 @@ void ConsumerStatsImpl::messageAcknowledged(Result res, CommandAck_AckType ackTy
     Lock lock(mutex_);
     ackedMsgMap_[std::make_pair(res, ackType)] += ackNums;
     totalAckedMsgMap_[std::make_pair(res, ackType)] += ackNums;
+}
+
+void ConsumerStatsImpl::scheduleTimer() {
+    timer_->expires_from_now(boost::posix_time::seconds(statsIntervalInSeconds_));
+    std::weak_ptr<ConsumerStatsImpl> weakSelf{shared_from_this()};
+    timer_->async_wait([this, weakSelf](const boost::system::error_code& ec) {
+        auto self = weakSelf.lock();
+        if (!self) {
+            return;
+        }
+        flushAndReset(ec);
+    });
 }
 
 std::ostream& operator<<(std::ostream& os,

--- a/lib/stats/ProducerStatsBase.h
+++ b/lib/stats/ProducerStatsBase.h
@@ -27,6 +27,7 @@
 namespace pulsar {
 class ProducerStatsBase {
    public:
+    virtual void start() {}
     virtual void messageSent(const Message& msg) = 0;
     virtual void messageReceived(Result, const boost::posix_time::ptime&) = 0;
     virtual ~ProducerStatsBase(){};

--- a/lib/stats/ProducerStatsImpl.cc
+++ b/lib/stats/ProducerStatsImpl.cc
@@ -72,7 +72,8 @@ void ProducerStatsImpl::flushAndReset(const boost::system::error_code& ec) {
     }
 
     Lock lock(mutex_);
-    ProducerStatsImpl tmp = *this;
+    std::ostringstream oss;
+    oss << *this;
     numMsgsSent_ = 0;
     numBytesSent_ = 0;
     sendMap_.clear();
@@ -81,7 +82,7 @@ void ProducerStatsImpl::flushAndReset(const boost::system::error_code& ec) {
     lock.unlock();
 
     scheduleTimer();
-    LOG_INFO(tmp);
+    LOG_INFO(oss.str());
 }
 
 void ProducerStatsImpl::messageSent(const Message& msg) {

--- a/lib/stats/ProducerStatsImpl.h
+++ b/lib/stats/ProducerStatsImpl.h
@@ -64,8 +64,7 @@ class ProducerStatsImpl : public std::enable_shared_from_this<ProducerStatsImpl>
     std::map<Result, unsigned long> totalSendMap_;
     LatencyAccumulator totalLatencyAccumulator_;
 
-    ExecutorServicePtr executor_;
-    DeadlineTimerPtr timer_;
+    const DeadlineTimerPtr timer_;
     std::mutex mutex_;
     unsigned int statsIntervalInSeconds_;
 
@@ -75,16 +74,20 @@ class ProducerStatsImpl : public std::enable_shared_from_this<ProducerStatsImpl>
 
     static std::string latencyToString(const LatencyAccumulator&);
 
+    void scheduleTimer();
+
    public:
     ProducerStatsImpl(std::string, ExecutorServicePtr, unsigned int);
 
     ProducerStatsImpl(const ProducerStatsImpl& stats);
 
+    void start() override;
+
     void flushAndReset(const boost::system::error_code&);
 
-    void messageSent(const Message&);
+    void messageSent(const Message&) override;
 
-    void messageReceived(Result, const boost::posix_time::ptime&);
+    void messageReceived(Result, const boost::posix_time::ptime&) override;
 
     ~ProducerStatsImpl();
 


### PR DESCRIPTION
### Motivation

The timers' callbacks in `ProducerStatsImpl` and `ConsumerStatsImpl` are not thread safe because they both capture the `this` pointer, while when the callback is called in the event loop, `this` might point to an expired instance.

### Modifications

- Capture the weak pointer instead of `this` in these callbacks. Since we cannot call `shared_from_this()` in the constructor, a `start()` method is added.
- Remove the useless `executor_` field and unnecessary null check for `timer_`.