### PR TITLE
Fix broken debian package build process

### DIFF
--- a/pkg/deb/Dockerfile
+++ b/pkg/deb/Dockerfile
@@ -19,7 +19,7 @@
 
 # Build pulsar client library in Centos with tools to
 
-FROM debian:9
+FROM debian:10
 
 ARG PLATFORM
 


### PR DESCRIPTION
### Motivation

Currently the debian package build is broken because `apt-get update` encountered 404 error. The base image is `debian:9`, which reached the EOL (June 30, 2022).

### Modifications

Upgrade the base image to `debian:10`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
