### PR TITLE
feat: Support message copy for C client.

### DIFF
--- a/include/pulsar/c/message.h
+++ b/include/pulsar/c/message.h
@@ -41,7 +41,7 @@ PULSAR_PUBLIC pulsar_message_t *pulsar_message_create();
  * @param from  A pointer to the pulsar_message_t object that you want to copy from
  * @param to  A pointer to the pulsar_message_t object that you want to copy to
  */
-PULSAR_PUBLIC void pulsar_message_copy(pulsar_message_t *from, pulsar_message_t *to);
+PULSAR_PUBLIC void pulsar_message_copy(const pulsar_message_t *from, pulsar_message_t *to);
 PULSAR_PUBLIC void pulsar_message_free(pulsar_message_t *message);
 
 /// Builder

--- a/include/pulsar/c/message.h
+++ b/include/pulsar/c/message.h
@@ -33,6 +33,15 @@ typedef struct _pulsar_message pulsar_message_t;
 typedef struct _pulsar_message_id pulsar_message_id_t;
 
 PULSAR_PUBLIC pulsar_message_t *pulsar_message_create();
+/**
+ * Copy the contents of one pulsar_message_t object to another.
+ *
+ * Note: This method is a shallow copy, which will copy the pulsar::Message.
+ *
+ * @param from  A pointer to the pulsar_message_t object that you want to copy from
+ * @param to  A pointer to the pulsar_message_t object that you want to copy to
+ */
+PULSAR_PUBLIC void pulsar_message_copy(pulsar_message_t *from, pulsar_message_t *to);
 PULSAR_PUBLIC void pulsar_message_free(pulsar_message_t *message);
 
 /// Builder

--- a/lib/c/c_Message.cc
+++ b/lib/c/c_Message.cc
@@ -23,7 +23,7 @@
 
 pulsar_message_t *pulsar_message_create() { return new pulsar_message_t; }
 
-void pulsar_message_copy(pulsar_message_t *from, pulsar_message_t *to) {
+void pulsar_message_copy(const pulsar_message_t *from, pulsar_message_t *to) {
     to->builder = from->builder;
     to->message = from->message;
 }

--- a/lib/c/c_Message.cc
+++ b/lib/c/c_Message.cc
@@ -23,6 +23,11 @@
 
 pulsar_message_t *pulsar_message_create() { return new pulsar_message_t; }
 
+void pulsar_message_copy(pulsar_message_t *from, pulsar_message_t *to) {
+    to->builder = from->builder;
+    to->message = from->message;
+}
+
 void pulsar_message_free(pulsar_message_t *message) { delete message; }
 
 void pulsar_message_set_content(pulsar_message_t *message, const void *data, size_t size) {

--- a/tests/c/c_MessageTest.cc
+++ b/tests/c/c_MessageTest.cc
@@ -17,14 +17,8 @@
  * under the License.
  */
 #include <gtest/gtest.h>
-#include <pulsar/Message.h>
-#include <pulsar/MessageBuilder.h>
+#include <lib/c/c_structs.h>
 #include <pulsar/c/message.h>
-
-struct _pulsar_message {
-    pulsar::MessageBuilder builder;
-    pulsar::Message message;
-};
 
 TEST(c_MessageTest, MessageCopy) {
     pulsar_message_t *from = pulsar_message_create();

--- a/tests/c/c_MessageTest.cc
+++ b/tests/c/c_MessageTest.cc
@@ -30,14 +30,11 @@ TEST(c_MessageTest, MessageCopy) {
     pulsar_message_t *from = pulsar_message_create();
     pulsar_message_set_content(from, "hello", 5);
     from->message = from->builder.build();
-    std::cout << "from: " << (const char *)pulsar_message_get_data(from) << std::endl;
-
     pulsar_message_t *to = pulsar_message_create();
+
     pulsar_message_copy(from, to);
+    ASSERT_STREQ((const char *)pulsar_message_get_data(to), (const char *)pulsar_message_get_data(from));
+
     pulsar_message_free(from);
-
-    std::cout << "to: " << (const char *)pulsar_message_get_data(to) << std::endl;
-    ASSERT_STREQ((const char *)pulsar_message_get_data(to), "hello");
-
     pulsar_message_free(to);
 }

--- a/tests/c/c_MessageTest.cc
+++ b/tests/c/c_MessageTest.cc
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/Message.h>
+#include <pulsar/MessageBuilder.h>
+#include <pulsar/c/message.h>
+
+struct _pulsar_message {
+    pulsar::MessageBuilder builder;
+    pulsar::Message message;
+};
+
+TEST(c_MessageTest, MessageCopy) {
+    pulsar_message_t *from = pulsar_message_create();
+    pulsar_message_set_content(from, "hello", 5);
+    from->message = from->builder.build();
+    std::cout << "from: " << (const char *)pulsar_message_get_data(from) << std::endl;
+
+    pulsar_message_t *to = pulsar_message_create();
+    pulsar_message_copy(from, to);
+    pulsar_message_free(from);
+
+    std::cout << "to: " << (const char *)pulsar_message_get_data(to) << std::endl;
+    ASSERT_STREQ((const char *)pulsar_message_get_data(to), "hello");
+
+    pulsar_message_free(to);
+}


### PR DESCRIPTION
### Motivation

Support message copy for C client.


### Modifications
- Add a new method to support the message copy for C client.

### Verifying this change
- Add c_MessageTest to cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
