### PR TITLE
[fix][flaky] Remove zero queue case in ConsumerInterceptorTest to reduce flaky

### DIFF
--- a/tests/InterceptorsTest.cc
+++ b/tests/InterceptorsTest.cc
@@ -451,8 +451,8 @@ TEST_P(ConsumerInterceptorsTest, TestNegativeAcksSend) {
 }
 
 INSTANTIATE_TEST_CASE_P(Pulsar, ProducerInterceptorsTest, ::testing::Values(true, false));
-INSTANTIATE_TEST_CASE_P(Pulsar, ConsumerInterceptorsTest,
-                        testing::Values(
-                            // Can't use zero queue on multi topics consumer
-                            std::make_tuple(Single, 0), std::make_tuple(Single, 1000),
-                            std::make_tuple(Partitioned, 1000), std::make_tuple(Pattern, 1000)));
+INSTANTIATE_TEST_CASE_P(
+    Pulsar, ConsumerInterceptorsTest,
+    testing::Values(
+        // TODO: Add back zero queue test case when the permit issue of the zero consumer has benn fixed.
+        std::make_tuple(Single, 1000), std::make_tuple(Partitioned, 1000), std::make_tuple(Pattern, 1000)));


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

After discussed with @BewareMyPower and @shibd , there is a permit issue with the zero queue consumer. The permit for the zero queue consumer may somehow be greater than 1 and cause the test stuck. 

### Modifications

* Remove the zero queue case in ConsumerInterceptorTest to unblock the flaky test first. We will add back the case if the issue is fixed.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
