### PR TITLE
[feat] Support consumer batch receive on C client.

### DIFF
--- a/include/pulsar/c/consumer.h
+++ b/include/pulsar/c/consumer.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 #include <pulsar/c/message.h>
+#include <pulsar/c/messages.h>
 #include <pulsar/c/result.h>
 #include <stdint.h>
 
@@ -33,6 +34,8 @@ typedef struct _pulsar_consumer pulsar_consumer_t;
 typedef void (*pulsar_result_callback)(pulsar_result, void *);
 
 typedef void (*pulsar_receive_callback)(pulsar_result result, pulsar_message_t *msg, void *ctx);
+
+typedef void (*pulsar_batch_receive_callback)(pulsar_result result, pulsar_messages_t *msg, void *ctx);
 
 /**
  * @return the topic this consumer is subscribed to
@@ -106,6 +109,26 @@ PULSAR_PUBLIC pulsar_result pulsar_consumer_receive_with_timeout(pulsar_consumer
  */
 PULSAR_PUBLIC void pulsar_consumer_receive_async(pulsar_consumer_t *consumer,
                                                  pulsar_receive_callback callback, void *ctx);
+
+/**
+ * Batch receiving messages.
+ *
+ * This calls blocks until has enough messages or wait timeout.
+ *
+ * @param msgs a non-const reference where the received messages will be copied
+ * @return ResultOk when a message is received
+ */
+PULSAR_PUBLIC pulsar_result pulsar_consumer_batch_receive(pulsar_consumer_t *consumer,
+                                                          pulsar_messages_t **msgs);
+
+/**
+ * Async batch receiving messages.
+ *
+ * @param msgs a non-const reference where the received messages will be copied
+ * @return ResultOk when a message is received
+ */
+PULSAR_PUBLIC void pulsar_consumer_batch_receive_async(pulsar_consumer_t *consumer,
+                                                       pulsar_batch_receive_callback callback, void *ctx);
 
 /**
  * Acknowledge the reception of a single message.

--- a/include/pulsar/c/consumer_configuration.h
+++ b/include/pulsar/c/consumer_configuration.h
@@ -89,6 +89,15 @@ typedef enum
     pulsar_consumer_regex_sub_mode_AllTopics = 2
 } pulsar_consumer_regex_subscription_mode;
 
+typedef struct {
+    // Max num message, if less than 0, it means no limit.
+    int maxNumMessage;
+    // Max num bytes, if less than 0, it means no limit.
+    long maxNumBytes;
+    // If less than 0, it means no limit.
+    long timeoutMs;
+} pulsar_consumer_batch_receive_policy_t;
+
 /// Callback definition for MessageListener
 typedef void (*pulsar_message_listener)(pulsar_consumer_t *consumer, pulsar_message_t *msg, void *ctx);
 
@@ -326,6 +335,22 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_regex_subscription_mode(
 
 PULSAR_PUBLIC pulsar_consumer_regex_subscription_mode
 pulsar_consumer_configuration_get_regex_subscription_mode(
+    pulsar_consumer_configuration_t *consumer_configuration);
+
+/**
+ * Set batch receive policy.
+ *
+ * The default value: {maxNumMessage: -1, maxNumBytes: 10 * 1024 * 1024, timeoutMs: 100}
+ * @param consumer_configuration  the consumer conf object.
+ * @param maxNumMessage default: Max num message, if less than 0, it means no limit.
+ * @param maxNumBytes Max num bytes, if less than 0, it means no limit.
+ * @param timeoutMs If less than 0, it means no limit.
+ */
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_batch_receive_policy(
+    pulsar_consumer_configuration_t *consumer_configuration,
+    const pulsar_consumer_batch_receive_policy_t *batch_receive_policy);
+
+PULSAR_PUBLIC pulsar_consumer_batch_receive_policy_t pulsar_consumer_configuration_get_batch_receive_policy(
     pulsar_consumer_configuration_t *consumer_configuration);
 
 // const CryptoKeyReaderPtr getCryptoKeyReader()

