### PR TITLE
[fix] callback of send batch message is error when flush

### DIFF
--- a/lib/BatchMessageContainerBase.cc
+++ b/lib/BatchMessageContainerBase.cc
@@ -92,7 +92,7 @@ void BatchMessageContainerBase::processAndClear(
     std::function<void(Result, const OpSendMsg&)> opSendMsgCallback, FlushCallback flushCallback) {
     if (isEmpty()) {
         if (flushCallback) {
-            flushCallback(ResultOk);
+            // do nothing, flushCallback complete until the lastOpSend complete
         }
     } else {
         const auto numBatches = getNumBatches();

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -480,7 +480,6 @@ TEST_P(ProducerTest, testFlushBatch) {
     ASSERT_EQ(needCallBack.load(), 0);
     producer.close();
 
-
     // test remain messages in batch not send
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producerConfiguration, producer));
 

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -459,7 +459,7 @@ TEST_P(ProducerTest, testFlushBatch) {
     producerConfiguration.setBatchingEnabled(true);
     producerConfiguration.setBatchingMaxMessages(10);
     producerConfiguration.setBatchingMaxPublishDelayMs(1000);
-    producerConfiguration.setBatchingMaxAllowedSizeInBytes(4*1024*1024);
+    producerConfiguration.setBatchingMaxAllowedSizeInBytes(4 * 1024 * 1024);
 
     // test all messages in batch has been sent
     Producer producer;


### PR DESCRIPTION
### Motivation

When sendAsync batch messages and then flush() and close(), found that the callback of message is ResultAlreadyClosed but not Ok. 

The root is if there is no batch messages remain in BatchMessageContainer when do flush,  the flush callback directly return Ok. Instead, it should return Ok until the lastSendOpFuture complete.  

### Modifications

1. fix the error code.
2. test two cases of flush batch messages.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` 
(Please explain why)

