### PR TITLE
Fix the buggy Future and Promise implementations

### DIFF
--- a/lib/BinaryProtoLookupService.cc
+++ b/lib/BinaryProtoLookupService.cc
@@ -146,7 +146,7 @@ void BinaryProtoLookupService::handlePartitionMetadataLookup(const std::string& 
 }
 
 uint64_t BinaryProtoLookupService::newRequestId() {
-    Lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return ++requestIdGenerator_;
 }
 

--- a/lib/Future.h
+++ b/lib/Future.h
@@ -35,6 +35,9 @@ class InternalState {
     using Listener = std::function<void(Result, const Type &)>;
     using Pair = std::pair<Result, Type>;
 
+    // NOTE: Add the constructor explicitly just to be compatible with GCC 4.8
+    InternalState() {}
+
     void addListener(Listener listener) {
         if (completed()) {
             // Allow get_future() being called multiple times, only the 1st time will wait() be called to wait

--- a/lib/Future.h
+++ b/lib/Future.h
@@ -71,7 +71,7 @@ class InternalState {
         return pair.first;
     }
 
-    // Only for test
+    // Only public for test
     void triggerListeners(Result result, const Type &value) {
         while (true) {
             Lock lock{mutex_};

--- a/lib/stats/ProducerStatsImpl.cc
+++ b/lib/stats/ProducerStatsImpl.cc
@@ -71,7 +71,7 @@ void ProducerStatsImpl::flushAndReset(const boost::system::error_code& ec) {
         return;
     }
 
-    Lock lock(mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
     std::ostringstream oss;
     oss << *this;
     numMsgsSent_ = 0;
@@ -86,7 +86,7 @@ void ProducerStatsImpl::flushAndReset(const boost::system::error_code& ec) {
 }
 
 void ProducerStatsImpl::messageSent(const Message& msg) {
-    Lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     numMsgsSent_++;
     totalMsgsSent_++;
     numBytesSent_ += msg.getLength();
@@ -96,7 +96,7 @@ void ProducerStatsImpl::messageSent(const Message& msg) {
 void ProducerStatsImpl::messageReceived(Result res, const boost::posix_time::ptime& publishTime) {
     boost::posix_time::ptime currentTime = boost::posix_time::microsec_clock::universal_time();
     double diffInMicros = (currentTime - publishTime).total_microseconds();
-    Lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     totalLatencyAccumulator_(diffInMicros);
     latencyAccumulator_(diffInMicros);
     sendMap_[res] += 1;       // Value will automatically be initialized to 0 in the constructor

--- a/tests/BasicEndToEndTest.cc
+++ b/tests/BasicEndToEndTest.cc
@@ -191,7 +191,7 @@ TEST(BasicEndToEndTest, testBatchMessages) {
 }
 
 void resendMessage(Result r, const MessageId msgId, Producer producer) {
-    Lock lock(mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
     if (r != ResultOk) {
         LOG_DEBUG("globalResendMessageCount" << globalResendMessageCount);
         if (++globalResendMessageCount >= 3) {
@@ -993,7 +993,7 @@ TEST(BasicEndToEndTest, testResendViaSendCallback) {
     // 3 seconds
     std::this_thread::sleep_for(std::chrono::microseconds(3 * 1000 * 1000));
     producer.close();
-    Lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     ASSERT_GE(globalResendMessageCount, 3);
 }
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/298

### Motivation

Currently the `Future` and `Promise` are implemented manually by managing conditional variables. However, the conditional variable sometimes behaviors incorrectly on macOS, while the existing `future` and `promise` from the C++ standard library works well.

### Modifications

Redesign `Future` and `Promise` based on the utilities in the standard `<future>` header. In addition, fix the possible race condition when `addListener` is called after `setValue` or `setFailed`:
- Thread 1: call `setValue`, switch existing listeners and call them one by one out of the lock.
- Thread 2: call `addListener`, detect `complete_` is true and call the listener directly.

Now, the previous listeners and the new listener are called concurrently in thread 1 and 2.

### Verifications

Run the reproduce code in #298 for 10 times and found it never failed or hang.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
