### PR TITLE
[fix] Use unique topic name in ConsumerInterceptorsTest

### DIFF
--- a/tests/InterceptorsTest.cc
+++ b/tests/InterceptorsTest.cc
@@ -21,6 +21,7 @@
 #include <pulsar/ConsumerInterceptor.h>
 #include <pulsar/ProducerInterceptor.h>
 
+#include <random>
 #include <utility>
 
 #include "HttpHelper.h"
@@ -272,8 +273,11 @@ class ConsumerTestInterceptor : public ConsumerInterceptor {
 class ConsumerInterceptorsTest : public ::testing::TestWithParam<std::tuple<TopicType, int>> {
    public:
     void SetUp() override {
-        topic_ = "persistent://public/default/InterceptorsTest-ConsumerInterceptors-" +
-                 std::to_string(time(nullptr));
+        std::random_device rd;
+        std::mt19937 mt(rd());
+        std::uniform_int_distribution<int> dist;
+        topic_ =
+            "persistent://public/default/InterceptorsTest-ConsumerInterceptors-" + std::to_string(dist(mt));
 
         switch (std::get<0>(GetParam())) {
             case Partitioned:

--- a/tests/InterceptorsTest.cc
+++ b/tests/InterceptorsTest.cc
@@ -33,6 +33,8 @@ DECLARE_LOG_OBJECT()
 static const std::string serviceUrl = "pulsar://localhost:6650";
 static const std::string adminUrl = "http://localhost:8080/";
 
+extern std::string unique_str();
+
 using namespace pulsar;
 
 class ProducerTestInterceptor : public ProducerInterceptor {
@@ -273,11 +275,7 @@ class ConsumerTestInterceptor : public ConsumerInterceptor {
 class ConsumerInterceptorsTest : public ::testing::TestWithParam<std::tuple<TopicType, int>> {
    public:
     void SetUp() override {
-        std::random_device rd;
-        std::mt19937 mt(rd());
-        std::uniform_int_distribution<int> dist;
-        topic_ =
-            "persistent://public/default/InterceptorsTest-ConsumerInterceptors-" + std::to_string(dist(mt));
+        topic_ = "persistent://public/default/InterceptorsTest-ConsumerInterceptors-" + unique_str();
 
         switch (std::get<0>(GetParam())) {
             case Partitioned:


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes #229


### Motivation

Using `time(nulltpr)` is not enough for generating the unique topic name. Especially when running a test for less than a second.

### Modifications

* Use `unique_str` to generate the topic name in ConsumerInterceptorsTest

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