--- a/include/pulsar/c/messages.h
+++ b/include/pulsar/c/messages.h
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <pulsar/defines.h>
+
+typedef struct _pulsar_messages pulsar_messages_t;
+
+/**
+ * Create the messages.
+ * @return messages
+ */
+PULSAR_PUBLIC pulsar_messages_t *pulsar_messages_create();
+
+/**
+ * Free the messages.
+ */
+PULSAR_PUBLIC void pulsar_messages_free(pulsar_messages_t *messages);
+
+/**
+ * Get the size of the messages.
+ * @return the size of messages.
+ */
+PULSAR_PUBLIC int pulsar_messages_size(pulsar_messages_t *messages);
+
+/**
+ * Append message to messages.
+ * @param message the pointer of message
+ */
+PULSAR_PUBLIC void pulsar_messages_append(pulsar_messages_t *messages, const pulsar_message_t *message);
+
+/**
+ * Get message by index.
+ * @param index the index of messages
+ * @return
+ */
+PULSAR_PUBLIC pulsar_message_t *pulsar_messages_get(pulsar_messages_t *messages, int index);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/c/c_Consumer.cc
+++ b/lib/c/c_Consumer.cc
@@ -74,6 +74,32 @@ void pulsar_consumer_receive_async(pulsar_consumer_t *consumer, pulsar_receive_c
         std::bind(handle_receive_callback, std::placeholders::_1, std::placeholders::_2, callback, ctx));
 }
 
+pulsar_result pulsar_consumer_batch_receive(pulsar_consumer_t *consumer, pulsar_messages_t **msg) {
+    pulsar::Messages messages;
+
+    pulsar::Result res = consumer->consumer.batchReceive(messages);
+    if (res == pulsar::ResultOk) {
+        (*msg) = new pulsar_messages_t;
+        (*msg)->messages = messages;
+    }
+    return (pulsar_result)res;
+}
+
+static void handle_batch_receive_callback(pulsar::Result result, pulsar::Messages messages,
+                                          pulsar_batch_receive_callback callback, void *ctx) {
+    if (callback) {
+        pulsar_messages_t *msgs = new pulsar_messages_t;
+        msgs->messages = messages;
+        callback((pulsar_result)result, msgs, ctx);
+    }
+}
+
+void pulsar_consumer_batch_receive_async(pulsar_consumer_t *consumer, pulsar_batch_receive_callback callback,
+                                         void *ctx) {
+    consumer->consumer.batchReceiveAsync(std::bind(handle_batch_receive_callback, std::placeholders::_1,
+                                                   std::placeholders::_2, callback, ctx));
+}
+
 pulsar_result pulsar_consumer_acknowledge(pulsar_consumer_t *consumer, pulsar_message_t *message) {
     return (pulsar_result)consumer->consumer.acknowledge(message->message);
 }

--- a/lib/c/c_ConsumerConfiguration.cc
+++ b/lib/c/c_ConsumerConfiguration.cc
@@ -250,3 +250,20 @@ pulsar_consumer_regex_subscription_mode pulsar_consumer_configuration_get_regex_
     return (pulsar_consumer_regex_subscription_mode)
         consumer_configuration->consumerConfiguration.getRegexSubscriptionMode();
 }
+
+void pulsar_consumer_configuration_set_batch_receive_policy(
+    pulsar_consumer_configuration_t *consumer_configuration,
+    const pulsar_consumer_batch_receive_policy_t *batch_receive_policy_t) {
+    pulsar::BatchReceivePolicy batchReceivePolicy(batch_receive_policy_t->maxNumMessage,
+                                                  batch_receive_policy_t->maxNumBytes,
+                                                  batch_receive_policy_t->timeoutMs);
+    consumer_configuration->consumerConfiguration.setBatchReceivePolicy(batchReceivePolicy);
+}
+
+pulsar_consumer_batch_receive_policy_t pulsar_consumer_configuration_get_batch_receive_policy(
+    pulsar_consumer_configuration_t *consumer_configuration) {
+    pulsar::BatchReceivePolicy batchReceivePolicy =
+        consumer_configuration->consumerConfiguration.getBatchReceivePolicy();
+    return {batchReceivePolicy.getMaxNumMessages(), batchReceivePolicy.getMaxNumBytes(),
+            batchReceivePolicy.getTimeoutMs()};
+}

--- a/lib/c/c_Messages.cc
+++ b/lib/c/c_Messages.cc
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <pulsar/c/message.h>
+#include <pulsar/c/messages.h>
+
+#include "c_structs.h"
+
+pulsar_messages_t *pulsar_messages_create() { return new pulsar_messages_t; }
+
+void pulsar_messages_free(pulsar_messages_t *messages) { delete messages; }
+
+int pulsar_messages_size(pulsar_messages_t *messages) { return messages->messages.size(); }
+
+void pulsar_messages_append(pulsar_messages_t *messages, const pulsar_message_t *message) {
+    messages->messages.push_back(message->message);
+}
+
+pulsar_message_t *pulsar_messages_get(pulsar_messages_t *messages, int index) {
+    auto msg = new pulsar_message_t;
+    msg->message = messages->messages[index];
+    return msg;
+}

