### PR TITLE
[feat] Support dead letter topic for C client.

### DIFF
--- a/include/pulsar/c/consumer_configuration.h
+++ b/include/pulsar/c/consumer_configuration.h
@@ -369,7 +369,7 @@ PULSAR_PUBLIC pulsar_consumer_batch_receive_policy_t pulsar_consumer_configurati
 
 PULSAR_PUBLIC void pulsar_consumer_configuration_set_dlq_policy(
     pulsar_consumer_configuration_t *consumer_configuration,
-    pulsar_consumer_config_dead_letter_policy_t *dlq_policy);
+    const pulsar_consumer_config_dead_letter_policy_t *dlq_policy);
 
 /**
  * Get the dlq policy

--- a/include/pulsar/c/consumer_configuration.h
+++ b/include/pulsar/c/consumer_configuration.h
@@ -98,6 +98,21 @@ typedef struct {
     long timeoutMs;
 } pulsar_consumer_batch_receive_policy_t;
 
+typedef struct {
+    // Name of the dead topic where the failing messages are sent.
+    // The default value is: sourceTopicName + "-" + subscriptionName + "-DLQ"
+    const char *dead_letter_topic;
+    // Maximum number of times that a message is redelivered before being sent to the dead letter queue.
+    // - The maxRedeliverCount must be greater than 0.
+    // - The default value is {INT_MAX} (DLQ is not enabled)
+    const int max_redeliver_count;
+    // Name of the initial subscription name of the dead letter topic.
+    // If this field is not set, the initial subscription for the dead letter topic is not created.
+    // If this field is set but the broker's `allowAutoSubscriptionCreation` is disabled, the DLQ producer
+    // fails to be created.
+    const char *initial_subscription_name;
+} pulsar_consumer_config_dead_letter_policy_t;
+
 /// Callback definition for MessageListener
 typedef void (*pulsar_message_listener)(pulsar_consumer_t *consumer, pulsar_message_t *msg, void *ctx);
 
@@ -352,6 +367,13 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_batch_receive_policy(
 
 PULSAR_PUBLIC pulsar_consumer_batch_receive_policy_t pulsar_consumer_configuration_get_batch_receive_policy(
     pulsar_consumer_configuration_t *consumer_configuration);
+
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_dlq_policy(
+    pulsar_consumer_configuration_t *consumer_configuration,
+    pulsar_consumer_config_dead_letter_policy_t *dlq_policy);
+
+PULSAR_PUBLIC pulsar_consumer_config_dead_letter_policy_t
+pulsar_consumer_configuration_get_dlq_policy(pulsar_consumer_configuration_t *consumer_configuration);
 
 // const CryptoKeyReaderPtr getCryptoKeyReader()
 //

--- a/include/pulsar/c/consumer_configuration.h
+++ b/include/pulsar/c/consumer_configuration.h
@@ -100,14 +100,13 @@ typedef struct {
 
 typedef struct {
     // Name of the dead topic where the failing messages are sent.
-    // The default value is: sourceTopicName + "-" + subscriptionName + "-DLQ"
+    // If it's null, use sourceTopicName + "-" + subscriptionName + "-DLQ" as the value
     const char *dead_letter_topic;
     // Maximum number of times that a message is redelivered before being sent to the dead letter queue.
-    // - The maxRedeliverCount must be greater than 0.
-    // - The default value is {INT_MAX} (DLQ is not enabled)
-    const int max_redeliver_count;
+    // If it's not greater than 0, treat it as INT_MAX, it means DLQ disable.
+    int max_redeliver_count;
     // Name of the initial subscription name of the dead letter topic.
-    // If this field is not set, the initial subscription for the dead letter topic is not created.
+    // If it's null, the initial subscription for the dead letter topic is not created.
     // If this field is set but the broker's `allowAutoSubscriptionCreation` is disabled, the DLQ producer
     // fails to be created.
     const char *initial_subscription_name;
@@ -372,8 +371,17 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_dlq_policy(
     pulsar_consumer_configuration_t *consumer_configuration,
     pulsar_consumer_config_dead_letter_policy_t *dlq_policy);
 
-PULSAR_PUBLIC pulsar_consumer_config_dead_letter_policy_t
-pulsar_consumer_configuration_get_dlq_policy(pulsar_consumer_configuration_t *consumer_configuration);
+/**
+ * Get the dlq policy
+ *
+ * @param [in] consumer_configuration a non-null pointer of the consumer configuration
+ * @param [out] dlq_policy If dlq_policy is not null,
+ * the instance that it points to will be updated to the dead letter policy of the consumer configuration.
+ *
+ */
+PULSAR_PUBLIC void pulsar_consumer_configuration_get_dlq_policy(
+    pulsar_consumer_configuration_t *consumer_configuration,
+    pulsar_consumer_config_dead_letter_policy_t *dlq_policy);
 
 // const CryptoKeyReaderPtr getCryptoKeyReader()
 //

