### PR TITLE
Fix flaky testConsumerEventWithoutPartition cause by the change of Pulsar 3.0

### DIFF
--- a/tests/SynchronizedQueue.h
+++ b/tests/SynchronizedQueue.h
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <mutex>
+#include <queue>
+
+template <typename T>
+class SynchronizedQueue {
+   public:
+    void push(const T& value) {
+        std::lock_guard<std::mutex> lock{mutex_};
+        queue_.push(value);
+    }
+
+    T pop() {
+        std::lock_guard<std::mutex> lock{mutex_};
+        auto value = queue_.front();
+        queue_.pop();
+        return value;
+    }
+
+    size_t size() const {
+        std::lock_guard<std::mutex> lock{mutex_};
+        return queue_.size();
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    std::queue<T> queue_;
+};


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/280

### Motivation

https://github.com/apache/pulsar/pull/19502 brings a change to the consumer selection of the Failover subscription.

Before that PR, if a new consumer joins a Failover subscription when there is a consumer that subscribes the topic, the new consumer will receive the "inactive" event.

After that PR, a random consumer will receive the "inactive" event.

### Modifications

Change the assertion when `consumer` subscribes the topic with the same subscription.

In addition, use a thread safe queue to avoid race conditions.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
