### PR TITLE
Speed up the process to start standalone for tests

### DIFF
--- a/build-support/start-mim-test-service-inside-container.sh
+++ b/build-support/start-mim-test-service-inside-container.sh
@@ -31,8 +31,24 @@ bin/pulsar tokens create \
             --secret-key file:///pulsar/data/tokens/secret.key \
             > /pulsar/data/tokens/token.txt
 
+# Unset the HTTP proxy to avoid the REST requests being affected
+export http_proxy=
+TOKEN=$(bin/pulsar tokens create \
+            --subject superUser \
+            --secret-key file:///pulsar/data/tokens/secret.key)
+
+# Create "standalone" cluster if it does not exist
+put() {
+    curl -H "Authorization: Bearer $TOKEN" \
+        -L http://localhost:8081/admin/v2/$1 \
+        -H 'Content-Type: application/json' \
+        -X PUT \
+        -d $(echo $2 | sed 's/ //g')
+}
+
 export PULSAR_STANDALONE_CONF=test-conf/standalone-ssl-mim.conf
 export PULSAR_PID_DIR=/tmp
+sed -i 's/immediateFlush: false/immediateFlush: true/' conf/log4j2.yaml
 bin/pulsar-daemon start standalone \
         --no-functions-worker --no-stream-storage \
         --bookkeeper-dir data/bookkeeper
@@ -42,25 +58,28 @@ until curl http://localhost:8081/metrics > /dev/null 2>&1 ; do sleep 1; done
 
 echo "-- Pulsar service is ready -- Configure permissions"
 
-export PULSAR_CLIENT_CONF=test-conf/client-ssl-mim.conf
-
 # Create "standalone" cluster if it does not exist
-bin/pulsar-admin clusters list | grep -q '^standalone$' ||
-        bin/pulsar-admin clusters create \
-                standalone \
-                --url http://localhost:8081/ \
-                --url-secure https://localhost:8444/ \
-                --broker-url pulsar://localhost:6652/ \
-                --broker-url-secure pulsar+ssl://localhost:6653/
+put clusters/standalone '{
+  "serviceUrl": "http://localhost:8081/",
+  "serviceUrlTls": "https://localhost:8444/",
+  "brokerServiceUrl": "pulsar://localhost:6652/",
+  "brokerServiceUrlTls": "pulsar+ssl://localhost:6653/"
+}'
 
 # Create "private" tenant
-bin/pulsar-admin tenants create private -r "" -c "standalone"
+put tenants/private '{
+  "adminRoles": [],
+  "allowedClusters": ["standalone"]
+}'
 
 # Create "private/auth" with required authentication
-bin/pulsar-admin namespaces create private/auth --clusters standalone
-
-bin/pulsar-admin namespaces grant-permission private/auth \
-                        --actions produce,consume \
-                        --role "token-principal"
+put namespaces/private/auth '{
+  "auth_policies": {
+    "namespace_auth": {
+      "token-principal": ["produce", "consume"]
+    }
+  },
+  "replication_clusters": ["standalone"]
+}'
 
 echo "-- Ready to start tests"


### PR DESCRIPTION
### Motivation

It took too much time to start Pulsar standalone for tests because of the slow JVM startup when running `pulsar-admin` commands.

### Modifications

Use `curl` to send REST requests directly. After this change, the startup time reduced from 1m39.597s to 32.451s in my local env.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
