### PR TITLE
[doc] Fix compile perf on MacOS and Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ cmake .
 make
 ```
 
+If you want to run performance, you need to run:
+
+```shell
+cmake . -DBUILD_PERF_TOOLS=ON
+make
+```
+
 #### Checks
 
 Client library will be placed in:
@@ -94,6 +101,11 @@ Client library will be placed in:
 ```
 lib/libpulsar.so
 lib/libpulsar.a
+```
+Examples can be run on:
+
+```
+examples/
 ```
 
 Tools will be placed in:
@@ -118,6 +130,13 @@ cmake .
 make
 ```
 
+If you want to run performance, you need to run:
+
+```shell
+cmake . -DBUILD_PERF_TOOLS=ON
+make
+```
+
 #### Checks
 
 Client library will be placed in:
@@ -125,6 +144,12 @@ Client library will be placed in:
 ```
 lib/libpulsar.dylib
 lib/libpulsar.a
+```
+
+Examples can be run on:
+
+```
+examples/
 ```
 
 Tools will be placed in:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cmake .
 make
 ```
 
-If you want to run performance, you need to run:
+If you want to build performance tools, you need to run:
 
 ```shell
 cmake . -DBUILD_PERF_TOOLS=ON
@@ -102,7 +102,8 @@ Client library will be placed in:
 lib/libpulsar.so
 lib/libpulsar.a
 ```
-Examples can be run on:
+
+Examples will be placed in:
 
 ```
 examples/
@@ -130,7 +131,7 @@ cmake .
 make
 ```
 
-If you want to run performance, you need to run:
+If you want to build performance tools, you need to run:
 
 ```shell
 cmake . -DBUILD_PERF_TOOLS=ON
@@ -146,7 +147,7 @@ lib/libpulsar.dylib
 lib/libpulsar.a
 ```
 
-Examples can be run on:
+Examples will be placed in:
 
 ```
 examples/


### PR DESCRIPTION
### Motivation

On README, currently not introduced how to compile `perf`.

### Modifications

-  Introduced how to compile `perf`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
