### PR TITLE
Add missing tls related method definitions for C client.

### DIFF
--- a/include/pulsar/c/client_configuration.h
+++ b/include/pulsar/c/client_configuration.h
@@ -160,6 +160,18 @@ PULSAR_PUBLIC const char *pulsar_client_configuration_get_tls_trust_certs_file_p
 PULSAR_PUBLIC void pulsar_client_configuration_set_tls_allow_insecure_connection(
     pulsar_client_configuration_t *conf, int allowInsecure);
 
+PULSAR_PUBLIC void pulsar_client_configuration_set_tls_private_key_file_path(
+    pulsar_client_configuration_t *conf, const char *private_key_file_path);
+
+PULSAR_PUBLIC const char *pulsar_client_configuration_get_tls_private_key_file_path(
+    pulsar_client_configuration_t *conf);
+
+PULSAR_PUBLIC void pulsar_client_configuration_set_tls_certificate_file_path(
+    pulsar_client_configuration_t *conf, const char *certificateFilePath);
+
+PULSAR_PUBLIC const char *pulsar_client_configuration_get_tls_certificate_file_path(
+    pulsar_client_configuration_t *conf);
+
 PULSAR_PUBLIC int pulsar_client_configuration_is_tls_allow_insecure_connection(
     pulsar_client_configuration_t *conf);
 

--- a/tests/c/c_ClientConfigurationTest.cc
+++ b/tests/c/c_ClientConfigurationTest.cc
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "pulsar/c/client_configuration.h"
+
+TEST(C_ClientConfigurationTest, testCApiConfig) {
+    pulsar_client_configuration_t *conf = pulsar_client_configuration_create();
+
+    pulsar_client_configuration_set_tls_private_key_file_path(conf, "private.key");
+    pulsar_client_configuration_set_tls_certificate_file_path(conf, "certificate.pem");
+
+    ASSERT_STREQ(pulsar_client_configuration_get_tls_private_key_file_path(conf), "private.key");
+    ASSERT_STREQ(pulsar_client_configuration_get_tls_certificate_file_path(conf), "certificate.pem");
+}


### PR DESCRIPTION
### Motivation

The current C for `tls_private_key_file_path` and `tls_certificate_file_path` param only defines the get and set method implementation, not the interface.

### Modifications

- Add get and set interface for `tls_private_key_file_path` and `tls_certificate_file_path`.

### Verifying this change

- Add `C_ClientConfigurationTest` to cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
