### PR TITLE
Fix the wrong backoff computation when retrying

### DIFF
--- a/lib/ClientImpl.cc
+++ b/lib/ClientImpl.cc
@@ -598,6 +598,7 @@ void ClientImpl::closeAsync(CloseCallback callback) {
     state_ = Closing;
 
     memoryLimitController_.close();
+    lookupServicePtr_->close();
 
     auto producers = producers_.move();
     auto consumers = consumers_.move();

--- a/lib/LookupService.h
+++ b/lib/LookupService.h
@@ -86,6 +86,8 @@ class LookupService {
                                                  const std::string& version = "") = 0;
 
     virtual ~LookupService() {}
+
+    virtual void close() {}
 };
 
 typedef std::shared_ptr<LookupService> LookupServicePtr;

--- a/lib/RetryableOperation.h
+++ b/lib/RetryableOperation.h
@@ -65,7 +65,7 @@ class RetryableOperation : public std::enable_shared_from_this<RetryableOperatio
     }
 
     void cancel() {
-        promise_.setValue(T{});
+        promise_.setFailed(ResultDisconnected);
         boost::system::error_code ec;
         timer_->cancel(ec);
     }

--- a/lib/RetryableOperation.h
+++ b/lib/RetryableOperation.h
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <pulsar/Result.h>
+
+#include <algorithm>
+#include <atomic>
+#include <functional>
+#include <memory>
+
+#include "Backoff.h"
+#include "ExecutorService.h"
+#include "Future.h"
+#include "LogUtils.h"
+
+namespace pulsar {
+
+template <typename T>
+class RetryableOperation : public std::enable_shared_from_this<RetryableOperation<T>> {
+    struct PassKey {
+        explicit PassKey() {}
+    };
+
+    RetryableOperation(const std::string& name, std::function<Future<Result, T>()>&& func, int timeoutSeconds,
+                       DeadlineTimerPtr timer)
+        : name_(name),
+          func_(std::move(func)),
+          timeout_(boost::posix_time::seconds(timeoutSeconds)),
+          backoff_(boost::posix_time::milliseconds(100), timeout_ + timeout_,
+                   boost::posix_time::milliseconds(0)),
+          timer_(timer) {}
+
+   public:
+    template <typename... Args>
+    explicit RetryableOperation(PassKey, Args&&... args) : RetryableOperation(std::forward<Args>(args)...) {}
+
+    template <typename... Args>
+    static std::shared_ptr<RetryableOperation<T>> create(Args&&... args) {
+        return std::make_shared<RetryableOperation<T>>(PassKey{}, std::forward<Args>(args)...);
+    }
+
+    Future<Result, T> run() {
+        bool expected = false;
+        if (!started_.compare_exchange_strong(expected, true)) {
+            return promise_.getFuture();
+        }
+        return runImpl(timeout_);
+    }
+
+    void cancel() {
+        promise_.setValue(T{});
+        boost::system::error_code ec;
+        timer_->cancel(ec);
+    }
+
+   private:
+    const std::string name_;
+    std::function<Future<Result, T>()> func_;
+    const TimeDuration timeout_;
+    Backoff backoff_;
+    Promise<Result, T> promise_;
+    std::atomic_bool started_{false};
+    DeadlineTimerPtr timer_;
+
+    Future<Result, T> runImpl(TimeDuration remainingTime) {
+        std::weak_ptr<RetryableOperation<T>> weakSelf{this->shared_from_this()};
+        func_().addListener([this, weakSelf, remainingTime](Result result, const T& value) {
+            auto self = weakSelf.lock();
+            if (!self) {
+                return;
+            }
+            if (result == ResultOk) {
+                promise_.setValue(value);
+                return;
+            }
+            if (result != ResultRetryable) {
+                promise_.setFailed(result);
+                return;
+            }
+            if (remainingTime.total_milliseconds() <= 0) {
+                promise_.setFailed(ResultTimeout);
+                return;
+            }
+
+            auto delay = std::min(backoff_.next(), remainingTime);
+            timer_->expires_from_now(delay);
+
+            auto nextRemainingTime = remainingTime - delay;
+            LOG_INFO("Reschedule " << name_ << " for " << delay.total_milliseconds()
+                                   << " ms, remaining time: " << nextRemainingTime.total_milliseconds()
+                                   << " ms");
+            timer_->async_wait([this, weakSelf, nextRemainingTime](const boost::system::error_code& ec) {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    return;
+                }
+                if (ec) {
+                    if (ec == boost::asio::error::operation_aborted) {
+                        LOG_DEBUG("Timer for " << name_ << " is cancelled");
+                        promise_.setFailed(ResultTimeout);
+                    } else {
+                        LOG_WARN("Timer for " << name_ << " failed: " << ec.message());
+                    }
+                } else {
+                    LOG_DEBUG("Run operation " << name_ << ", remaining time: "
+                                               << nextRemainingTime.total_milliseconds() << " ms");
+                    runImpl(nextRemainingTime);
+                }
+            });
+        });
+        return promise_.getFuture();
+    }
+
+    DECLARE_LOG_OBJECT()
+};
+
+}  // namespace pulsar

