### PR TITLE
Fix broker return error code confuse when not set subscription name.

### DIFF
--- a/lib/ClientImpl.cc
+++ b/lib/ClientImpl.cc
@@ -506,7 +506,14 @@ void ClientImpl::handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr co
         }
         callback(result, Consumer(consumer));
     } else {
-        callback(result, {});
+        // In order to be compatible with the current broker error code confusion.
+        // https://github.com/apache/pulsar/blob/cd2aa550d0fe4e72b5ff88c4f6c1c2795b3ff2cd/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java#L240-L241
+        if (result == ResultProducerBusy) {
+            LOG_ERROR("Failed to create consumer: SubscriptionName cannot be empty.");
+            callback(ResultInvalidConfiguration, {});
+        } else {
+            callback(result, {});
+        }
     }
 }
 

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -1311,4 +1311,14 @@ TEST(ConsumerTest, testNegativeAckDeadlock) {
     client.close();
 }
 
+TEST(ConsumerTest, testNotSetSubscriptionName) {
+    const std::string topic = "test-not-set-sub-name";
+    Client client{lookupUrl};
+    ConsumerConfiguration conf;
+    Consumer consumer;
+    ASSERT_EQ(ResultInvalidConfiguration, client.subscribe(topic, "", conf, consumer));
+
+    client.close();
+}
+
 }  // namespace pulsar


### PR DESCRIPTION
### Motivation

When creating a consumer and not set a subscription name, users will receive a `ResutlProducerBusy` result, which is confusing.

```
2023-06-19 08:48:54.412 INFO  [0x7ff84d51c640] Client:90 | Subscribing on Topic :persistent://public/default/test-1
2023-06-19 08:48:54.416 INFO  [0x7ff84d51c640] ClientConnection:184 | [<none> -> pulsar+ssl://v2-10-o.chaos-platform.test.sn2.dev:6651] Create ClientConnection, timeout=10000
2023-06-19 08:48:59.379 INFO  [0x7ff84d51c640] ConnectionPool:106 | Created connection for pulsar+ssl://v2-10-o.chaos-platform.test.sn2.dev:6651
2023-06-19 08:48:59.381 INFO  [0x70000011e000] ClientConnection:382 | [198.18.0.1:52214 -> 198.18.2.113:6651] Connected to broker
2023-06-19 08:49:01.687 INFO  [0x70000011e000] HandlerBase:72 | [0x600001d1a628, , 0] Getting connection from pool
2023-06-19 08:49:01.937 INFO  [0x70000011e000] ClientConnection:184 | [<none> -> pulsar+ssl://v2-10-o.chaos-platform.test.sn2.dev:6651] Create ClientConnection, timeout=10000
2023-06-19 08:49:01.955 INFO  [0x70000011e000] ConnectionPool:106 | Created connection for pulsar://v2-10-o-broker-1.v2-10-o-broker-headless.chaos-platform.svc.cluster.local:6650
2023-06-19 08:49:01.956 INFO  [0x70000011e000] ClientConnection:384 | [198.18.0.1:52222 -> 198.18.2.113:6651] Connected to broker through proxy. Logical broker: pulsar://v2-10-o-broker-1.v2-10-o-broker-headless.chaos-platform.svc.cluster.local:6650
2023-06-19 08:49:03.534 WARN  [0x70000011e000] ClientConnection:1597 | [198.18.0.1:52222 -> 198.18.2.113:6651] Received error response from server: ProducerBusy (Empty subscription name) -- req_id: 0
2023-06-19 08:49:03.534 ERROR [0x70000011e000] ConsumerImpl:325 | [0x600001d1a628, , 0] Failed to create consumer: ProducerBusy
2023-06-19 08:49:03.534 ERROR [0x70000011e000] MultiTopicsConsumerImpl:138 | Failed when subscribed to topic persistent://public/default/test-1 in TopicsConsumer. Error - ProducerBusy
2023-06-19 08:49:03.534 ERROR [0x70000011e000] MultiTopicsConsumerImpl:149 | Unable to create Consumer - [Muti Topics Consumer: TopicName - 0x600001d2a748 - Subscription - ] Error - ProducerBusy
2023-06-19 08:49:03.535 WARN  [0x70000011e000] ConsumerImpl:1213 | [0x600001d1a628, , 0] Failed to close consumer: AlreadyClosed
2023-06-19 08:49:03.535 ERROR [0x70000011e000] MultiTopicsConsumerImpl:502 | Closing the consumer failed for partition - persistent://public/default/test-1-partition-0 with error - AlreadyClosed
2023-06-19 08:49:03.535 WARN  [0x70000011e000] MultiTopicsConsumerImpl:462 | [Muti Topics Consumer: TopicName - 0x600001d2a748 - Subscription - ]Failed to close consumer: AlreadyClosed
2023-06-19 08:49:03.535 ERROR [0x70000011e000] MultiTopicsConsumerImpl:299 | Unable to create Consumer - [Muti Topics Consumer: TopicName - 0x600001d2a748 - Subscription - ] Error - ProducerBusy
libc++abi: terminating due to uncaught exception of type std::runtime_error: Error creating consumer: 19
```

The root cause is broker returns the error code `ProducerBusy` on this scene.

https://github.com/apache/pulsar/blob/cd2aa550d0fe4e72b5ff88c4f6c1c2795b3ff2cd/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java#L240-L241


### Modifications
- On the cpp client side, if receive a ProducerBusy error, trans it to `ResultInvalidConfiguration`.

### Verifying this change
- Add `testNotSetSubscriptionName ` unit test to cover it.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
