### PR TITLE
[Bug Fix][KeySharedPolicy] Fixed bug where KeySharedPolicy::setStickyRanges duplicated ranges.

### DIFF
--- a/include/pulsar/KeySharedPolicy.h
+++ b/include/pulsar/KeySharedPolicy.h
@@ -99,6 +99,12 @@ class PULSAR_PUBLIC KeySharedPolicy {
     KeySharedPolicy& setStickyRanges(std::initializer_list<StickyRange> ranges);
 
     /**
+     * @param ranges used with sticky mode
+     */
+    KeySharedPolicy& setStickyRanges(StickyRanges ranges);
+
+
+    /**
      * @return ranges used with sticky mode
      */
     StickyRanges getStickyRanges() const;

--- a/lib/KeySharedPolicy.cc
+++ b/lib/KeySharedPolicy.cc
@@ -51,7 +51,16 @@ KeySharedPolicy &KeySharedPolicy::setAllowOutOfOrderDelivery(bool allowOutOfOrde
 bool KeySharedPolicy::isAllowOutOfOrderDelivery() const { return impl_->allowOutOfOrderDelivery; }
 
 KeySharedPolicy &KeySharedPolicy::setStickyRanges(std::initializer_list<StickyRange> ranges) {
-    if (ranges.size() == 0) {
+    StickyRanges v;
+    for(StickyRange i:ranges)
+    {
+        v.push_back(i);
+    }
+    return this->setStickyRanges(v);
+}
+
+KeySharedPolicy &KeySharedPolicy::setStickyRanges(StickyRanges ranges) {
+    if (ranges.empty()) {
         throw std::invalid_argument("Ranges for KeyShared policy must not be empty.");
     }
     for (StickyRange range : ranges) {
@@ -65,9 +74,9 @@ KeySharedPolicy &KeySharedPolicy::setStickyRanges(std::initializer_list<StickyRa
                 throw std::invalid_argument("Ranges for KeyShared policy with overlap.");
             }
         }
-        for (StickyRange range : ranges) {
-            impl_->ranges.push_back(range);
-        }
+    }
+    for (StickyRange range : ranges) {
+        impl_->ranges.push_back(range);
     }
     return *this;
 }

--- a/tests/KeySharedPolicyTest.cc
+++ b/tests/KeySharedPolicyTest.cc
@@ -201,3 +201,25 @@ TEST_F(KeySharedPolicyTest, InvalidStickyRanges) {
     ASSERT_THROW(ksp.setStickyRanges({StickyRange(0, 65536)}), std::invalid_argument);
     ASSERT_THROW(ksp.setStickyRanges({StickyRange(0, 10), StickyRange(9, 20)}), std::invalid_argument);
 }
+
+TEST_F(KeySharedPolicyTest, testStickyConsumerExpected) {
+    // Test whether the saved range vector is as expected
+    KeySharedPolicy ksp;
+    ksp.setStickyRanges({StickyRange(0, 300), StickyRange(400, 500)});
+
+    std::vector<std::pair<int, int>> expectedStickyRange {{0, 300}, {400, 500}};
+    ASSERT_EQ(ksp.getStickyRanges(),expectedStickyRange);
+}
+
+TEST_F(KeySharedPolicyTest, testStickyConsumerVectors) {
+    // test whether the saved range vector is the same when using initializer_list or vector
+    KeySharedPolicy ksp;
+    ksp.setStickyRanges({StickyRange(0, 300), StickyRange(400, 500)});
+
+    KeySharedPolicy ksp2;
+    std::vector<std::pair<int, int>> stickyRangeVec {{0, 300}, {400, 500}};
+    ksp2.setStickyRanges(stickyRangeVec);
+
+    ASSERT_EQ(ksp.getStickyRanges(), ksp2.getStickyRanges());
+
+}


### PR DESCRIPTION
*[fix] Fixed bug where KeySharedPolicy::setStickyRanges appended duplicate ranges to KeySharedPolicy->ranges. The for loop was nested when it shouldn't have been nested. 

This fixes the issue #241 

*Added a test that checks to see if the KeySharedPolicy->ranges variable is set as expected after calling KeySharedPolicy::setStickyRanges

*Added overloaded KeySharedPolicy::setStickyRanges function that takes the StickyRanges vector. This is convenient in case a developer wants to provide a vector. It is also required for adding KeySharedPolicy to the python pulsar client which uses pybind11. std::initializer_list type conversion is not supported with pybind11. See https://github.com/pybind/pybind11/issues/1302#issuecomment-369090893
I am in the process of adding support for KeySharedPolicy to the python-pulsar-client and will submit a pr soon.

*Added a test that checks to see if the KeySharedPolicy->ranges variable is the same when using the two different overloaded KeySharedPolicy::setStickyRanges functions.

### Modifications

Moved for loop in KeySharedPolicy::setStickyRanges to unnested location to eliminate duplicate vector entries.

Added simple overloaded version of the same function that a parameter of type StickyRanges in addition to existing function that takes a parameter of type std::initializer_list<StickyRange>

Added two new tests in KeySharedPolicyTest.cc to validate the changes.

### Verifying this change

This change added tests and can be verified as follows:

Added two new tests in KeySharedPolicyTest.cc to validate the changes.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ *] `doc-not-needed` 
(Please explain why)
Bug fix did not change functionality in any new ways that are not covered by existing documentation.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