--- a/lib/RetryableOperationCache.h
+++ b/lib/RetryableOperationCache.h
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <mutex>
+#include <unordered_map>
+
+#include "ExecutorService.h"
+#include "RetryableOperation.h"
+
+namespace pulsar {
+
+template <typename T>
+class RetryableOperationCache;
+
+template <typename T>
+using RetryableOperationCachePtr = std::shared_ptr<RetryableOperationCache<T>>;
+
+template <typename T>
+class RetryableOperationCache : public std::enable_shared_from_this<RetryableOperationCache<T>> {
+    struct PassKey {
+        explicit PassKey() {}
+    };
+
+    RetryableOperationCache(ExecutorServiceProviderPtr executorProvider, int timeoutSeconds)
+        : executorProvider_(executorProvider), timeoutSeconds_(timeoutSeconds) {}
+
+    using Self = RetryableOperationCache<T>;
+
+   public:
+    template <typename... Args>
+    explicit RetryableOperationCache(PassKey, Args&&... args)
+        : RetryableOperationCache(std::forward<Args>(args)...) {}
+
+    template <typename... Args>
+    static std::shared_ptr<Self> create(Args&&... args) {
+        return std::make_shared<Self>(PassKey{}, std::forward<Args>(args)...);
+    }
+
+    Future<Result, T> run(const std::string& key, std::function<Future<Result, T>()>&& func) {
+        std::unique_lock<std::mutex> lock{mutex_};
+        auto it = operations_.find(key);
+        if (it == operations_.end()) {
+            DeadlineTimerPtr timer;
+            try {
+                timer = executorProvider_->get()->createDeadlineTimer();
+            } catch (const std::runtime_error& e) {
+                LOG_ERROR("Failed to retry lookup for " << key << ": " << e.what());
+                Promise<Result, T> promise;
+                promise.setFailed(ResultConnectError);
+                return promise.getFuture();
+            }
+
+            auto operation = RetryableOperation<T>::create(key, std::move(func), timeoutSeconds_, timer);
+            auto future = operation->run();
+            operations_[key] = operation;
+            lock.unlock();
+
+            std::weak_ptr<Self> weakSelf{this->shared_from_this()};
+            future.addListener([this, weakSelf, key, operation](Result, const T&) {
+                auto self = weakSelf.lock();
+                if (!self) {
+                    return;
+                }
+                std::lock_guard<std::mutex> lock{mutex_};
+                operations_.erase(key);
+                operation->cancel();
+            });
+
+            return future;
+        } else {
+            return it->second->run();
+        }
+    }
+
+    void clear() {
+        decltype(operations_) operations;
+        {
+            std::lock_guard<std::mutex> lock{mutex_};
+            operations.swap(operations_);
+        }
+        // cancel() could trigger the listener to erase the key from operations, so we should use a swap way
+        // to release the lock here
+        for (auto&& kv : operations) {
+            kv.second->cancel();
+        }
+    }
+
+    size_t size() const {
+        std::lock_guard<std::mutex> lock{mutex_};
+        return operations_.size();
+    }
+
+   private:
+    ExecutorServiceProviderPtr executorProvider_;
+    const int timeoutSeconds_;
+
+    std::unordered_map<std::string, std::shared_ptr<RetryableOperation<T>>> operations_;
+    mutable std::mutex mutex_;
+
+    DECLARE_LOG_OBJECT()
+};
+
+}  // namespace pulsar

--- a/lib/RetryableOperationCache.h
+++ b/lib/RetryableOperationCache.h
@@ -34,6 +34,8 @@ using RetryableOperationCachePtr = std::shared_ptr<RetryableOperationCache<T>>;
 
 template <typename T>
 class RetryableOperationCache : public std::enable_shared_from_this<RetryableOperationCache<T>> {
+    friend class LookupServiceTest;
+    friend class RetryableOperationCacheTest;
     struct PassKey {
         explicit PassKey() {}
     };
@@ -100,11 +102,6 @@ class RetryableOperationCache : public std::enable_shared_from_this<RetryableOpe
         for (auto&& kv : operations) {
             kv.second->cancel();
         }
-    }
-
-    size_t size() const {
-        std::lock_guard<std::mutex> lock{mutex_};
-        return operations_.size();
     }
 
    private:

