### PR TITLE
Exit CI when unit test failed.

### DIFF
--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -64,6 +64,9 @@ if [ -f /gtest-parallel ]; then
     python3 /gtest-parallel $tests --dump_json_test_results=/tmp/gtest_parallel_results.json \
       --workers=$gtest_workers --retry_failed=$RETRY_FAILED -d /tmp \
       ./pulsar-tests --gtest_filter='-CustomLoggerTest*'
+    if [ -d "/tmp/gtest-parallel-logs/failed" ]; then
+      exit 1;
+    fi
     # The customized logger might affect other tests
     ./pulsar-tests --gtest_filter='CustomLoggerTest*'
     RES=$?


### PR DESCRIPTION
### Motivation

Currently, When the unit test run fails, it does not exit ci. 

### Modifications

- Determine whether the test passes by determining whether the `/tmp/gtest-parallel-logs/failed` directory exists

### Verifying this change

Currently, `c_ConsumerTest.testBatchReceive` always fail, if CI fails, it means that this modification takes effect.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
