### PR TITLE
PIP-254: Support configuring client version with a description suffix

### DIFF
--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -329,6 +329,42 @@ class PULSAR_PUBLIC ClientConfiguration {
    private:
     const AuthenticationPtr& getAuthPtr() const;
     std::shared_ptr<ClientConfigurationImpl> impl_;
+
+    // By default, when the client connects to the broker, a version string like "Pulsar-CPP-v<x.y.z>" will be
+    // carried and saved by the broker. The client version string could be queried from the topic stats.
+    //
+    // This method provides a way to add more description to a specific `Client` instance. If it's configured,
+    // the description will be appended to the original client version string, with '-' as the separator.
+    //
+    // For example, if the client version is 3.2.0, and the description is "forked", the final client version
+    // string will be "Pulsar-CPP-v3.2.0-forked".
+    //
+    // NOTE: This method should only be called by the PulsarWrapper and the length should not exceed 64.
+    //
+    // For example, you can add a PulsarWrapper class like:
+    //
+    // ```c++
+    // namespace pulsar {
+    // class PulsarWrapper {
+    //     static ClientConfiguration clientConfig() {
+    //         ClientConfiguration conf;
+    //         conf.setDescription("forked");
+    //         return conf;
+    //     }
+    // };
+    // }
+    // ```
+    //
+    // Then, call the method before passing the `conf` to the constructor of `Client`:
+    //
+    // ```c++
+    // auto conf = PulsarWrapper::clientConfig();
+    // // Set other attributes of `conf` here...
+    // Client client{"pulsar://localhost:6650", conf);
+    // ```
+    ClientConfiguration& setDescription(const std::string& description);
+
+    const std::string& getDescription() const noexcept;
 };
 }  // namespace pulsar
 

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <stdexcept>
+
 #include "ClientConfigurationImpl.h"
 
 namespace pulsar {
@@ -188,5 +190,15 @@ ClientConfiguration& ClientConfiguration::setConnectionTimeout(int timeoutMs) {
 }
 
 int ClientConfiguration::getConnectionTimeout() const { return impl_->connectionTimeoutMs; }
+
+ClientConfiguration& ClientConfiguration::setDescription(const std::string& description) {
+    if (description.length() > 64) {
+        throw std::invalid_argument("The description length exceeds 64");
+    }
+    impl_->description = description;
+    return *this;
+}
+
+const std::string& ClientConfiguration::getDescription() const noexcept { return impl_->description; }
 
 }  // namespace pulsar

--- a/lib/ClientConfigurationImpl.h
+++ b/lib/ClientConfigurationImpl.h
@@ -45,6 +45,7 @@ struct ClientConfigurationImpl {
     unsigned int partitionsUpdateInterval{60};  // 1 minute
     std::string listenerName;
     int connectionTimeoutMs{10000};  // 10 seconds
+    std::string description;
 
     std::unique_ptr<LoggerFactory> takeLogger() { return std::move(loggerFactory); }
 };

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -127,7 +127,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
      */
     ClientConnection(const std::string& logicalAddress, const std::string& physicalAddress,
                      ExecutorServicePtr executor, const ClientConfiguration& clientConfiguration,
-                     const AuthenticationPtr& authentication);
+                     const AuthenticationPtr& authentication, const std::string& clientVersion);
     ~ClientConnection();
 
     /*
@@ -372,9 +372,11 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     void startConsumerStatsTimer(std::vector<uint64_t> consumerStatsRequests);
     uint32_t maxPendingLookupRequest_;
     uint32_t numOfPendingLookupRequest_ = 0;
-    friend class PulsarFriend;
 
     bool isTlsAllowInsecureConnection_ = false;
+
+    const std::string clientVersion_;
+    friend class PulsarFriend;
 
     void closeSocket();
     void checkServerError(ServerError error);

--- a/lib/ClientImpl.cc
+++ b/lib/ClientImpl.cc
@@ -19,8 +19,10 @@
 #include "ClientImpl.h"
 
 #include <pulsar/ClientConfiguration.h>
+#include <pulsar/Version.h>
 
 #include <random>
+#include <sstream>
 
 #include "BinaryProtoLookupService.h"
 #include "ClientConfigurationImpl.h"
@@ -89,7 +91,8 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
           std::make_shared<ExecutorServiceProvider>(clientConfiguration_.getMessageListenerThreads())),
       partitionListenerExecutorProvider_(
           std::make_shared<ExecutorServiceProvider>(clientConfiguration_.getMessageListenerThreads())),
-      pool_(clientConfiguration_, ioExecutorProvider_, clientConfiguration_.getAuthPtr(), poolConnections),
+      pool_(clientConfiguration_, ioExecutorProvider_, clientConfiguration_.getAuthPtr(), poolConnections,
+            ClientImpl::getClientVersion(clientConfiguration)),
       producerIdGenerator_(0),
       consumerIdGenerator_(0),
       closingError(ResultOk) {
@@ -761,5 +764,14 @@ uint64_t ClientImpl::getNumberOfConsumers() {
 }
 
 const ClientConfiguration& ClientImpl::getClientConfig() const { return clientConfiguration_; }
+
+std::string ClientImpl::getClientVersion(const ClientConfiguration& clientConfiguration) {
+    std::ostringstream oss;
+    oss << "Pulsar-CPP-v" << PULSAR_VERSION_STR;
+    if (!clientConfiguration.getDescription().empty()) {
+        oss << "-" << clientConfiguration.getDescription();
+    }
+    return oss.str();
+}
 
 } /* namespace pulsar */

