### PR TITLE
Fix ci failed on macos env.

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -49,8 +49,11 @@ jobs:
 
       - name: Install deps (macOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
-        run:
-          brew install pkg-config wireshark protobuf
+        run: |
+          # Install protobuf v21.12
+          wget https://raw.githubusercontent.com/Homebrew/homebrew-core/2d47ed2eac09d59ffc2c92b1d804f1c232188c88/Formula/protobuf.rb
+          brew install --formula ./protobuf.rb
+          brew install pkg-config wireshark
 
       - name: Build wireshark plugin
         run: |
@@ -267,7 +270,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: brew install openssl protobuf boost zstd snappy googletest
+        run: |
+         # Install protobuf v21.12
+         wget https://raw.githubusercontent.com/Homebrew/homebrew-core/2d47ed2eac09d59ffc2c92b1d804f1c232188c88/Formula/protobuf.rb
+         brew install --formula ./protobuf.rb
+         brew install openssl boost zstd snappy googletest
 
       - name: Configure (default)
         shell: bash


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar-client-cpp/actions/runs/5321241967/jobs/9636098738?pr=287

The root cause is the protobuf release v23.3 last week, which requires the abseil library that is built with C++ 17.

https://github.com/Homebrew/homebrew-core/blob/1a476ad7dc979671b4faf7601ae7d0cb6f39d9cf/Formula/protobuf.rb#L45-L46


### Modifications
- Specify to install protobuf v21.12

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
