### PR TITLE
[feat][Message] Add getIndex method on Message

### DIFF
--- a/include/pulsar/Message.h
+++ b/include/pulsar/Message.h
@@ -31,6 +31,7 @@
 namespace pulsar {
 namespace proto {
 class CommandMessage;
+class BrokerEntryMetadata;
 class MessageMetadata;
 class SingleMessageMetadata;
 }  // namespace proto
@@ -125,6 +126,12 @@ class PULSAR_PUBLIC Message {
     void setMessageId(const MessageId& messageId) const;
 
     /**
+     * Get the index of this message, if it doesn't exist, return -1
+     * @return
+     */
+    int64_t getIndex() const;
+
+    /**
      * Get the partition key for this message
      * @return key string that is hashed to determine message's topic partition
      */
@@ -195,9 +202,11 @@ class PULSAR_PUBLIC Message {
     MessageImplPtr impl_;
 
     Message(MessageImplPtr& impl);
-    Message(const MessageId& messageId, proto::MessageMetadata& metadata, SharedBuffer& payload);
+    Message(const MessageId& messageId, proto::BrokerEntryMetadata& brokerEntryMetadata,
+            proto::MessageMetadata& metadata, SharedBuffer& payload);
     /// Used for Batch Messages
-    Message(const MessageId& messageId, proto::MessageMetadata& metadata, SharedBuffer& payload,
+    Message(const MessageId& messageId, proto::BrokerEntryMetadata& brokerEntryMetadata,
+            proto::MessageMetadata& metadata, SharedBuffer& payload,
             proto::SingleMessageMetadata& singleMetadata, const std::shared_ptr<std::string>& topicName);
     friend class PartitionedProducerImpl;
     friend class MultiTopicsConsumerImpl;

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -277,6 +277,7 @@ SharedBuffer Commands::newConnect(const AuthenticationPtr& authentication, const
 
     FeatureFlags* flags = connect->mutable_feature_flags();
     flags->set_supports_auth_refresh(true);
+    flags->set_supports_broker_entry_metadata(true);
     if (connectingThroughProxy) {
         Url logicalAddressUrl;
         Url::parse(logicalAddress, logicalAddressUrl);
@@ -908,7 +909,8 @@ Message Commands::deSerializeSingleMessageInBatch(Message& batchedMessage, int32
     const MessageId& m = batchedMessage.impl_->messageId;
     auto messageId = MessageIdBuilder::from(m).batchIndex(batchIndex).batchSize(batchSize).build();
     auto batchedMessageId = std::make_shared<BatchedMessageIdImpl>(*(messageId.impl_), acker);
-    Message singleMessage(MessageId{batchedMessageId}, batchedMessage.impl_->metadata, payload, metadata,
+    Message singleMessage(MessageId{batchedMessageId}, batchedMessage.impl_->brokerEntryMetadata,
+                          batchedMessage.impl_->metadata, payload, metadata,
                           batchedMessage.impl_->topicName_);
     singleMessage.impl_->cnx_ = batchedMessage.impl_->cnx_;
 

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -60,6 +60,7 @@ using UnAckedMessageTrackerPtr = std::shared_ptr<UnAckedMessageTrackerInterface>
 
 namespace proto {
 class CommandMessage;
+class BrokerEntryMetadata;
 class MessageMetadata;
 }  // namespace proto
 
@@ -87,7 +88,8 @@ class ConsumerImpl : public ConsumerImplBase {
     void sendFlowPermitsToBroker(const ClientConnectionPtr& cnx, int numMessages);
     uint64_t getConsumerId();
     void messageReceived(const ClientConnectionPtr& cnx, const proto::CommandMessage& msg,
-                         bool& isChecksumValid, proto::MessageMetadata& msgMetadata, SharedBuffer& payload);
+                         bool& isChecksumValid, proto::BrokerEntryMetadata& brokerEntryMetadata,
+                         proto::MessageMetadata& msgMetadata, SharedBuffer& payload);
     void messageProcessed(Message& msg, bool track = true);
     void activeConsumerChanged(bool isActive);
     inline CommandSubscribe_SubType getSubType();

--- a/lib/Message.cc
+++ b/lib/Message.cc
@@ -70,17 +70,21 @@ Message::Message() : impl_() {}
 
 Message::Message(MessageImplPtr& impl) : impl_(impl) {}
 
-Message::Message(const MessageId& messageId, proto::MessageMetadata& metadata, SharedBuffer& payload)
+Message::Message(const MessageId& messageId, proto::BrokerEntryMetadata& brokerEntryMetadata,
+                 proto::MessageMetadata& metadata, SharedBuffer& payload)
     : impl_(std::make_shared<MessageImpl>()) {
     impl_->messageId = messageId;
+    impl_->brokerEntryMetadata = brokerEntryMetadata;
     impl_->metadata = metadata;
     impl_->payload = payload;
 }
 
-Message::Message(const MessageId& messageID, proto::MessageMetadata& metadata, SharedBuffer& payload,
+Message::Message(const MessageId& messageID, proto::BrokerEntryMetadata& brokerEntryMetadata,
+                 proto::MessageMetadata& metadata, SharedBuffer& payload,
                  proto::SingleMessageMetadata& singleMetadata, const std::shared_ptr<std::string>& topicName)
     : impl_(std::make_shared<MessageImpl>()) {
     impl_->messageId = messageID;
+    impl_->brokerEntryMetadata = brokerEntryMetadata;
     impl_->metadata = metadata;
     impl_->payload = payload;
     impl_->metadata.mutable_properties()->CopyFrom(singleMetadata.properties());
@@ -134,6 +138,15 @@ void Message::setMessageId(const MessageId& messageID) const {
         impl_->messageId = messageID;
     }
     return;
+}
+
+int64_t Message::getIndex() const {
+    if (!impl_ || !impl_->brokerEntryMetadata.has_index()) {
+        return -1;
+    } else {
+        // casting uint64_t to int64_t, server definition ensures that's safe
+        return static_cast<int64_t>(impl_->brokerEntryMetadata.index());
+    }
 }
 
 bool Message::hasPartitionKey() const {

--- a/lib/MessageImpl.cc
+++ b/lib/MessageImpl.cc
@@ -20,8 +20,6 @@
 
 namespace pulsar {
 
-MessageImpl::MessageImpl() : metadata(), payload(), messageId(), cnx_(0), topicName_(), redeliveryCount_() {}
-
 const Message::StringMap& MessageImpl::properties() {
     if (properties_.size() == 0) {
         for (int i = 0; i < metadata.properties_size(); i++) {

--- a/lib/MessageImpl.h
+++ b/lib/MessageImpl.h
@@ -35,10 +35,9 @@ class BatchMessageContainer;
 
 class MessageImpl {
    public:
-    MessageImpl();
-
     const Message::StringMap& properties();
 
+    proto::BrokerEntryMetadata brokerEntryMetadata;
     proto::MessageMetadata metadata;
     SharedBuffer payload;
     std::shared_ptr<KeyValueImpl> keyValuePtr;

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -112,6 +112,27 @@ class ActiveInactiveListenerEvent : public ConsumerEventListener {
     std::mutex mutex_;
 };
 
+TEST(ConsumerTest, testConsumerIndex) {
+    Client client(lookupUrl);
+    const std::string topicName = "testConsumerIndex-topic-" + std::to_string(time(nullptr));
+    const std::string subName = "sub";
+    Producer producer;
+    Result producerResult = client.createProducer(topicName, producer);
+    ASSERT_EQ(producerResult, ResultOk);
+    Consumer consumer;
+    Result consumerResult = client.subscribe(topicName, subName, consumer);
+    ASSERT_EQ(consumerResult, ResultOk);
+    const auto msg = MessageBuilder().setContent("testConsumeSuccess").build();
+    Result sendResult = producer.send(msg);
+    ASSERT_EQ(sendResult, ResultOk);
+    Message receivedMsg;
+    Result receiveResult = consumer.receive(receivedMsg);
+    ASSERT_EQ(receiveResult, ResultOk);
+    ASSERT_EQ(receivedMsg.getDataAsString(), "testConsumeSuccess");
+    ASSERT_EQ(receivedMsg.getIndex(), -1);
+    client.close();
+}
+
 typedef std::shared_ptr<ActiveInactiveListenerEvent> ActiveInactiveListenerEventPtr;
 
 TEST(ConsumerTest, testConsumerEventWithoutPartition) {

--- a/tests/brokermetadata/docker-compose.yml
+++ b/tests/brokermetadata/docker-compose.yml
@@ -35,8 +35,8 @@ services:
       - advertisedAddress=localhost
       - advertisedListeners=external:pulsar://localhost:6650
       - PULSAR_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m
-      - PULSAR_PREFIX_BROKER_ENTRY_METADATA_INTERCEPTORS=org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor
-      - PULSAR_PREFIX_EXPOSING_BROKER_ENTRY_METADATA_TO_CLIENT_ENABLED=true
+      - PULSAR_PREFIX_brokerEntryMetadataInterceptors=org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor
+      - PULSAR_PREFIX_exposingBrokerEntryMetadataToClientEnabled=true
     ports:
       - "6650:6650"
       - "8080:8080"


### PR DESCRIPTION
### Motivation
After #276 , We already can consume messages contains index well. Now we can add a method allow user to getIndex.
Index is an optional brokerMetadata. If the index not exists, we will return -1

### Verifying this change
- Add the assertions to assert the index not equals -1.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
