### PR TITLE
[fix] Fix compilation error that occurs when USE_LOG4CXX is ON

### DIFF
--- a/lib/Log4cxxLogger.cc
+++ b/lib/Log4cxxLogger.cc
@@ -59,6 +59,8 @@ class Log4CxxLogger : public Logger {
                 return log4cxx::Level::getWarn();
             case LEVEL_ERROR:
                 return log4cxx::Level::getError();
+            default:
+                return log4cxx::Level::getInfo();
         }
     }
 };


### PR DESCRIPTION
### Motivation

When I tried to compile with the USE_LOG4CXX option ON, it failed with the following error:
```
/pulsar-client-cpp/lib/Log4cxxLogger.cc: In static member function 'static log4cxx::LevelPtr pulsar::Log4CxxLogger::getLevel(pulsar::Logger::Level)':
/pulsar-client-cpp/lib/Log4cxxLogger.cc:63:5: error: control reaches end of non-void function [-Werror=return-type]
     }
     ^
```

The reason seems to be that there is no `default` branch in the `switch` statement in `Log4CxxLogger::getLevel`, and control may reach the end of the function without returning anything.
https://github.com/apache/pulsar-client-cpp/blob/872f8abaade7ecd346d3f59e2f6b3901c65ef7de/lib/Log4cxxLogger.cc#L52-L63

### Modifications

Added the `default` branch to the `switch` statement. This branch returns INFO.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)