--- a/tests/LookupServiceTest.cc
+++ b/tests/LookupServiceTest.cc
@@ -159,25 +159,7 @@ TEST(LookupServiceTest, testRetry) {
     ASSERT_EQ(ResultOk, future3.get(namespaceTopicsPtr));
     LOG_INFO("getTopicPartitionName Async returns " << namespaceTopicsPtr->size() << " topics");
 
-    std::atomic_int retryCount{0};
-    constexpr int totalRetryCount = 3;
-    auto future4 = lookupService->executeAsync<int>("key", [&retryCount]() -> Future<Result, int> {
-        Promise<Result, int> promise;
-        if (++retryCount < totalRetryCount) {
-            LOG_INFO("Retry count: " << retryCount);
-            promise.setFailed(ResultRetryable);
-        } else {
-            LOG_INFO("Retry done with " << retryCount << " times");
-            promise.setValue(100);
-        }
-        return promise.getFuture();
-    });
-    int customResult = 0;
-    ASSERT_EQ(ResultOk, future4.get(customResult));
-    ASSERT_EQ(customResult, 100);
-    ASSERT_EQ(retryCount.load(), totalRetryCount);
-
-    ASSERT_EQ(PulsarFriend::getNumberOfPendingTasks(*lookupService), 0);
+    ASSERT_EQ(lookupService->getNumberOfPendingTasks(), 0);
 }
 
 TEST(LookupServiceTest, testTimeout) {
@@ -221,7 +203,7 @@ TEST(LookupServiceTest, testTimeout) {
     ASSERT_EQ(ResultTimeout, future3.get(namespaceTopicsPtr));
     afterMethod("getTopicsOfNamespaceAsync");
 
-    ASSERT_EQ(PulsarFriend::getNumberOfPendingTasks(*lookupService), 0);
+    ASSERT_EQ(lookupService->getNumberOfPendingTasks(), 0);
 }
 
 class LookupServiceTest : public ::testing::TestWithParam<std::string> {

--- a/tests/PulsarFriend.h
+++ b/tests/PulsarFriend.h
@@ -31,7 +31,6 @@
 #include "lib/PartitionedProducerImpl.h"
 #include "lib/ProducerImpl.h"
 #include "lib/ReaderImpl.h"
-#include "lib/RetryableLookupService.h"
 #include "lib/stats/ConsumerStatsImpl.h"
 #include "lib/stats/ProducerStatsImpl.h"
 
@@ -179,10 +178,6 @@ class PulsarFriend {
 
     static void setServiceUrlIndex(const Client& client, size_t index) {
         setServiceUrlIndex(client.impl_->serviceNameResolver_, index);
-    }
-
-    static size_t getNumberOfPendingTasks(const RetryableLookupService& lookupService) {
-        return lookupService.backoffTimers_.size();
     }
 
     static proto::MessageMetadata& getMessageMetadata(Message& message) { return message.impl_->metadata; }

--- a/tests/RetryableOperationCacheTest.cc
+++ b/tests/RetryableOperationCacheTest.cc
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <stdexcept>
+
+#include "lib/RetryableOperationCache.h"
+
+using namespace pulsar;
+
+using IntFuture = Future<Result, int>;
+
+static int wait(IntFuture future) {
+    int value;
+    auto result = future.get(value);
+    if (result != ResultOk) {
+        throw std::runtime_error(strResult(result));
+    }
+    return value;
+}
+
+class CountdownFunc {
+    const int result_;
+    const int totalRetryCount_ = 3;
+    std::atomic_int current_{0};
+
+   public:
+    CountdownFunc(int result, int totalRetryCount = 3) : result_(result), totalRetryCount_(totalRetryCount) {}
+
+    CountdownFunc(const CountdownFunc& rhs)
+        : result_(rhs.result_), totalRetryCount_(rhs.totalRetryCount_), current_(rhs.current_.load()) {}
+
+    IntFuture operator()() {
+        Promise<Result, int> promise;
+        if (++current_ < totalRetryCount_) {
+            promise.setFailed(ResultRetryable);
+        } else {
+            promise.setValue(result_);
+        }
+        return promise.getFuture();
+    }
+};
+
+class RetryableOperationCacheTest : public ::testing::Test {
+   protected:
+    void SetUp() override { provider_ = std::make_shared<ExecutorServiceProvider>(1); }
+
+    void TearDown() override {
+        provider_->close();
+        futures_.clear();
+    }
+
+    ExecutorServiceProviderPtr provider_;
+    std::vector<IntFuture> futures_;
+};
+
+TEST_F(RetryableOperationCacheTest, testRetry) {
+    auto cache = RetryableOperationCache<int>::create(provider_, 30 /* seconds */);
+    for (int i = 0; i < 10; i++) {
+        futures_.emplace_back(cache->run("key-" + std::to_string(i), CountdownFunc{i * 100}));
+    }
+    ASSERT_EQ(cache->size(), 10);
+    for (int i = 0; i < 10; i++) {
+        ASSERT_EQ(wait(futures_[i]), i * 100);
+    }
+    ASSERT_EQ(cache->size(), 0);
+}
+
+TEST_F(RetryableOperationCacheTest, testCache) {
+    auto cache = RetryableOperationCache<int>::create(provider_, 30 /* seconds */);
+    constexpr int numKeys = 5;
+    for (int i = 0; i < 100; i++) {
+        futures_.emplace_back(cache->run("key-" + std::to_string(i % numKeys), CountdownFunc{i * 100}));
+    }
+    ASSERT_EQ(cache->size(), numKeys);
+    for (int i = 0; i < 100; i++) {
+        ASSERT_EQ(wait(futures_[i]), (i % numKeys) * 100);
+    }
+    ASSERT_EQ(cache->size(), 0);
+}
+
+TEST_F(RetryableOperationCacheTest, testTimeout) {
+    auto cache = RetryableOperationCache<int>::create(provider_, 1 /* seconds */);
+    auto future = cache->run("key", CountdownFunc{0, 1000 /* retry count */});
+    try {
+        wait(future);
+        FAIL();
+    } catch (const std::runtime_error& e) {
+        ASSERT_STREQ(e.what(), strResult(ResultTimeout));
+    }
+}
+
+TEST_F(RetryableOperationCacheTest, testClear) {
+    auto cache = RetryableOperationCache<int>::create(provider_, 30 /* seconds */);
+    for (int i = 0; i < 10; i++) {
+        futures_.emplace_back(cache->run("key-" + std::to_string(i), CountdownFunc{100}));
+    }
+    ASSERT_EQ(cache->size(), 10);
+    cache->clear();
+    for (auto&& future : futures_) {
+        int value;
+        // All cancelled futures complete with the default int value
+        ASSERT_EQ(ResultOk, future.get(value));
+        ASSERT_EQ(value, 0);
+    }
+    ASSERT_EQ(cache->size(), 0);
+}

--- a/tests/RetryableOperationCacheTest.cc
+++ b/tests/RetryableOperationCacheTest.cc
@@ -126,8 +126,8 @@ TEST_F(RetryableOperationCacheTest, testClear) {
     cache->clear();
     for (auto&& future : futures_) {
         int value;
-        // All cancelled futures complete with the default int value
-        ASSERT_EQ(ResultOk, future.get(value));
+        // All cancelled futures complete with ResultDisconnected and the default int value
+        ASSERT_EQ(ResultDisconnected, future.get(value));
         ASSERT_EQ(value, 0);
     }
     ASSERT_EQ(getSize(*cache), 0);

--- a/tests/TableViewTest.cc
+++ b/tests/TableViewTest.cc
@@ -23,7 +23,9 @@
 #include <future>
 
 #include "HttpHelper.h"
+#include "LogUtils.h"
 #include "PulsarFriend.h"
+#include "TopicName.h"
 #include "WaitUtils.h"
 
 using namespace pulsar;


### PR DESCRIPTION
### Motivation

All the retryable operations share the same `Backoff` object in `RetryableLookupService`, so if the reconnection happens for some times, the delay of retrying will keeps the maximum value (30 seconds).

### Modifications

Refactor the design of the `RetryableLookupService`:
- Add a `RetryableOperation` class to represent a retryable operation, each instance has its own `Backoff` object. The operation could only be executed once.
- Add a `RetryableOperationCache` class to represent a map that maps a specific name to its associated operation. It's an optimization that if an operation (e.g. find the owner topic of topic A) was not complete while the same operation was executed, the future would be reused.
- In `RetryableLookupService`, just maintain some caches for different operations.
- Add `RetryableOperationCacheTest` to verify the behaviors.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
