### PR TITLE
[feat] Support set batch index ack for C client.

### DIFF
--- a/include/pulsar/c/consumer_configuration.h
+++ b/include/pulsar/c/consumer_configuration.h
@@ -304,6 +304,12 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_start_message_id_inclusive(
 PULSAR_PUBLIC int pulsar_consumer_configuration_is_start_message_id_inclusive(
     pulsar_consumer_configuration_t *consumer_configuration);
 
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_batch_index_ack_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration, int enabled);
+
+PULSAR_PUBLIC int pulsar_consumer_configuration_is_batch_index_ack_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration);
+
 // const CryptoKeyReaderPtr getCryptoKeyReader()
 //
 // const;

--- a/lib/c/c_ConsumerConfiguration.cc
+++ b/lib/c/c_ConsumerConfiguration.cc
@@ -227,3 +227,13 @@ int pulsar_consumer_configuration_is_start_message_id_inclusive(
     pulsar_consumer_configuration_t *consumer_configuration) {
     return consumer_configuration->consumerConfiguration.isStartMessageIdInclusive();
 }
+
+void pulsar_consumer_configuration_set_batch_index_ack_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration, int enabled) {
+    consumer_configuration->consumerConfiguration.setBatchIndexAckEnabled(enabled);
+}
+
+int pulsar_consumer_configuration_is_batch_index_ack_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration) {
+    return consumer_configuration->consumerConfiguration.isBatchIndexAckEnabled();
+}

--- a/tests/c/c_ConsumerConfigurationTest.cc
+++ b/tests/c/c_ConsumerConfigurationTest.cc
@@ -34,4 +34,7 @@ TEST(C_ConsumerConfigurationTest, testCApiConfig) {
 
     pulsar_consumer_configuration_set_start_message_id_inclusive(consumer_conf, 1);
     ASSERT_EQ(pulsar_consumer_configuration_is_start_message_id_inclusive(consumer_conf), 1);
+
+    pulsar_consumer_configuration_set_batch_index_ack_enabled(consumer_conf, 1);
+    ASSERT_EQ(pulsar_consumer_configuration_is_batch_index_ack_enabled(consumer_conf), 1);
 }


### PR DESCRIPTION
### Motivation
Support set batch index ack for C client.

### Modifications

- Add get and set batch index ack enabled method.

### Verifying this change

- `C_ConsumerConfigurationTest`  to cover set and get batch index ack enabled, other features are covered by C++ unit tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
