### PR TITLE
[cleanup] Remove useless variable `interceptors_` in `ProducerImplBase`

### DIFF
--- a/lib/ProducerImplBase.h
+++ b/lib/ProducerImplBase.h
@@ -49,9 +49,6 @@ class ProducerImplBase {
     virtual void flushAsync(FlushCallback callback) = 0;
     virtual bool isConnected() const = 0;
     virtual uint64_t getNumberOfConnectedProducer() = 0;
-
-   protected:
-    ProducerInterceptorsPtr interceptors_;
 };
 }  // namespace pulsar
 #endif  // PULSAR_PRODUCER_IMPL_BASE_HEADER


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

The variable `interceptors_` in `ProducerImplBase` is useless. This PR cleans up the code.

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
