### PR TITLE
[docs] Fix the developer guide for macOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,20 +131,27 @@ perf/perfConsumer
 #### Install all dependencies:
 
 ```shell
-brew install cmake openssl protobuf boost boost-python3 googletest zstd snappy
+brew install cmake openssl protobuf boost googletest zstd snappy
 ```
 
 #### Compile Pulsar client library:
 
 ```shell
-cmake .
+cmake . -DCMAKE_CXX_STANDARD=14
+make
+```
+
+You need to configure `CMAKE_CXX_STANDARD` with 14 because the latest `googletest` dependency from HomeBrew requires the C++14 support. If you don't want to build tests, you can run:
+
+```bash
+cmake . -DBUILD_TESTS=OFF
 make
 ```
 
 If you want to build performance tools, you need to run:
 
 ```shell
-cmake . -DBUILD_PERF_TOOLS=ON
+cmake . -DBUILD_PERF_TOOLS=ON -DCMAKE_CXX_STANDARD=14
 make
 ```
 


### PR DESCRIPTION
### Motivation

We don't need to install `boost-python3`, which was required for the Python wrapper that is independent now. And the latest `googletest` dependency requires the C++14 support so that we need to pass an extra CMake option for it. See https://github.com/apache/pulsar-client-cpp/pull/269

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [x] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