--- a/lib/c/c_ConsumerConfiguration.cc
+++ b/lib/c/c_ConsumerConfiguration.cc
@@ -279,12 +279,19 @@ void pulsar_consumer_configuration_set_dlq_policy(pulsar_consumer_configuration_
     if (dlq_policy->initial_subscription_name != nullptr) {
         dlqPolicyBuilder.initialSubscriptionName(dlq_policy->initial_subscription_name);
     }
+    if (dlq_policy->max_redeliver_count <= 0) {
+        dlqPolicyBuilder.maxRedeliverCount(INT_MAX);
+    }
     consumer_configuration->consumerConfiguration.setDeadLetterPolicy(dlqPolicyBuilder.build());
 }
 
-pulsar_consumer_config_dead_letter_policy_t pulsar_consumer_configuration_get_dlq_policy(
-    pulsar_consumer_configuration_t *consumer_configuration) {
+void pulsar_consumer_configuration_get_dlq_policy(pulsar_consumer_configuration_t *consumer_configuration,
+                                                  pulsar_consumer_config_dead_letter_policy_t *dlq_policy) {
+    if (!dlq_policy) {
+        return;
+    }
     auto deadLetterPolicy = consumer_configuration->consumerConfiguration.getDeadLetterPolicy();
-    return {deadLetterPolicy.getDeadLetterTopic().c_str(), deadLetterPolicy.getMaxRedeliverCount(),
-            deadLetterPolicy.getInitialSubscriptionName().c_str()};
+    dlq_policy->dead_letter_topic = deadLetterPolicy.getDeadLetterTopic().c_str();
+    dlq_policy->max_redeliver_count = deadLetterPolicy.getMaxRedeliverCount();
+    dlq_policy->initial_subscription_name = deadLetterPolicy.getInitialSubscriptionName().c_str();
 }

--- a/lib/c/c_ConsumerConfiguration.cc
+++ b/lib/c/c_ConsumerConfiguration.cc
@@ -21,8 +21,9 @@
 #include <pulsar/c/consumer.h>
 #include <pulsar/c/consumer_configuration.h>
 
+#include <climits>
+
 #include "c_structs.h"
-#include "climits"
 
 pulsar_consumer_configuration_t *pulsar_consumer_configuration_create() {
     return new pulsar_consumer_configuration_t;
@@ -270,8 +271,9 @@ pulsar_consumer_batch_receive_policy_t pulsar_consumer_configuration_get_batch_r
             batchReceivePolicy.getTimeoutMs()};
 }
 
