### PR TITLE
Fix possible crash caused by MessageId::getTopicName

### DIFF
--- a/include/pulsar/MessageId.h
+++ b/include/pulsar/MessageId.h
@@ -67,6 +67,8 @@ class PULSAR_PUBLIC MessageId {
 
     /**
      * Get the topic Name from which this message originated from
+     *
+     * @return the topic name or an empty string if there is no topic name
      */
     const std::string& getTopicName() const;
 

--- a/lib/MessageIdImpl.h
+++ b/lib/MessageIdImpl.h
@@ -68,7 +68,10 @@ class MessageIdImpl {
     int32_t batchIndex_ = -1;
     int32_t batchSize_ = 0;
 
-    const std::string& getTopicName() { return *topicName_; }
+    const std::string& getTopicName() {
+        static const std::string EMPTY_TOPIC = "";
+        return topicName_ ? *topicName_ : EMPTY_TOPIC;
+    }
     void setTopicName(const std::shared_ptr<std::string>& topicName) { topicName_ = topicName; }
 
     virtual const BitSet& getBitSet() const noexcept {

--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -661,6 +661,11 @@ void MultiTopicsConsumerImpl::acknowledgeAsync(const MessageId& msgId, ResultCal
     }
 
     const std::string& topicPartitionName = msgId.getTopicName();
+    if (topicPartitionName.empty()) {
+        LOG_ERROR("MessageId without a topic name cannot be acknowledged for a multi-topics consumer");
+        callback(ResultOperationNotSupported);
+        return;
+    }
     auto optConsumer = consumers_.find(topicPartitionName);
 
     if (optConsumer) {
@@ -681,6 +686,11 @@ void MultiTopicsConsumerImpl::acknowledgeAsync(const MessageIdList& messageIdLis
     std::unordered_map<std::string, MessageIdList> topicToMessageId;
     for (const MessageId& messageId : messageIdList) {
         auto topicName = messageId.getTopicName();
+        if (topicName.empty()) {
+            LOG_ERROR("MessageId without a topic name cannot be acknowledged for a multi-topics consumer");
+            callback(ResultOperationNotSupported);
+            return;
+        }
         topicToMessageId[topicName].emplace_back(messageId);
     }
 

--- a/tests/AcknowledgeTest.cc
+++ b/tests/AcknowledgeTest.cc
@@ -302,4 +302,17 @@ TEST_F(AcknowledgeTest, testMixedCumulativeAck) {
     ASSERT_EQ(ResultTimeout, consumer.getConsumer().receive(msg, 1000));
 }
 
+TEST_F(AcknowledgeTest, testInvalidMessageId) {
+    Client client(lookupUrl);
+    std::vector<std::string> topics{"test-invalid-message-id0" + unique_str(),
+                                    "test-invalid-message-id1" + unique_str()};
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topics, "sub", consumer));
+
+    Message msg;
+    ASSERT_EQ(ResultOperationNotSupported, consumer.acknowledge(msg));
+    msg = MessageBuilder().setContent("msg").build();
+    ASSERT_EQ(ResultOperationNotSupported, consumer.acknowledge(msg));
+}
+
 INSTANTIATE_TEST_SUITE_P(BasicEndToEndTest, AcknowledgeTest, testing::Values(100, 0));

--- a/tests/BasicEndToEndTest.cc
+++ b/tests/BasicEndToEndTest.cc
@@ -537,7 +537,7 @@ void testPartitionedProducerConsumer(bool lazyStartPartitionedProducers, std::st
     ASSERT_EQ(consumer.getSubscriptionName(), "subscription-A");
     for (int i = 0; i < 10; i++) {
         Message m;
-        consumer.receive(m, 10000);
+        ASSERT_EQ(ResultOk, consumer.receive(m, 10000));
         consumer.acknowledge(m);
     }
     client.shutdown();


### PR DESCRIPTION
### Motivation

Currently if a `MessageId` does not have a topic name, the `getTopicName` method will dereference a null pointer, which leads to a crash. This case usually happens when an invalid message is acknowledged, like
https://github.com/apache/pulsar-client-cpp/issues/224.

### Modifications

Return the const reference to an empty string in `getTopicName` when the inner topic name field is a null pointer. Then, return `ResultOperationNotSupported` when acknowledging such invalid messages.