### PR TITLE
Support specifying the C++ standard for some higher dependencies

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -267,7 +267,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: brew install openssl protobuf boost zstd snappy gtest
+        run: brew install openssl protobuf boost zstd snappy googletest
 
       - name: Configure (default)
         shell: bash

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -267,14 +267,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: brew install openssl protobuf boost zstd snappy
+        run: brew install openssl protobuf boost zstd snappy gtest
 
       - name: Configure (default)
         shell: bash
         run: |
+          # The latest GTest requires C++14
           cmake \
               -B ./build-macos \
-              -DBUILD_TESTS=OFF \
+              -DCMAKE_CXX_STANDARD=14 \
               -S .
 
       - name: Compile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,9 @@ find_package(Threads REQUIRED)
 MESSAGE(STATUS "Threads library: " ${CMAKE_THREAD_LIBS_INIT})
 
 set(Boost_NO_BOOST_CMAKE ON)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_C_STANDARD 11)
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif ()
 
 # Compiler specific configuration:
 # https://stackoverflow.com/questions/10046114/in-cmake-how-can-i-test-if-the-compiler-is-clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(Boost_NO_BOOST_CMAKE ON)
 if (NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 11)
 endif ()
+set(CMAKE_C_STANDARD 11)
 
 # Compiler specific configuration:
 # https://stackoverflow.com/questions/10046114/in-cmake-how-can-i-test-if-the-compiler-is-clang

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ If you want to build and run the tests, you need to install [GTest](https://gith
 
 If you want to use `ClientConfiguration::setLogConfFilePath`, you need to install the [Log4CXX](https://logging.apache.org/log4cxx) and add CMake option `-DUSE_LOG4CXX=ON`.
 
+The [dependencies.yaml](./dependencies.yaml) file provides the recommended dependency versions, while you can still build from source with other dependency versions. If a dependency requires a higher C++ standard, e.g. C++14, you can specify the standard like:
+
+```bash
+cmake . -DCMAKE_CXX_STANDARD=14
+```
+
 ## Platforms
 
 Pulsar C++ Client Library has been tested on:


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/268

### Motivation

When users build from source with a dependency that requires a higher C++ version than 11, it will fail because currently the C++ standard is pinned to 11. For example, the latest GTest requires C++14 now. So currently there is no way to build the tests except modifying the CMakeLists.txt file.

### Modifications

Make `CMAKE_CXX_STANDARD` configurable and test it for the macOS workflow because the `gtest` dependency installed from `brew` requires C++14. Add the description into the README for it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
