### PR TITLE
Fix deadlock for negative acknowledgment

### DIFF
--- a/lib/NegativeAcksTracker.h
+++ b/lib/NegativeAcksTracker.h
@@ -22,6 +22,7 @@
 #include <pulsar/ConsumerConfiguration.h>
 #include <pulsar/MessageId.h>
 
+#include <atomic>
 #include <boost/asio/deadline_timer.hpp>
 #include <chrono>
 #include <map>
@@ -65,9 +66,9 @@ class NegativeAcksTracker {
     typedef typename std::chrono::steady_clock Clock;
     std::map<MessageId, Clock::time_point> nackedMessages_;
 
-    ExecutorServicePtr executor_;
-    DeadlineTimerPtr timer_;
-    bool enabledForTesting_;  // to be able to test deterministically
+    const DeadlineTimerPtr timer_;
+    std::atomic_bool closed_{false};
+    std::atomic_bool enabledForTesting_{true};  // to be able to test deterministically
 
     FRIEND_TEST(ConsumerTest, testNegativeAcksTrackerClose);
 };


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/265

### Modifications

Make `timer_` const and `enabledForTesting_` atomic in `NegativeAcksTracker` so that the `mutex_` can be used only for the `nackedMessages_` field. After that, we can unlock `mutex_` in `handleTimer` to avoid the potential deadlock from user-provided logger or intercepter.

Add `ConsumerTest.testNegativeAckDeadlock` to verify the fix.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