-void pulsar_consumer_configuration_set_dlq_policy(pulsar_consumer_configuration_t *consumer_configuration,
-                                                  pulsar_consumer_config_dead_letter_policy_t *dlq_policy) {
+void pulsar_consumer_configuration_set_dlq_policy(
+    pulsar_consumer_configuration_t *consumer_configuration,
+    const pulsar_consumer_config_dead_letter_policy_t *dlq_policy) {
     auto dlqPolicyBuilder =
         pulsar::DeadLetterPolicyBuilder().maxRedeliverCount(dlq_policy->max_redeliver_count);
     if (dlq_policy->dead_letter_topic != nullptr) {

--- a/lib/c/c_ConsumerConfiguration.cc
+++ b/lib/c/c_ConsumerConfiguration.cc
@@ -270,19 +270,6 @@ pulsar_consumer_batch_receive_policy_t pulsar_consumer_configuration_get_batch_r
 }
 
 void pulsar_consumer_configuration_set_dlq_policy(pulsar_consumer_configuration_t *consumer_configuration,
-                                                  const char *dead_letter_topic, int max_redeliver_count,
-                                                  const char *initial_subscription_name) {
-    auto policyBuilder = pulsar::DeadLetterPolicyBuilder().maxRedeliverCount(max_redeliver_count);
-    if (dead_letter_topic != nullptr) {
-        policyBuilder.deadLetterTopic(dead_letter_topic);
-    }
-    if (initial_subscription_name != nullptr) {
-        policyBuilder.initialSubscriptionName(initial_subscription_name);
-    }
-    consumer_configuration->consumerConfiguration.setDeadLetterPolicy(policyBuilder.build());
-}
-
-void pulsar_consumer_configuration_set_dlq_policy(pulsar_consumer_configuration_t *consumer_configuration,
                                                   pulsar_consumer_config_dead_letter_policy_t *dlq_policy) {
     auto dlqPolicyBuilder =
         pulsar::DeadLetterPolicyBuilder().maxRedeliverCount(dlq_policy->max_redeliver_count);

--- a/lib/c/c_ConsumerConfiguration.cc
+++ b/lib/c/c_ConsumerConfiguration.cc
@@ -22,6 +22,7 @@
 #include <pulsar/c/consumer_configuration.h>
 
 #include "c_structs.h"
+#include "climits"
 
 pulsar_consumer_configuration_t *pulsar_consumer_configuration_create() {
     return new pulsar_consumer_configuration_t;

--- a/tests/c/c_ConsumerConfigurationTest.cc
+++ b/tests/c/c_ConsumerConfigurationTest.cc
@@ -51,5 +51,21 @@ TEST(C_ConsumerConfigurationTest, testCApiConfig) {
     ASSERT_EQ(get_batch_receive_policy.maxNumBytes, 1000);
     ASSERT_EQ(get_batch_receive_policy.timeoutMs, 1000);
 
+    pulsar_consumer_config_dead_letter_policy_t dlq_policy{.max_redeliver_count = 10};
+    pulsar_consumer_configuration_set_dlq_policy(consumer_conf, &dlq_policy);
+    pulsar_consumer_config_dead_letter_policy_t get_dlq_policy =
+        pulsar_consumer_configuration_get_dlq_policy(consumer_conf);
+    ASSERT_EQ(get_dlq_policy.max_redeliver_count, 10);
+    ASSERT_TRUE(get_dlq_policy.dead_letter_topic[0] == '\0');
+    ASSERT_TRUE(get_dlq_policy.initial_subscription_name[0] == '\0');
+
+    pulsar_consumer_config_dead_letter_policy_t dlq_policy_2{"dlq-topic", 10, "init-sub"};
+    pulsar_consumer_configuration_set_dlq_policy(consumer_conf, &dlq_policy_2);
+    pulsar_consumer_config_dead_letter_policy_t get_dlq_policy_2 =
+        pulsar_consumer_configuration_get_dlq_policy(consumer_conf);
+    ASSERT_EQ(get_dlq_policy_2.max_redeliver_count, 10);
+    ASSERT_EQ(strcmp(get_dlq_policy_2.dead_letter_topic, "dlq-topic"), 0);
+    ASSERT_EQ(strcmp(get_dlq_policy_2.initial_subscription_name, "init-sub"), 0);
+
     pulsar_consumer_configuration_free(consumer_conf);
 }

--- a/tests/c/c_ConsumerConfigurationTest.cc
+++ b/tests/c/c_ConsumerConfigurationTest.cc
@@ -19,7 +19,7 @@
 #include <gtest/gtest.h>
 #include <pulsar/c/consumer_configuration.h>
 
-#include "climits"
+#include <climits>
 
 TEST(C_ConsumerConfigurationTest, testCApiConfig) {
     pulsar_consumer_configuration_t *consumer_conf = pulsar_consumer_configuration_create();

--- a/tests/c/c_ConsumerConfigurationTest.cc
+++ b/tests/c/c_ConsumerConfigurationTest.cc
@@ -19,6 +19,8 @@
 #include <gtest/gtest.h>
 #include <pulsar/c/consumer_configuration.h>
 
+#include "climits"
+
 TEST(C_ConsumerConfigurationTest, testCApiConfig) {
     pulsar_consumer_configuration_t *consumer_conf = pulsar_consumer_configuration_create();
 

--- a/tests/c/c_ConsumerConfigurationTest.cc
+++ b/tests/c/c_ConsumerConfigurationTest.cc
@@ -51,19 +51,20 @@ TEST(C_ConsumerConfigurationTest, testCApiConfig) {
     ASSERT_EQ(get_batch_receive_policy.maxNumBytes, 1000);
     ASSERT_EQ(get_batch_receive_policy.timeoutMs, 1000);
 
-    pulsar_consumer_config_dead_letter_policy_t dlq_policy{.max_redeliver_count = 10};
+    pulsar_consumer_config_dead_letter_policy_t dlq_policy{NULL, 10, NULL};
     pulsar_consumer_configuration_set_dlq_policy(consumer_conf, &dlq_policy);
-    pulsar_consumer_config_dead_letter_policy_t get_dlq_policy =
-        pulsar_consumer_configuration_get_dlq_policy(consumer_conf);
+
+    pulsar_consumer_config_dead_letter_policy_t get_dlq_policy;
+    pulsar_consumer_configuration_get_dlq_policy(consumer_conf, &get_dlq_policy);
     ASSERT_EQ(get_dlq_policy.max_redeliver_count, 10);
     ASSERT_TRUE(get_dlq_policy.dead_letter_topic[0] == '\0');
     ASSERT_TRUE(get_dlq_policy.initial_subscription_name[0] == '\0');
 
-    pulsar_consumer_config_dead_letter_policy_t dlq_policy_2{"dlq-topic", 10, "init-sub"};
+    pulsar_consumer_config_dead_letter_policy_t dlq_policy_2{"dlq-topic", 0, "init-sub"};
     pulsar_consumer_configuration_set_dlq_policy(consumer_conf, &dlq_policy_2);
-    pulsar_consumer_config_dead_letter_policy_t get_dlq_policy_2 =
-        pulsar_consumer_configuration_get_dlq_policy(consumer_conf);
-    ASSERT_EQ(get_dlq_policy_2.max_redeliver_count, 10);
+    pulsar_consumer_config_dead_letter_policy_t get_dlq_policy_2;
+    pulsar_consumer_configuration_get_dlq_policy(consumer_conf, &get_dlq_policy_2);
+    ASSERT_EQ(get_dlq_policy_2.max_redeliver_count, INT_MAX);
     ASSERT_EQ(strcmp(get_dlq_policy_2.dead_letter_topic, "dlq-topic"), 0);
     ASSERT_EQ(strcmp(get_dlq_policy_2.initial_subscription_name, "init-sub"), 0);
 

--- a/tests/c/c_ConsumerTest.cc
+++ b/tests/c/c_ConsumerTest.cc
@@ -122,7 +122,7 @@ TEST(c_ConsumerTest, testBatchReceive) {
     pulsar_client_configuration_free(conf);
 }
 
-TEST(C_ConsumerConfigurationTest, testCDeadLetterTopic) {
+TEST(c_ConsumerTest, testCDeadLetterTopic) {
     const char *topic_name = "persistent://public/default/test-c-dlq-topic";
     const char *dlq_topic_name = "persistent://public/default/c-dlq-topic";
     const char *sub_name = "my-sub-name";
@@ -158,7 +158,7 @@ TEST(C_ConsumerConfigurationTest, testCDeadLetterTopic) {
 
     // Redelivery all messages
     for (int i = 1; i <= max_redeliver_count * num + num; ++i) {
-        pulsar_message_t *message = pulsar_message_create();
+        pulsar_message_t *message = NULL;
         pulsar_result res = pulsar_consumer_receive(consumer, &message);
         ASSERT_EQ(pulsar_result_Ok, res);
         if (i % num == 0) {
@@ -173,21 +173,16 @@ TEST(C_ConsumerConfigurationTest, testCDeadLetterTopic) {
     result = pulsar_client_subscribe(client, dlq_topic_name, sub_name, dlq_consumer_conf, &dlq_consumer);
     ASSERT_EQ(pulsar_result_Ok, result);
     for (int i = 0; i < num; ++i) {
-        pulsar_message_t *message = pulsar_message_create();
+        pulsar_message_t *message = NULL;
         pulsar_result res = pulsar_consumer_receive(dlq_consumer, &message);
         ASSERT_EQ(pulsar_result_Ok, res);
         pulsar_message_free(message);
     }
-    pulsar_message_t *message = pulsar_message_create();
+    pulsar_message_t *message = NULL;
     pulsar_result res = pulsar_consumer_receive_with_timeout(dlq_consumer, &message, 200);
     ASSERT_EQ(pulsar_result_Timeout, res);
     pulsar_message_free(message);
 
-    ASSERT_EQ(pulsar_result_Ok, pulsar_consumer_unsubscribe(consumer));
-    ASSERT_EQ(pulsar_result_AlreadyClosed, pulsar_consumer_close(consumer));
-    ASSERT_EQ(pulsar_result_Ok, pulsar_consumer_unsubscribe(dlq_consumer));
-    ASSERT_EQ(pulsar_result_AlreadyClosed, pulsar_consumer_close(dlq_consumer));
-    ASSERT_EQ(pulsar_result_Ok, pulsar_producer_close(producer));
     ASSERT_EQ(pulsar_result_Ok, pulsar_client_close(client));
 
     pulsar_consumer_free(consumer);


### PR DESCRIPTION
### Motivation

#114  Support dead letter topic for C client.

### Modifications

- Support pass dead letter topic policy by consumer config of C client.

### Verifying this change

- Add `testCDeadLetterTopic` to cover simple dlq case(other case cover by C++ test). 
- Enhance `testCApiConfig` to cover config set.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
