### PR TITLE
Fix the test script does not work for Docker on macOS

### DIFF
--- a/pulsar-test-service-start.sh
+++ b/pulsar-test-service-start.sh
@@ -25,12 +25,12 @@ cd $SRC_DIR
 
 ./pulsar-test-service-stop.sh
 
-CONTAINER_ID=$(docker run -i -p 8080:8080 -p 6650:6650 -p 8443:8443 -p 6651:6651 --rm --detach apachepulsar/pulsar:latest sleep 3600)
+CONTAINER_ID=$(docker run -i --user $(id -u) -p 8080:8080 -p 6650:6650 -p 8443:8443 -p 6651:6651 --rm --detach apachepulsar/pulsar:latest sleep 3600)
 build-support/setup-test-service-container.sh $CONTAINER_ID start-test-service-inside-container.sh
 
 docker cp $CONTAINER_ID:/pulsar/data/tokens/token.txt .test-token.txt
 
-CONTAINER_ID=$(docker run -i -p 8081:8081 -p 6652:6652 -p 8444:8444 -p 6653:6653 --rm --detach apachepulsar/pulsar:latest sleep 3600)
+CONTAINER_ID=$(docker run -i --user $(id -u) -p 8081:8081 -p 6652:6652 -p 8444:8444 -p 6653:6653 --rm --detach apachepulsar/pulsar:latest sleep 3600)
 build-support/setup-test-service-container.sh $CONTAINER_ID start-mim-test-service-inside-container.sh
 
 echo "-- Ready to start tests"


### PR DESCRIPTION
### Motivation

When I run `./pulsar-test-service-start.sh` on macOS m1 13.4, the standalone failed to start due to the wrong permission of the `test-conf` directory that is copied into the container via `docker cp`:

```
I have no name!@a00f70265760:/pulsar$ ls -l | grep test-conf
drwx------ 3  501 dialout  4096 Jun  4 13:31 test-conf
```

It seems to be a bug: https://github.com/docker/for-mac/issues/1814

### Modifications

Execute `docker run` with the current username via `id -u`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
