### PR TITLE
[feat] Support set consumer regex subscription mode for C client.

### DIFF
--- a/include/pulsar/c/consumer_configuration.h
+++ b/include/pulsar/c/consumer_configuration.h
@@ -79,6 +79,16 @@ typedef enum
     pulsar_ConsumerConsume
 } pulsar_consumer_crypto_failure_action;
 
+typedef enum
+{
+    // Only subscribe to persistent topics.
+    pulsar_consumer_regex_sub_mode_PersistentOnly = 0,
+    // Only subscribe to non-persistent topics.
+    pulsar_consumer_regex_sub_mode_NonPersistentOnly = 1,
+    // Subscribe to both persistent and non-persistent topics.
+    pulsar_consumer_regex_sub_mode_AllTopics = 2
+} pulsar_consumer_regex_subscription_mode;
+
 /// Callback definition for MessageListener
 typedef void (*pulsar_message_listener)(pulsar_consumer_t *consumer, pulsar_message_t *msg, void *ctx);
 
@@ -308,6 +318,14 @@ PULSAR_PUBLIC void pulsar_consumer_configuration_set_batch_index_ack_enabled(
     pulsar_consumer_configuration_t *consumer_configuration, int enabled);
 
 PULSAR_PUBLIC int pulsar_consumer_configuration_is_batch_index_ack_enabled(
+    pulsar_consumer_configuration_t *consumer_configuration);
+
+PULSAR_PUBLIC void pulsar_consumer_configuration_set_regex_subscription_mode(
+    pulsar_consumer_configuration_t *consumer_configuration,
+    pulsar_consumer_regex_subscription_mode regex_sub_mode);
+
+PULSAR_PUBLIC pulsar_consumer_regex_subscription_mode
+pulsar_consumer_configuration_get_regex_subscription_mode(
     pulsar_consumer_configuration_t *consumer_configuration);
 
 // const CryptoKeyReaderPtr getCryptoKeyReader()

--- a/lib/c/c_ConsumerConfiguration.cc
+++ b/lib/c/c_ConsumerConfiguration.cc
@@ -237,3 +237,16 @@ int pulsar_consumer_configuration_is_batch_index_ack_enabled(
     pulsar_consumer_configuration_t *consumer_configuration) {
     return consumer_configuration->consumerConfiguration.isBatchIndexAckEnabled();
 }
+
+void pulsar_consumer_configuration_set_regex_subscription_mode(
+    pulsar_consumer_configuration_t *consumer_configuration,
+    pulsar_consumer_regex_subscription_mode regex_sub_mode) {
+    consumer_configuration->consumerConfiguration.setRegexSubscriptionMode(
+        (pulsar::RegexSubscriptionMode)regex_sub_mode);
+}
+
+pulsar_consumer_regex_subscription_mode pulsar_consumer_configuration_get_regex_subscription_mode(
+    pulsar_consumer_configuration_t *consumer_configuration) {
+    return (pulsar_consumer_regex_subscription_mode)
+        consumer_configuration->consumerConfiguration.getRegexSubscriptionMode();
+}

--- a/tests/c/c_ConsumerConfigurationTest.cc
+++ b/tests/c/c_ConsumerConfigurationTest.cc
@@ -37,4 +37,9 @@ TEST(C_ConsumerConfigurationTest, testCApiConfig) {
 
     pulsar_consumer_configuration_set_batch_index_ack_enabled(consumer_conf, 1);
     ASSERT_EQ(pulsar_consumer_configuration_is_batch_index_ack_enabled(consumer_conf), 1);
+
+    pulsar_consumer_configuration_set_regex_subscription_mode(
+        consumer_conf, pulsar_consumer_regex_sub_mode_NonPersistentOnly);
+    ASSERT_EQ(pulsar_consumer_configuration_get_regex_subscription_mode(consumer_conf),
+              pulsar_consumer_regex_sub_mode_NonPersistentOnly);
 }


### PR DESCRIPTION
### Motivation

- Support set consumer regex subscription mode for C client.

### Modifications

- Add get and set `pulsar_consumer_regex_subscription_mode` method.

### Verifying this change

- C_ConsumerConfigurationTest to cover set and get `pulsar_consumer_regex_subscription_mode`, other features are covered by C++ unit tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
