### PR TITLE
Avoid copying OpSendMsg when sending messages

### DIFF
--- a/lib/BatchMessageContainer.cc
+++ b/lib/BatchMessageContainer.cc
@@ -21,6 +21,7 @@
 #include <stdexcept>
 
 #include "LogUtils.h"
+#include "OpSendMsg.h"
 
 DECLARE_LOG_OBJECT()
 
@@ -52,14 +53,10 @@ void BatchMessageContainer::clear() {
     LOG_DEBUG(*this << " clear() called");
 }
 
-Result BatchMessageContainer::createOpSendMsg(OpSendMsg& opSendMsg,
-                                              const FlushCallback& flushCallback) const {
-    return createOpSendMsgHelper(opSendMsg, flushCallback, batch_);
-}
-
-std::vector<Result> BatchMessageContainer::createOpSendMsgs(std::vector<OpSendMsg>& opSendMsgs,
-                                                            const FlushCallback& flushCallback) const {
-    throw std::runtime_error("createOpSendMsgs is not supported for BatchMessageContainer");
+std::unique_ptr<OpSendMsg> BatchMessageContainer::createOpSendMsg(const FlushCallback& flushCallback) {
+    auto op = createOpSendMsgHelper(flushCallback, batch_);
+    clear();
+    return op;
 }
 
 void BatchMessageContainer::serialize(std::ostream& os) const {

--- a/lib/BatchMessageContainer.h
+++ b/lib/BatchMessageContainer.h
@@ -39,25 +39,22 @@ class BatchMessageContainer : public BatchMessageContainerBase {
 
     ~BatchMessageContainer();
 
-    size_t getNumBatches() const override { return 1; }
+    bool hasMultiOpSendMsgs() const override { return false; }
 
     bool isFirstMessageToAdd(const Message& msg) const override { return batch_.empty(); }
 
     bool add(const Message& msg, const SendCallback& callback) override;
 
-    void clear() override;
-
-    Result createOpSendMsg(OpSendMsg& opSendMsg, const FlushCallback& flushCallback) const override;
-
-    std::vector<Result> createOpSendMsgs(std::vector<OpSendMsg>& opSendMsgs,
-                                         const FlushCallback& flushCallback) const override;
-
     void serialize(std::ostream& os) const override;
+
+    std::unique_ptr<OpSendMsg> createOpSendMsg(const FlushCallback& flushCallback) override;
 
    private:
     MessageAndCallbackBatch batch_;
     size_t numberOfBatchesSent_ = 0;
     double averageBatchSize_ = 0;
+
+    void clear() override;
 };
 
 }  // namespace pulsar

--- a/lib/BatchMessageKeyBasedContainer.h
+++ b/lib/BatchMessageKeyBasedContainer.h
@@ -32,18 +32,13 @@ class BatchMessageKeyBasedContainer : public BatchMessageContainerBase {
 
     ~BatchMessageKeyBasedContainer();
 
-    size_t getNumBatches() const override { return batches_.size(); }
+    bool hasMultiOpSendMsgs() const override { return true; }
 
     bool isFirstMessageToAdd(const Message& msg) const override;
 
     bool add(const Message& msg, const SendCallback& callback) override;
 
-    void clear() override;
-
-    Result createOpSendMsg(OpSendMsg& opSendMsg, const FlushCallback& flushCallback) const override;
-
-    std::vector<Result> createOpSendMsgs(std::vector<OpSendMsg>& opSendMsgs,
-                                         const FlushCallback& flushCallback) const override;
+    std::vector<std::unique_ptr<OpSendMsg>> createOpSendMsgs(const FlushCallback& flushCallback) override;
 
     void serialize(std::ostream& os) const override;
 
@@ -53,8 +48,7 @@ class BatchMessageKeyBasedContainer : public BatchMessageContainerBase {
     size_t numberOfBatchesSent_ = 0;
     double averageBatchSize_ = 0;
 
-    Result createOpSendMsg(OpSendMsg& opSendMsg, const FlushCallback& flushCallback,
-                           MessageAndCallbackBatch& batch) const;
+    void clear() override;
 };
 
 }  // namespace pulsar

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -69,8 +69,7 @@ typedef std::weak_ptr<ConsumerImpl> ConsumerImplWeakPtr;
 class LookupDataResult;
 class BrokerConsumerStatsImpl;
 class PeriodicTask;
-
-struct OpSendMsg;
+struct SendArguments;
 
 namespace proto {
 class BaseCommand;
@@ -153,8 +152,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     void sendCommand(const SharedBuffer& cmd);
     void sendCommandInternal(const SharedBuffer& cmd);
-    void sendMessage(const OpSendMsg& opSend);
-    void sendMessageInternal(const OpSendMsg& opSend);
+    void sendMessage(const std::shared_ptr<SendArguments>& args);
 
     void registerProducer(int producerId, ProducerImplPtr producer);
     void registerConsumer(int consumerId, ConsumerImplPtr consumer);

--- a/lib/Commands.h
+++ b/lib/Commands.h
@@ -40,6 +40,7 @@ using BatchMessageAckerPtr = std::shared_ptr<BatchMessageAcker>;
 class MessageIdImpl;
 using MessageIdImplPtr = std::shared_ptr<MessageIdImpl>;
 class BitSet;
+struct SendArguments;
 
 namespace proto {
 class BaseCommand;
@@ -98,9 +99,8 @@ class Commands {
     static SharedBuffer newGetSchema(const std::string& topic, const std::string& version,
                                      uint64_t requestId);
 
-    static PairSharedBuffer newSend(SharedBuffer& headers, proto::BaseCommand& cmd, uint64_t producerId,
-                                    uint64_t sequenceId, ChecksumType checksumType,
-                                    const proto::MessageMetadata& metadata, const SharedBuffer& payload);
+    static PairSharedBuffer newSend(SharedBuffer& headers, proto::BaseCommand& cmd, ChecksumType checksumType,
+                                    const SendArguments& args);
 
     static SharedBuffer newSubscribe(
         const std::string& topic, const std::string& subscription, uint64_t consumerId, uint64_t requestId,

--- a/lib/MessageAndCallbackBatch.cc
+++ b/lib/MessageAndCallbackBatch.cc
@@ -64,10 +64,17 @@ void MessageAndCallbackBatch::complete(Result result, const MessageId& id) const
     completeSendCallbacks(callbacks_, result, id);
 }
 
-SendCallback MessageAndCallbackBatch::createSendCallback() const {
+SendCallback MessageAndCallbackBatch::createSendCallback(const FlushCallback& flushCallback) const {
     const auto& callbacks = callbacks_;
-    return [callbacks]  // save a copy of `callbacks_`
-        (Result result, const MessageId& id) { completeSendCallbacks(callbacks, result, id); };
+    if (flushCallback) {
+        return [callbacks, flushCallback](Result result, const MessageId& id) {
+            completeSendCallbacks(callbacks, result, id);
+            flushCallback(result);
+        };
+    } else {
+        return [callbacks]  // save a copy of `callbacks_`
+            (Result result, const MessageId& id) { completeSendCallbacks(callbacks, result, id); };
+    }
 }
 
 }  // namespace pulsar

--- a/lib/MessageAndCallbackBatch.h
+++ b/lib/MessageAndCallbackBatch.h
@@ -30,6 +30,7 @@ namespace pulsar {
 
 class MessageImpl;
 using MessageImplPtr = std::shared_ptr<MessageImpl>;
+using FlushCallback = std::function<void(Result)>;
 
 class MessageAndCallbackBatch : public boost::noncopyable {
    public:
@@ -58,14 +59,7 @@ class MessageAndCallbackBatch : public boost::noncopyable {
      */
     void complete(Result result, const MessageId& id) const;
 
-    /**
-     * Create a single callback to trigger all the internal callbacks in order
-     * It's used when you want to clear and add new messages and callbacks but current callbacks need to be
-     * triggered later.
-     *
-     * @return the merged send callback
-     */
-    SendCallback createSendCallback() const;
+    SendCallback createSendCallback(const FlushCallback& flushCallback) const;
 
     const MessageImplPtr& msgImpl() const { return msgImpl_; }
     uint64_t sequenceId() const noexcept { return sequenceId_; }

--- a/lib/OpSendMsg.h
+++ b/lib/OpSendMsg.h
@@ -21,6 +21,7 @@
 
 #include <pulsar/Message.h>
 #include <pulsar/Producer.h>
+#include <pulsar/Result.h>
 
 #include <boost/date_time/posix_time/ptime.hpp>
 
@@ -31,46 +32,72 @@
 
 namespace pulsar {
 
+struct SendArguments {
+    const uint64_t producerId;
+    const uint64_t sequenceId;
+    const proto::MessageMetadata metadata;
+    const SharedBuffer payload;
+
+    SendArguments(uint64_t producerId, uint64_t sequenceId, const proto::MessageMetadata& metadata,
+                  const SharedBuffer& payload)
+        : producerId(producerId), sequenceId(sequenceId), metadata(metadata), payload(payload) {}
+    SendArguments(const SendArguments&) = delete;
+    SendArguments& operator=(const SendArguments&) = delete;
+};
+
 struct OpSendMsg {
-    proto::MessageMetadata metadata_;
-    SharedBuffer payload_;
-    SendCallback sendCallback_;
-    uint64_t producerId_;
-    uint64_t sequenceId_;
-    boost::posix_time::ptime timeout_;
-    uint32_t messagesCount_;
-    uint64_t messagesSize_;
-    std::vector<std::function<void(Result)>> trackerCallbacks_;
-    ChunkMessageIdImplPtr chunkedMessageId_;
+    const Result result;
+    const int32_t chunkId;
+    const int32_t numChunks;
+    const uint32_t messagesCount;
+    const uint64_t messagesSize;
+    const boost::posix_time::ptime timeout;
+    const SendCallback sendCallback;
+    std::vector<std::function<void(Result)>> trackerCallbacks;
+    ChunkMessageIdImplPtr chunkedMessageId;
+    // Use shared_ptr here because producer might resend the message with the same arguments
+    const std::shared_ptr<SendArguments> sendArgs;
 
-    OpSendMsg() = default;
-
-    OpSendMsg(const proto::MessageMetadata& metadata, const SharedBuffer& payload,
-              const SendCallback& sendCallback, uint64_t producerId, uint64_t sequenceId, int sendTimeoutMs,
-              uint32_t messagesCount, uint64_t messagesSize, ChunkMessageIdImplPtr chunkedMessageId = nullptr)
-        : metadata_(metadata),  // the copy happens here because OpSendMsg of chunks are constructed with
-                                // a shared metadata object
-          payload_(payload),
-          sendCallback_(sendCallback),
-          producerId_(producerId),
-          sequenceId_(sequenceId),
-          timeout_(TimeUtils::now() + milliseconds(sendTimeoutMs)),
-          messagesCount_(messagesCount),
-          messagesSize_(messagesSize),
-          chunkedMessageId_(chunkedMessageId) {}
+    template <typename... Args>
+    static std::unique_ptr<OpSendMsg> create(Args&&... args) {
+        return std::unique_ptr<OpSendMsg>(new OpSendMsg(std::forward<Args>(args)...));
+    }
 
     void complete(Result result, const MessageId& messageId) const {
-        if (sendCallback_) {
-            sendCallback_(result, messageId);
+        if (sendCallback) {
+            sendCallback(result, messageId);
         }
-        for (const auto& trackerCallback : trackerCallbacks_) {
+        for (const auto& trackerCallback : trackerCallbacks) {
             trackerCallback(result);
         }
     }
 
     void addTrackerCallback(std::function<void(Result)> trackerCallback) {
-        trackerCallbacks_.emplace_back(trackerCallback);
+        trackerCallbacks.emplace_back(trackerCallback);
     }
+
+   private:
+    OpSendMsg(Result result, SendCallback&& callback)
+        : result(result),
+          chunkId(-1),
+          numChunks(-1),
+          messagesCount(0),
+          messagesSize(0),
+          sendCallback(std::move(callback)),
+          sendArgs(nullptr) {}
+
+    OpSendMsg(const proto::MessageMetadata& metadata, uint32_t messagesCount, uint64_t messagesSize,
+              int sendTimeoutMs, SendCallback&& callback, ChunkMessageIdImplPtr chunkedMessageId,
+              uint64_t producerId, SharedBuffer payload)
+        : result(ResultOk),
+          chunkId(metadata.chunk_id()),
+          numChunks(metadata.num_chunks_from_msg()),
+          messagesCount(messagesCount),
+          messagesSize(messagesSize),
+          timeout(TimeUtils::now() + boost::posix_time::milliseconds(sendTimeoutMs)),
+          sendCallback(std::move(callback)),
+          chunkedMessageId(chunkedMessageId),
+          sendArgs(new SendArguments(producerId, metadata.sequence_id(), metadata, payload)) {}
 };
 
 }  // namespace pulsar


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/306

### Motivation

`OpSendMsg` is a struct whose size is 400 bytes. We should avoid the copy operation on it.

### Modifications

Pass the `unique_ptr<OpSendMsg>` everywhere instead of `OpSendMsg`.
- Use `unique_ptr<OpSendMsg>` as the element of the pending message queue in `ProducerImpl` and disable the copy constructor and assignment for `OpSendMsg`.
- Add `SendArgument`, which includes the necessary fields to construct a `CommandSend` request. Use `shared_ptr` rather than `unique_ptr` to store `SendArgument` in `OpSendMsg` because the producer might need to resend the message so the `SendArgument` object could be shared by `ProducerImpl` and `ClientConnection`.

This patch is more like a refactor because the compiler optimization might reduce unnecessary copying.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