--- a/lib/c/c_structs.h
+++ b/lib/c/c_structs.h
@@ -61,6 +61,10 @@ struct _pulsar_message {
     pulsar::Message message;
 };
 
+struct _pulsar_messages {
+    std::vector<pulsar::Message> messages;
+};
+
 struct _pulsar_message_id {
     pulsar::MessageId messageId;
 };

--- a/tests/c/c_ConsumerConfigurationTest.cc
+++ b/tests/c/c_ConsumerConfigurationTest.cc
@@ -42,4 +42,6 @@ TEST(C_ConsumerConfigurationTest, testCApiConfig) {
         consumer_conf, pulsar_consumer_regex_sub_mode_NonPersistentOnly);
     ASSERT_EQ(pulsar_consumer_configuration_get_regex_subscription_mode(consumer_conf),
               pulsar_consumer_regex_sub_mode_NonPersistentOnly);
+
+    pulsar_consumer_configuration_free(consumer_conf);
 }

--- a/tests/c/c_ConsumerTest.cc
+++ b/tests/c/c_ConsumerTest.cc
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/c/client.h>
+const char *lookup_url = "pulsar://localhost:6650";
+
+TEST(C_ConsumerConfigurationTest, testCBatchReceive) {
+    const char *topic_name = "persistent://public/default/test-c-batch-receive5";
+    const char *sub_name = "my-sub-name";
+
+    pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
+    pulsar_client_t *client = pulsar_client_create(lookup_url, conf);
+
+    pulsar_producer_configuration_t *producer_conf = pulsar_producer_configuration_create();
+    pulsar_producer_t *producer;
+    pulsar_result result = pulsar_client_create_producer(client, topic_name, producer_conf, &producer);
+    ASSERT_EQ(pulsar_result_Ok, result);
+
+    pulsar_consumer_configuration_t *consumer_conf = pulsar_consumer_configuration_create();
+    const int batch_receive_max_size = 10;
+
+    pulsar_consumer_batch_receive_policy_t batch_receive_policy{batch_receive_max_size, -1, -1};
+    pulsar_consumer_configuration_set_batch_receive_policy(consumer_conf, &batch_receive_policy);
+
+    pulsar_consumer_t *consumer;
+    result = pulsar_client_subscribe(client, topic_name, sub_name, consumer_conf, &consumer);
+    ASSERT_EQ(pulsar_result_Ok, result);
+
+    // Send messages
+    const char *data = "my-content";
+    for (int i = 0; i < batch_receive_max_size; i++) {
+        pulsar_message_t *message = pulsar_message_create();
+        pulsar_message_set_content(message, data, strlen(data));
+        pulsar_result res = pulsar_producer_send(producer, message);
+        ASSERT_EQ(pulsar_result_Ok, res);
+        pulsar_message_free(message);
+    }
+
+    // Batch receive messages
+    pulsar_messages_t *msgs = pulsar_messages_create();
+    pulsar_result res = pulsar_consumer_batch_receive(consumer, &msgs);
+    ASSERT_EQ(pulsar_result_Ok, res);
+    ASSERT_EQ(batch_receive_max_size, pulsar_messages_size(msgs));
+    for (int i = 0; i < pulsar_messages_size(msgs); i++) {
+        pulsar_message_t *msg = pulsar_messages_get(msgs, i);
+        const char *msg_data = (const char *)pulsar_message_get_data(msg);
+        ASSERT_STREQ(data, msg_data);
+    }
+    pulsar_messages_free(msgs);
+
+    ASSERT_EQ(pulsar_result_Ok, pulsar_consumer_unsubscribe(consumer));
+    ASSERT_EQ(pulsar_result_AlreadyClosed, pulsar_consumer_close(consumer));
+    ASSERT_EQ(pulsar_result_Ok, pulsar_producer_close(producer));
+    ASSERT_EQ(pulsar_result_Ok, pulsar_client_close(client));
+
+    pulsar_consumer_free(consumer);
+    pulsar_consumer_configuration_free(consumer_conf);
+    pulsar_producer_free(producer);
+    pulsar_producer_configuration_free(producer_conf);
+    pulsar_client_free(client);
+    pulsar_client_configuration_free(conf);
+}


### PR DESCRIPTION
### Motivation

Support consumer batch receive on C client.

### Modifications
- Add messages on C.
- Support batch receive and async batch receive API.

### Verifying this change

- Add `ConsumerTest.testCBatchReceive` to cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
