### PR TITLE
Fix flaky test ProducerTest.testWaitForExclusiveProducer

### DIFF
--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -322,8 +322,8 @@ TEST(ProducerTest, testWaitForExclusiveProducer) {
     client.createProducerAsync(topicName, producerConfiguration2,
                                [&latch, &producer2](Result res, Producer producer) {
                                    ASSERT_EQ(ResultOk, res);
-                                   latch.countdown();
                                    producer2 = producer;
+                                   latch.countdown();
                                });
 
     // when p1 close, p2 success created.


### PR DESCRIPTION
### Motivation
#135 

The root cause is when the `latch.wait()` is passed, `producer2` maybe not be set.

### Modifications
- Set producer2 before `latch.countdown()`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
