### PR TITLE
[feat] PIP-273: Enable hostname verification by default

### DIFF
--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -252,7 +252,7 @@ class PULSAR_PUBLIC ClientConfiguration {
      * It validates the incoming x509 certificate and matches the provided hostname (CN/SAN) with the
      * expected broker's hostname. It follows the server identity hostname verification in RFC 2818.
      *
-     * The default value is false.
+     * The default value is true.
      *
      * @see [RFC 2818](https://tools.ietf.org/html/rfc2818).
      *

--- a/lib/ClientConfigurationImpl.h
+++ b/lib/ClientConfigurationImpl.h
@@ -41,7 +41,7 @@ struct ClientConfigurationImpl {
     bool tlsAllowInsecureConnection{false};
     unsigned int statsIntervalInSeconds{600};  // 10 minutes
     std::unique_ptr<LoggerFactory> loggerFactory;
-    bool validateHostName{false};
+    bool validateHostName{true};
     unsigned int partitionsUpdateInterval{60};  // 1 minute
     std::string listenerName;
     int connectionTimeoutMs{10000};  // 10 seconds


### PR DESCRIPTION
PIP: https://github.com/apache/pulsar/pull/20453

### Motivation

Enable hostname verification by default.

### Modifications

* Update the default value and the documentation to show the new default value.

### Verifying this change

This is a trivial change. I expect some tests to fail as a part of it and I will fix those.

### Documentation

- [x] `doc-required` 