### PR TITLE
Fix retriable errors not handled well when creating producer or consumer

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -318,10 +318,13 @@ void ConsumerImpl::handleCreateConsumer(const ClientConnectionPtr& cnx, Result r
             scheduleReconnection(get_shared_this_ptr());
         } else {
             // Consumer was not yet created, retry to connect to broker if it's possible
-            if (isRetriableError(result) && (creationTimestamp_ + operationTimeut_ < TimeUtils::now())) {
+            if (isRetriableError(result) && (TimeUtils::now() - creationTimestamp_ < operationTimeut_)) {
                 LOG_WARN(getName() << "Temporary error in creating consumer : " << strResult(result));
                 scheduleReconnection(get_shared_this_ptr());
             } else {
+                if (isRetriableError(result)) {
+                    result = ResultTimeout;
+                }
                 LOG_ERROR(getName() << "Failed to create consumer: " << strResult(result));
                 consumerCreatedPromise_.setFailed(result);
                 state_ = Failed;

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -318,13 +318,11 @@ void ConsumerImpl::handleCreateConsumer(const ClientConnectionPtr& cnx, Result r
             scheduleReconnection(get_shared_this_ptr());
         } else {
             // Consumer was not yet created, retry to connect to broker if it's possible
-            if (isRetriableError(result) && (TimeUtils::now() - creationTimestamp_ < operationTimeut_)) {
-                LOG_WARN(getName() << "Temporary error in creating consumer : " << strResult(result));
+            result = convertToTimeoutIfNecessary(result, creationTimestamp_);
+            if (result == ResultRetryable) {
+                LOG_WARN(getName() << "Temporary error in creating consumer: " << strResult(result));
                 scheduleReconnection(get_shared_this_ptr());
             } else {
-                if (isRetriableError(result)) {
-                    result = ResultTimeout;
-                }
                 LOG_ERROR(getName() << "Failed to create consumer: " << strResult(result));
                 consumerCreatedPromise_.setFailed(result);
                 state_ = Failed;

--- a/lib/HandlerBase.cc
+++ b/lib/HandlerBase.cc
@@ -138,8 +138,6 @@ void HandlerBase::handleDisconnection(Result result, ClientConnectionWeakPtr con
     }
 }
 
-bool HandlerBase::isRetriableError(Result result) { return result == ResultRetryable; }
-
 void HandlerBase::scheduleReconnection(HandlerBasePtr handler) {
     const auto state = handler->state_.load();
     if (state == Pending || state == Ready) {
@@ -161,6 +159,14 @@ void HandlerBase::handleTimeout(const boost::system::error_code& ec, HandlerBase
     } else {
         handler->epoch_++;
         handler->grabCnx();
+    }
+}
+
+Result HandlerBase::convertToTimeoutIfNecessary(Result result, ptime startTimestamp) const {
+    if (result == ResultRetryable && (TimeUtils::now() - startTimestamp >= operationTimeut_)) {
+        return ResultTimeout;
+    } else {
+        return result;
     }
 }
 

--- a/lib/HandlerBase.h
+++ b/lib/HandlerBase.h
@@ -69,11 +69,6 @@ class HandlerBase {
      */
     static void scheduleReconnection(HandlerBasePtr handler);
 
-    /*
-     * Should we retry in error that are transient
-     */
-    bool isRetriableError(Result result);
-
     /**
      * Do some cleanup work before changing `connection_` to `cnx`.
      *
@@ -126,6 +121,8 @@ class HandlerBase {
     std::atomic<State> state_;
     Backoff backoff_;
     uint64_t epoch_;
+
+    Result convertToTimeoutIfNecessary(Result result, ptime startTimestamp) const;
 
    private:
     DeadlineTimerPtr timer_;

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -285,6 +285,9 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
                 LOG_WARN(getName() << "Temporary error in creating producer: " << strResult(result));
                 scheduleReconnection(shared_from_this());
             } else {
+                if (isRetriableError(result)) {
+                    result = ResultTimeout;
+                }
                 LOG_ERROR(getName() << "Failed to create producer: " << strResult(result));
                 failPendingMessages(result, false);
                 state_ = Failed;

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -281,7 +281,7 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
             scheduleReconnection(shared_from_this());
         } else {
             // Producer was not yet created, retry to connect to broker if it's possible
-            if (isRetriableError(result) && (creationTimestamp_ + operationTimeut_ < TimeUtils::now())) {
+            if (isRetriableError(result) && (TimeUtils::now() - creationTimestamp_ < operationTimeut_)) {
                 LOG_WARN(getName() << "Temporary error in creating producer: " << strResult(result));
                 scheduleReconnection(shared_from_this());
             } else {

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -281,13 +281,11 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
             scheduleReconnection(shared_from_this());
         } else {
             // Producer was not yet created, retry to connect to broker if it's possible
-            if (isRetriableError(result) && (TimeUtils::now() - creationTimestamp_ < operationTimeut_)) {
+            result = convertToTimeoutIfNecessary(result, creationTimestamp_);
+            if (result == ResultRetryable) {
                 LOG_WARN(getName() << "Temporary error in creating producer: " << strResult(result));
                 scheduleReconnection(shared_from_this());
             } else {
-                if (isRetriableError(result)) {
-                    result = ResultTimeout;
-                }
                 LOG_ERROR(getName() << "Failed to create producer: " << strResult(result));
                 failPendingMessages(result, false);
                 state_ = Failed;

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -1321,4 +1321,18 @@ TEST(ConsumerTest, testNotSetSubscriptionName) {
     client.close();
 }
 
+TEST(ConsumerTest, testRetrySubscribe) {
+    Client client{lookupUrl};
+    for (int i = 0; i < 10; i++) {
+        // "Subscription is fenced" error might happen here because the previous seek operation might not be
+        // done in broker, the consumer should retry until timeout
+        Consumer consumer;
+        ASSERT_EQ(client.subscribe("test-close-before-seek-done", "sub", consumer), ResultOk);
+        consumer.seekAsync(MessageId::earliest(), [](Result) {});
+        consumer.close();
+    }
+    // TODO: Currently it's hard to test the timeout error without configuring the operation timeout in
+    // milliseconds
+}
+
 }  // namespace pulsar


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/292

### Motivation

When a consumer failed to subscribe due to a retriable error, the time point comparation is wrong:

https://github.com/apache/pulsar-client-cpp/blob/633f4bbe8c182128da09803172676b9d6af05057/lib/ConsumerImpl.cc#L321

`creationTimestamp_ + operationTimeut_` is the deadline, `TimeUtils::now()` is the current time, we should use `>` instead of `<` here to compare them. Otherwise, if the consumer encountered a retriable error and the deadline is not exceeded, the consumer won't reconnect and fail with `ResultRetryable`.

### Modifications

Reverse the comparation between the deadline and the current time. When it times out, completing the future with `ResultTimeout` instead of the `result` itself, which is always `ResultRetryable`.

Add `ConsumerTest.testRetrySubscribe` to verify this change.

### TODO

Support configuring the operation timeout in milliseconds.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
