### PR TITLE
[improve] change RoutingMode default from UseSinglePartition to RoundRobinDistribution

### DIFF
--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -65,17 +65,17 @@ PartitionedProducerImpl::PartitionedProducerImpl(ClientImplPtr client, const Top
 
 MessageRoutingPolicyPtr PartitionedProducerImpl::getMessageRouter() {
     switch (conf_.getPartitionsRoutingMode()) {
+        case ProducerConfiguration::UseSinglePartition:
+            return std::make_shared<SinglePartitionMessageRouter>(getNumPartitions(),
+                                                                  conf_.getHashingScheme());
+        case ProducerConfiguration::CustomPartition:
+            return conf_.getMessageRouterPtr();
         case ProducerConfiguration::RoundRobinDistribution:
+        default:
             return std::make_shared<RoundRobinMessageRouter>(
                 conf_.getHashingScheme(), conf_.getBatchingEnabled(), conf_.getBatchingMaxMessages(),
                 conf_.getBatchingMaxAllowedSizeInBytes(),
                 boost::posix_time::milliseconds(conf_.getBatchingMaxPublishDelayMs()));
-        case ProducerConfiguration::CustomPartition:
-            return conf_.getMessageRouterPtr();
-        case ProducerConfiguration::UseSinglePartition:
-        default:
-            return std::make_shared<SinglePartitionMessageRouter>(getNumPartitions(),
-                                                                  conf_.getHashingScheme());
     }
 }
 

--- a/lib/ProducerConfigurationImpl.h
+++ b/lib/ProducerConfigurationImpl.h
@@ -34,7 +34,7 @@ struct ProducerConfigurationImpl {
     CompressionType compressionType{CompressionNone};
     int maxPendingMessages{1000};
     int maxPendingMessagesAcrossPartitions{50000};
-    ProducerConfiguration::PartitionsRoutingMode routingMode{ProducerConfiguration::UseSinglePartition};
+    ProducerConfiguration::PartitionsRoutingMode routingMode{ProducerConfiguration::RoundRobinDistribution};
     MessageRoutingPolicyPtr messageRouter;
     ProducerConfiguration::HashingScheme hashingScheme{ProducerConfiguration::BoostHash};
     bool useLazyStartPartitionedProducers{false};


### PR DESCRIPTION
### Motivation

It is more reasonable to set routingMode default RoundRobinDistribution, just as the java client. 

Otherwise, user may ignore this config, and producer can not produce msg to new updated partition  

### Modifications

change default routingMode config 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
