### PR TITLE
Fix the visibility compilation error for GCC <= 7

### DIFF
--- a/lib/RetryableOperation.h
+++ b/lib/RetryableOperation.h
@@ -79,7 +79,12 @@ class RetryableOperation : public std::enable_shared_from_this<RetryableOperatio
     std::atomic_bool started_{false};
     DeadlineTimerPtr timer_;
 
-    Future<Result, T> runImpl(TimeDuration remainingTime) {
+    // Fix the "declared with greater visibility" error for GCC <= 7
+#ifdef __GNUC__
+    __attribute__((visibility("hidden")))
+#endif
+    Future<Result, T>
+    runImpl(TimeDuration remainingTime) {
         std::weak_ptr<RetryableOperation<T>> weakSelf{this->shared_from_this()};
         func_().addListener([this, weakSelf, remainingTime](Result result, const T& value) {
             auto self = weakSelf.lock();


### PR DESCRIPTION
### Motivation

Fixes #311 

https://github.com/apache/pulsar-client-cpp/pull/296 introduced a regression for GCC <= 7.

> lib/RetryableOperation.h:109:66: error: 'pulsar::RetryableOperation<T>::runImpl(pulsar::TimeDuration)::<lambda(pulsar::Result, const T&)> [with T = pulsar::LookupService::LookupResult]::<lambda(const boost::system::error_code&)>' declared with greater visibility than the type of its field 'pulsar::RetryableOperation<T>::runImpl(pulsar::TimeDuration)::<lambda(pulsar::Result, const T&)> [with T = pulsar::LookupService::LookupResult]::<lambda(const boost::system::error_code&)>::<this capture>' [-Werror=attributes]

It seems to be a bug for GCC <= 7 abort the visibility of the lambda expression might not be affected by the `-fvisibility=hidden` option.

### Modifications

Add `__attribute__((visibility("hidden")))` to
`RetryableOperation::runImpl` explicitly.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