--- a/lib/ClientImpl.h
+++ b/lib/ClientImpl.h
@@ -157,6 +157,8 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
                                           const std::string& consumerName, const ConsumerConfiguration& conf,
                                           SubscribeCallback callback);
 
+    static std::string getClientVersion(const ClientConfiguration& clientConfiguration);
+
     enum State
     {
         Open,

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -262,11 +262,12 @@ PairSharedBuffer Commands::newSend(SharedBuffer& headers, BaseCommand& cmd, uint
 }
 
 SharedBuffer Commands::newConnect(const AuthenticationPtr& authentication, const std::string& logicalAddress,
-                                  bool connectingThroughProxy, Result& result) {
+                                  bool connectingThroughProxy, const std::string& clientVersion,
+                                  Result& result) {
     BaseCommand cmd;
     cmd.set_type(BaseCommand::CONNECT);
     CommandConnect* connect = cmd.mutable_connect();
-    connect->set_client_version(std::string("Pulsar-CPP-v") + PULSAR_VERSION_STR);
+    connect->set_client_version(clientVersion);
     connect->set_auth_method_name(authentication->getAuthMethodName());
     connect->set_protocol_version(ProtocolVersion_MAX);
 

--- a/lib/Commands.h
+++ b/lib/Commands.h
@@ -82,7 +82,8 @@ class Commands {
     const static int checksumSize = 4;
 
     static SharedBuffer newConnect(const AuthenticationPtr& authentication, const std::string& logicalAddress,
-                                   bool connectingThroughProxy, Result& result);
+                                   bool connectingThroughProxy, const std::string& clientVersion,
+                                   Result& result);
 
     static SharedBuffer newAuthResponse(const AuthenticationPtr& authentication, Result& result);
 

--- a/lib/ConnectionPool.cc
+++ b/lib/ConnectionPool.cc
@@ -34,13 +34,13 @@ DECLARE_LOG_OBJECT()
 namespace pulsar {
 
 ConnectionPool::ConnectionPool(const ClientConfiguration& conf, ExecutorServiceProviderPtr executorProvider,
-                               const AuthenticationPtr& authentication, bool poolConnections)
+                               const AuthenticationPtr& authentication, bool poolConnections,
+                               const std::string& clientVersion)
     : clientConfiguration_(conf),
       executorProvider_(executorProvider),
       authentication_(authentication),
-      pool_(),
       poolConnections_(poolConnections),
-      mutex_() {}
+      clientVersion_(clientVersion) {}
 
 bool ConnectionPool::close() {
     bool expectedState = false;
@@ -94,7 +94,7 @@ Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(
     ClientConnectionPtr cnx;
     try {
         cnx.reset(new ClientConnection(logicalAddress, physicalAddress, executorProvider_->get(),
-                                       clientConfiguration_, authentication_));
+                                       clientConfiguration_, authentication_, clientVersion_));
     } catch (const std::runtime_error& e) {
         lock.unlock();
         LOG_ERROR("Failed to create connection: " << e.what())

--- a/lib/ConnectionPool.h
+++ b/lib/ConnectionPool.h
@@ -41,7 +41,8 @@ using ExecutorServiceProviderPtr = std::shared_ptr<ExecutorServiceProvider>;
 class PULSAR_PUBLIC ConnectionPool {
    public:
     ConnectionPool(const ClientConfiguration& conf, ExecutorServiceProviderPtr executorProvider,
-                   const AuthenticationPtr& authentication, bool poolConnections = true);
+                   const AuthenticationPtr& authentication, bool poolConnections,
+                   const std::string& clientVersion);
 
     /**
      * Close the connection pool.
@@ -80,6 +81,7 @@ class PULSAR_PUBLIC ConnectionPool {
     typedef std::map<std::string, ClientConnectionWeakPtr> PoolMap;
     PoolMap pool_;
     bool poolConnections_;
+    const std::string clientVersion_;
     mutable std::mutex mutex_;
     std::atomic_bool closed_{false};
 

--- a/tests/LookupServiceTest.cc
+++ b/tests/LookupServiceTest.cc
@@ -48,7 +48,7 @@ TEST(LookupServiceTest, basicLookup) {
     std::string url = "pulsar://localhost:6650";
     ClientConfiguration conf;
     ExecutorServiceProviderPtr ioExecutorProvider_(std::make_shared<ExecutorServiceProvider>(1));
-    ConnectionPool pool_(conf, ioExecutorProvider_, authData, true);
+    ConnectionPool pool_(conf, ioExecutorProvider_, authData, true, "");
     ServiceNameResolver serviceNameResolver(url);
     BinaryProtoLookupService lookupService(serviceNameResolver, pool_, conf);
 
@@ -112,7 +112,7 @@ static void testMultiAddresses(LookupService& lookupService) {
 }
 
 TEST(LookupServiceTest, testMultiAddresses) {
-    ConnectionPool pool({}, std::make_shared<ExecutorServiceProvider>(1), AuthFactory::Disabled(), true);
+    ConnectionPool pool({}, std::make_shared<ExecutorServiceProvider>(1), AuthFactory::Disabled(), true, "");
     ServiceNameResolver serviceNameResolver("pulsar://localhost,localhost:9999");
     ClientConfiguration conf;
     BinaryProtoLookupService binaryLookupService(serviceNameResolver, pool, conf);
@@ -126,7 +126,7 @@ TEST(LookupServiceTest, testMultiAddresses) {
 }
 TEST(LookupServiceTest, testRetry) {
     auto executorProvider = std::make_shared<ExecutorServiceProvider>(1);
-    ConnectionPool pool({}, executorProvider, AuthFactory::Disabled(), true);
+    ConnectionPool pool({}, executorProvider, AuthFactory::Disabled(), true, "");
     ServiceNameResolver serviceNameResolver("pulsar://localhost:9999,localhost");
     ClientConfiguration conf;
 
@@ -178,7 +178,7 @@ TEST(LookupServiceTest, testRetry) {
 
 TEST(LookupServiceTest, testTimeout) {
     auto executorProvider = std::make_shared<ExecutorServiceProvider>(1);
-    ConnectionPool pool({}, executorProvider, AuthFactory::Disabled(), true);
+    ConnectionPool pool({}, executorProvider, AuthFactory::Disabled(), true, "");
     ServiceNameResolver serviceNameResolver("pulsar://localhost:9990,localhost:9902,localhost:9904");
     ClientConfiguration conf;
 
@@ -361,7 +361,7 @@ TEST(LookupServiceTest, testRedirectionLimit) {
     ClientConfiguration conf;
     conf.setMaxLookupRedirects(redirect_limit);
     ExecutorServiceProviderPtr ioExecutorProvider_(std::make_shared<ExecutorServiceProvider>(1));
-    ConnectionPool pool_(conf, ioExecutorProvider_, authData, true);
+    ConnectionPool pool_(conf, ioExecutorProvider_, authData, true, "");
     std::string url = "pulsar://localhost:6650";
     ServiceNameResolver serviceNameResolver(url);
     BinaryProtoLookupServiceRedirectTestHelper lookupService(serviceNameResolver, pool_, conf);


### PR DESCRIPTION
### Motivation

The C++ catch up of [PIP-254](https://github.com/apache/pulsar/issues/19705)

### Modifications

Different from the Java implementation, this PR adds private methods to set or get the description in `ClientConfiguration`. Since `PulsarWrapper` is used as a friend class of nearly all public classes, the 3rd party library that is based on the C++ SDK can set the description by defining a `PulsarWrapper` class.

For the `ConnectionPool` and any `ClientConnection` instance created, store the client version and pass it into `Commands::newConnect`.

Modify the `ClientTest.testClientVersion` to verify the changes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
