### PR TITLE
Close the socket gracefully on Windows

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -609,10 +609,10 @@ void ClientConnection::handleRead(const boost::system::error_code& err, size_t b
     incomingBuffer_.bytesWritten(bytesTransferred);
 
     if (err || bytesTransferred == 0) {
-        if (bytesTransferred == 0 || err == boost::asio::error::eof) {
-            LOG_DEBUG(cnxString_ << "Server closed the connection: " << err.message());
-        } else if (err == boost::asio::error::operation_aborted) {
+        if (err == boost::asio::error::operation_aborted) {
             LOG_DEBUG(cnxString_ << "Read operation was canceled: " << err.message());
+        } else if (bytesTransferred == 0 || err == boost::asio::error::eof) {
+            LOG_DEBUG(cnxString_ << "Server closed the connection: " << err.message());
         } else {
             LOG_ERROR(cnxString_ << "Read operation failed: " << err.message());
         }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/261

### Motivation

When closing the socket on Windows, the `ERROR_CONNECTION_ABORTED` error might be returned in the callback of `async_receive`. It's caused by the `socket::close` method is not portable enough, see https://www.boost.org/doc/libs/1_81_0/doc/html/boost_asio/reference/basic_stream_socket/close/overload2.html

> For portable behaviour with respect to graceful closure of a connected socket, call shutdown() before closing the socket.

### Modifications

Call `shutdown` in `ClientConnection::closeSocket` before calling `close`. In addition, when no bytes are returned or the `eof` error happened,  print the logs with debug level whatever the error code is in the read callback.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
