### PR TITLE
[fix] Consumer batch receive will cause data loss.

### DIFF
--- a/lib/BlockingQueue.h
+++ b/lib/BlockingQueue.h
@@ -129,7 +129,8 @@ class BlockingQueue {
      */
     bool popIf(T& value, std::function<bool(const T& peekValue)> condition) {
         Lock lock(mutex_);
-        if (queue_.empty()) {
+
+        if (isEmptyNoMutex() || isClosedNoMutex()) {
             return false;
         }
 

--- a/lib/BlockingQueue.h
+++ b/lib/BlockingQueue.h
@@ -120,6 +120,36 @@ class BlockingQueue {
         return true;
     }
 
+    /**
+     * First peek data to the condition judgment, if true then pop it.
+     *
+     * @param value A reference to the value assigned after pop
+     * @param condition A function that returns true if the value should be popped
+     * @return true if the value was popped, false otherwise.
+     */
+    bool popIf(T& value, std::function<bool(const T& peekValue)> condition) {
+        Lock lock(mutex_);
+        if (queue_.empty()) {
+            return false;
+        }
+
+        bool wasFull = isFullNoMutex();
+
+        auto peekValue = queue_.front();
+        if (condition(peekValue)) {
+            value = peekValue;
+            queue_.pop_front();
+            lock.unlock();
+            if (wasFull) {
+                // Notify that an element is popped
+                queueFullCondition.notify_all();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     // Check the 1st element of the queue
     bool peek(T& value) {
         Lock lock(mutex_);

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -649,10 +649,11 @@ void ConsumerImpl::executeNotifyCallback(Message& msg) {
 void ConsumerImpl::notifyBatchPendingReceivedCallback(const BatchReceiveCallback& callback) {
     auto messages = std::make_shared<MessagesImpl>(batchReceivePolicy_.getMaxNumMessages(),
                                                    batchReceivePolicy_.getMaxNumBytes());
-    Message peekMsg;
-    while (incomingMessages_.pop(peekMsg, std::chrono::milliseconds(0)) && messages->canAdd(peekMsg)) {
-        messageProcessed(peekMsg);
-        Message interceptMsg = interceptors_->beforeConsume(Consumer(shared_from_this()), peekMsg);
+    Message msg;
+    while (incomingMessages_.peek(msg) && messages->canAdd(msg)) {
+        incomingMessages_.pop(msg);
+        messageProcessed(msg);
+        Message interceptMsg = interceptors_->beforeConsume(Consumer(shared_from_this()), msg);
         messages->add(interceptMsg);
     }
     auto self = get_shared_this_ptr();

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -650,8 +650,8 @@ void ConsumerImpl::notifyBatchPendingReceivedCallback(const BatchReceiveCallback
     auto messages = std::make_shared<MessagesImpl>(batchReceivePolicy_.getMaxNumMessages(),
                                                    batchReceivePolicy_.getMaxNumBytes());
     Message msg;
-    while (incomingMessages_.peek(msg) && messages->canAdd(msg)) {
-        incomingMessages_.pop(msg);
+    while (incomingMessages_.popIf(
+        msg, [&messages](const Message& peekMsg) { return messages->canAdd(peekMsg); })) {
         messageProcessed(msg);
         Message interceptMsg = interceptors_->beforeConsume(Consumer(shared_from_this()), msg);
         messages->add(interceptMsg);

--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -1054,10 +1054,11 @@ bool MultiTopicsConsumerImpl::hasEnoughMessagesForBatchReceive() const {
 void MultiTopicsConsumerImpl::notifyBatchPendingReceivedCallback(const BatchReceiveCallback& callback) {
     auto messages = std::make_shared<MessagesImpl>(batchReceivePolicy_.getMaxNumMessages(),
                                                    batchReceivePolicy_.getMaxNumBytes());
-    Message peekMsg;
-    while (incomingMessages_.pop(peekMsg, std::chrono::milliseconds(0)) && messages->canAdd(peekMsg)) {
-        messageProcessed(peekMsg);
-        messages->add(peekMsg);
+    Message msg;
+    while (incomingMessages_.peek(msg) && messages->canAdd(msg)) {
+        incomingMessages_.pop(msg);
+        messageProcessed(msg);
+        messages->add(msg);
     }
     auto weakSelf = weak_from_this();
     listenerExecutor_->postWork([weakSelf, callback, messages]() {

--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -1055,8 +1055,8 @@ void MultiTopicsConsumerImpl::notifyBatchPendingReceivedCallback(const BatchRece
     auto messages = std::make_shared<MessagesImpl>(batchReceivePolicy_.getMaxNumMessages(),
                                                    batchReceivePolicy_.getMaxNumBytes());
     Message msg;
-    while (incomingMessages_.peek(msg) && messages->canAdd(msg)) {
-        incomingMessages_.pop(msg);
+    while (incomingMessages_.popIf(
+        msg, [&messages](const Message& peekMsg) { return messages->canAdd(peekMsg); })) {
         messageProcessed(msg);
         messages->add(msg);
     }

--- a/lib/UnboundedBlockingQueue.h
+++ b/lib/UnboundedBlockingQueue.h
@@ -96,7 +96,8 @@ class UnboundedBlockingQueue {
      */
     bool popIf(T& value, std::function<bool(const T& peekValue)> condition) {
         Lock lock(mutex_);
-        if (queue_.empty()) {
+
+        if (isEmptyNoMutex() || isClosedNoMutex()) {
             return false;
         }
 

--- a/lib/UnboundedBlockingQueue.h
+++ b/lib/UnboundedBlockingQueue.h
@@ -87,6 +87,29 @@ class UnboundedBlockingQueue {
         return true;
     }
 
+    /**
+     * First peek data to the condition judgment, if true then pop it.
+     *
+     * @param value A reference to the value assigned after pop
+     * @param condition A function that returns true if the value should be popped
+     * @return true if the value was popped, false otherwise.
+     */
+    bool popIf(T& value, std::function<bool(const T& peekValue)> condition) {
+        Lock lock(mutex_);
+        if (queue_.empty()) {
+            return false;
+        }
+
+        auto peekValue = queue_.front();
+        if (condition(peekValue)) {
+            value = peekValue;
+            queue_.pop_front();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     // Check the 1st element of the queue
     bool peek(T& value) {
         Lock lock(mutex_);

--- a/tests/BlockingQueueTest.cc
+++ b/tests/BlockingQueueTest.cc
@@ -126,6 +126,27 @@ TEST(BlockingQueueTest, testBlockingProducer) {
     ASSERT_EQ(three, queue.size());
 }
 
+TEST(BlockingQueueTest, testPopIf) {
+    size_t size = 5;
+    BlockingQueue<int> queue(size);
+
+    for (int i = 1; i <= size; ++i) {
+        queue.push(i);
+    }
+
+    // Use producer worker to assert popIf will notify queueFull thread.
+    ProducerWorker producerWorker(queue);
+    producerWorker.produce(3);
+
+    int value;
+    for (int i = 1; i <= size; ++i) {
+        ASSERT_TRUE(queue.popIf(value, [&i](const int& peekValue) { return peekValue == i; }));
+    }
+
+    producerWorker.join();
+    ASSERT_EQ(3, queue.size());
+}
+
 TEST(BlockingQueueTest, testBlockingConsumer) {
     size_t size = 5;
     BlockingQueue<int> queue(size);

--- a/tests/UnboundedBlockingQueueTest.cc
+++ b/tests/UnboundedBlockingQueueTest.cc
@@ -112,6 +112,22 @@ TEST(UnboundedBlockingQueueTest, testQueueOperations) {
     ASSERT_FALSE(queue.peek(poppedElement));
 }
 
+TEST(UnboundedBlockingQueueTest, testPopIf) {
+    size_t size = 5;
+    UnboundedBlockingQueue<int> queue(size);
+
+    for (int i = 1; i <= size * 2; ++i) {
+        queue.push(i);
+    }
+
+    int value;
+    for (int i = 1; i <= size; ++i) {
+        ASSERT_TRUE(queue.popIf(value, [&i](const int& peekValue) { return peekValue == i; }));
+    }
+
+    ASSERT_EQ(size, queue.size());
+}
+
 TEST(UnboundedBlockingQueueTest, testBlockingProducer) {
     size_t size = 5;
     UnboundedBlockingQueue<int> queue(size);


### PR DESCRIPTION
### Motivation

Currently, the batch receive method may cause data loss.

The root cause is, when `peekMsg` can't add to `messages`(The batch has satisfied the batch receive policy), it has actually been popped.

https://github.com/apache/pulsar-client-cpp/blob/ba7f59d2bb28b72fa6d1d01abada71090537b45e/lib/ConsumerImpl.cc#L652-L657



### Modifications

- Peek first, pop only when it can be added.


### Verifying this change

- Change `testBatchReceive` test to cover this case: 
Send 100 messages first, batch receive 10 messages at a time, and assert that all messages can be received.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
