### PR TITLE
[C API] Support synchronous consumer batch receive

### DIFF
--- a/include/pulsar/c/consumer.h
+++ b/include/pulsar/c/consumer.h
@@ -114,8 +114,7 @@ PULSAR_PUBLIC void pulsar_consumer_receive_async(pulsar_consumer_t *consumer,
  * NOTE:
  * 1. When it's received successfully, `*msg` will point to the memory that is allocated internally. You
  * have to call `pulsar_messages_free` to free it.
- * 2. Otherwise, `*msgs` will be set to NULL.
- * 3. Undefined behavior will happen if `msgs` is NULL.
+ * 2. Undefined behavior will happen if `msgs` is NULL.
  */
 PULSAR_PUBLIC pulsar_result pulsar_consumer_batch_receive(pulsar_consumer_t *consumer,
                                                           pulsar_messages_t **msgs);

--- a/include/pulsar/c/consumer.h
+++ b/include/pulsar/c/consumer.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 #include <pulsar/c/message.h>
+#include <pulsar/c/messages.h>
 #include <pulsar/c/result.h>
 #include <stdint.h>
 
@@ -106,6 +107,18 @@ PULSAR_PUBLIC pulsar_result pulsar_consumer_receive_with_timeout(pulsar_consumer
  */
 PULSAR_PUBLIC void pulsar_consumer_receive_async(pulsar_consumer_t *consumer,
                                                  pulsar_receive_callback callback, void *ctx);
+
+/**
+ * Batch receiving messages.
+ *
+ * NOTE:
+ * 1. When it's received successfully, `*msg` will point to the memory that is allocated internally. You
+ * have to call `pulsar_messages_free` to free it.
+ * 2. Otherwise, `*msgs` will be set to NULL.
+ * 3. Undefined behavior will happen if `msgs` is NULL.
+ */
+PULSAR_PUBLIC pulsar_result pulsar_consumer_batch_receive(pulsar_consumer_t *consumer,
+                                                          pulsar_messages_t **msgs);
 
 /**
  * Acknowledge the reception of a single message.

--- a/include/pulsar/c/messages.h
+++ b/include/pulsar/c/messages.h
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <pulsar/c/message.h>
+#include <pulsar/defines.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _pulsar_messages pulsar_messages_t;
+
+/**
+ * Get the number of messages.
+ *
+ * NOTE: Undefined behavior will happen if `msgs` is NULL.
+ */
+PULSAR_PUBLIC size_t pulsar_messages_size(pulsar_messages_t* msgs);
+
+/**
+ * Get the Nth message according to the given index.
+ *
+ * NOTE:
+ * 1. You should not free the returned pointer, which always points to a valid memory unless `msgs` is freed.
+ * 2. Undefined behavior will happen if `msgs` is NULL or `index` is not smaller than the number of messages.
+ */
+PULSAR_PUBLIC pulsar_message_t* pulsar_message_get(pulsar_messages_t* msgs, size_t index);
+
+PULSAR_PUBLIC void pulsar_messages_free(pulsar_messages_t* msgs);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/pulsar/c/messages.h
+++ b/include/pulsar/c/messages.h
@@ -42,7 +42,7 @@ PULSAR_PUBLIC size_t pulsar_messages_size(pulsar_messages_t* msgs);
  * 1. You should not free the returned pointer, which always points to a valid memory unless `msgs` is freed.
  * 2. Undefined behavior will happen if `msgs` is NULL or `index` is not smaller than the number of messages.
  */
-PULSAR_PUBLIC pulsar_message_t* pulsar_message_get(pulsar_messages_t* msgs, size_t index);
+PULSAR_PUBLIC pulsar_message_t* pulsar_messages_get(pulsar_messages_t* msgs, size_t index);
 
 PULSAR_PUBLIC void pulsar_messages_free(pulsar_messages_t* msgs);
 

--- a/lib/c/c_Consumer.cc
+++ b/lib/c/c_Consumer.cc
@@ -60,6 +60,19 @@ pulsar_result pulsar_consumer_receive_with_timeout(pulsar_consumer_t *consumer, 
     return (pulsar_result)res;
 }
 
+pulsar_result pulsar_consumer_batch_receive(pulsar_consumer_t *consumer, pulsar_messages_t **msgs) {
+    pulsar::Messages messages;
+    pulsar::Result res = consumer->consumer.batchReceive(messages);
+    if (res == pulsar::ResultOk) {
+        (*msgs) = new pulsar_messages_t;
+        (*msgs)->messages.resize(messages.size());
+        for (size_t i = 0; i < messages.size(); i++) {
+            (*msgs)->messages[i].message = messages[i];
+        }
+    }
+    return (pulsar_result)res;
+}
+
 static void handle_receive_callback(pulsar::Result result, pulsar::Message message,
                                     pulsar_receive_callback callback, void *ctx) {
     if (callback) {

--- a/lib/c/c_Messages.cc
+++ b/lib/c/c_Messages.cc
@@ -22,6 +22,8 @@
 
 size_t pulsar_messages_size(pulsar_messages_t* msgs) { return msgs->messages.size(); }
 
-pulsar_message_t* pulsar_message_get(pulsar_messages_t* msgs, size_t index) { return &msgs->messages[index]; }
+pulsar_message_t* pulsar_messages_get(pulsar_messages_t* msgs, size_t index) {
+    return &msgs->messages[index];
+}
 
 void pulsar_messages_free(pulsar_messages_t* msgs) { delete msgs; }

--- a/lib/c/c_Messages.cc
+++ b/lib/c/c_Messages.cc
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <pulsar/c/messages.h>
+
+#include "lib/c/c_structs.h"
+
+size_t pulsar_messages_size(pulsar_messages_t* msgs) { return msgs->messages.size(); }
+
+pulsar_message_t* pulsar_message_get(pulsar_messages_t* msgs, size_t index) { return &msgs->messages[index]; }
+
+void pulsar_messages_free(pulsar_messages_t* msgs) { delete msgs; }

--- a/lib/c/c_structs.h
+++ b/lib/c/c_structs.h
@@ -65,6 +65,10 @@ struct _pulsar_message_id {
     pulsar::MessageId messageId;
 };
 
+struct _pulsar_messages {
+    std::vector<_pulsar_message> messages;
+};
+
 struct _pulsar_authentication {
     pulsar::AuthenticationPtr auth;
 };

--- a/tests/c/c_ConsumerTest.cc
+++ b/tests/c/c_ConsumerTest.cc
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/c/client.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static const char *lookup_url = "pulsar://localhost:6650";
+
+TEST(c_ConsumerTest, testBatchReceive) {
+    pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
+    pulsar_client_t *client = pulsar_client_create(lookup_url, conf);
+
+    char topic[128];
+    snprintf(topic, sizeof(topic), "c-consumer-test-batch-receive-%ld", time(NULL));
+
+    pulsar_producer_configuration_t *producer_conf = pulsar_producer_configuration_create();
+    pulsar_producer_t *producer;
+    pulsar_result result = pulsar_client_create_producer(client, topic, producer_conf, &producer);
+    ASSERT_EQ(pulsar_result_Ok, result);
+
+    pulsar_consumer_configuration_t *consumer_conf = pulsar_consumer_configuration_create();
+    pulsar_consumer_t *consumer;
+    result = pulsar_client_subscribe(client, topic, "sub", consumer_conf, &consumer);
+    ASSERT_EQ(pulsar_result_Ok, result);
+
+    const int num_messages = 10;
+    for (int i = 0; i < num_messages; i++) {
+        pulsar_message_t *msg = pulsar_message_create();
+        char buf[128];
+        snprintf(buf, sizeof(buf), "msg-%d", i);
+        pulsar_message_set_content(msg, buf, strlen(buf) + 1);
+        ASSERT_EQ(pulsar_result_Ok, pulsar_producer_send(producer, msg));
+        pulsar_message_free(msg);
+    }
+
+    pulsar_messages_t *msgs = NULL;
+    ASSERT_EQ(pulsar_result_Ok, pulsar_consumer_batch_receive(consumer, &msgs));
+    ASSERT_EQ(pulsar_messages_size(msgs), num_messages);
+    for (int i = 0; i < num_messages; i++) {
+        pulsar_message_t *msg = pulsar_message_get(msgs, i);
+        size_t length = pulsar_message_get_length(msg);
+        char *str = (char *)malloc(pulsar_message_get_length(msg));
+        strncpy(str, (const char *)pulsar_message_get_data(msg), length);
+
+        char expected_str[128];
+        snprintf(expected_str, sizeof(expected_str), "msg-%d", i);
+        printf("%d received: %s (%zd), expected: %s (%zd)\n", i, str, strlen(str), expected_str,
+               strlen(expected_str));
+        ASSERT_EQ(strcmp(str, expected_str), 0);
+
+        free(str);
+    }
+
+    pulsar_client_close(client);
+    pulsar_messages_free(msgs);
+    pulsar_consumer_free(consumer);
+    pulsar_consumer_configuration_free(consumer_conf);
+    pulsar_producer_free(producer);
+    pulsar_producer_configuration_free(producer_conf);
+    pulsar_client_free(client);
+    pulsar_client_configuration_free(conf);
+}

--- a/tests/c/c_ConsumerTest.cc
+++ b/tests/c/c_ConsumerTest.cc
@@ -56,7 +56,7 @@ TEST(c_ConsumerTest, testBatchReceive) {
     ASSERT_EQ(pulsar_result_Ok, pulsar_consumer_batch_receive(consumer, &msgs));
     ASSERT_EQ(pulsar_messages_size(msgs), num_messages);
     for (int i = 0; i < num_messages; i++) {
-        pulsar_message_t *msg = pulsar_message_get(msgs, i);
+        pulsar_message_t *msg = pulsar_messages_get(msgs, i);
         size_t length = pulsar_message_get_length(msg);
         char *str = (char *)malloc(pulsar_message_get_length(msg));
         strncpy(str, (const char *)pulsar_message_get_data(msg), length);


### PR DESCRIPTION
### Motivation

This is the 1st PR to support the batch receive feature for C APIs.

### Modifications

- Add the `pulsar_messages_t` struct to represent a list of messages
- Add the `pulsar_messages_get` and `pulsar_messages_size` functions to traverse all messages in `pulsar_messages_t`
- Add the `pulsar_consumer_batch_receive` function to receive messages in batch and the `pulsar_messages_free` function to free the allocated memory.
- Add `c_ConsumerTest.testBatchReceive` to test batch receive.

### Verifications

There is no memory leak in the test:

```bash
$ valgrind --leak-check=full ./tests/pulsar-tests --gtest_filter='c_ConsumerTest.*'
...
==3019==    definitely lost: 0 bytes in 0 blocks
==3019==    indirectly lost: 0 bytes in 0 blocks
==3019==      possibly lost: 0 bytes in 0 blocks
```

### TODO

- Batch receive policy
- Asynchronous batch receive
- Fix memory leak in other C tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
