### PR TITLE
[fix] Add the curl wrapper to avoid inconsistent curl options

### DIFF
--- a/lib/CurlWrapper.h
+++ b/lib/CurlWrapper.h
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <assert.h>
+#include <curl/curl.h>
+
+#include <string>
+
+namespace pulsar {
+
+struct CurlInitializer {
+    CurlInitializer() { curl_global_init(CURL_GLOBAL_ALL); }
+    ~CurlInitializer() { curl_global_cleanup(); }
+};
+static CurlInitializer curlInitializer;
+
+class CurlWrapper {
+   public:
+    CurlWrapper() noexcept {}
+    ~CurlWrapper() {
+        if (handle_) {
+            curl_easy_cleanup(handle_);
+        }
+    }
+
+    char* escape(const std::string& s) const {
+        assert(handle_);
+        return curl_easy_escape(handle_, s.c_str(), s.length());
+    }
+
+    // It must be called before calling other methods
+    bool init() {
+        handle_ = curl_easy_init();
+        return handle_ != nullptr;
+    }
+
+    struct Options {
+        std::string method;
+        std::string postFields;
+        std::string userAgent;
+        int timeoutInSeconds{0};
+        int maxLookupRedirects{-1};
+    };
+
+    struct TlsContext {
+        std::string trustCertsFilePath;
+        bool validateHostname{true};
+        bool allowInsecure{false};
+        std::string certPath;
+        std::string keyPath;
+    };
+
+    struct Result {
+        CURLcode code;
+        std::string responseData;
+        long responseCode;
+        std::string redirectUrl;
+        std::string error;
+        std::string serverError;
+    };
+
+    Result get(const std::string& url, const std::string& header, const Options& options,
+               const TlsContext* tlsContext) const;
+
+   private:
+    CURL* handle_;
+
+    struct CurlListGuard {
+        curl_slist*& headers;
+
+        CurlListGuard(curl_slist*& headers) : headers(headers) {}
+        ~CurlListGuard() {
+            if (headers) {
+                curl_slist_free_all(headers);
+            }
+        }
+    };
+};
+
+inline CurlWrapper::Result CurlWrapper::get(const std::string& url, const std::string& header,
+                                            const Options& options, const TlsContext* tlsContext) const {
+    assert(handle_);
+    curl_easy_setopt(handle_, CURLOPT_URL, url.c_str());
+
+    if (!options.postFields.empty()) {
+        curl_easy_setopt(handle_, CURLOPT_CUSTOMREQUEST, "POST");
+        curl_easy_setopt(handle_, CURLOPT_POSTFIELDS, options.postFields.c_str());
+    }
+
+    // Write response
+    curl_easy_setopt(
+        handle_, CURLOPT_WRITEFUNCTION,
+        +[](char* buffer, size_t size, size_t nitems, void* outstream) -> size_t {
+            static_cast<std::string*>(outstream)->append(buffer, size * nitems);
+            return size * nitems;
+        });
+    std::string response;
+    curl_easy_setopt(handle_, CURLOPT_WRITEDATA, &response);
+
+    // New connection is made for each call
+    curl_easy_setopt(handle_, CURLOPT_FRESH_CONNECT, 1L);
+    curl_easy_setopt(handle_, CURLOPT_FORBID_REUSE, 1L);
+
+    // Skipping signal handling - results in timeouts not honored during the DNS lookup
+    // Without this config, Curl_resolv_timeout might crash in multi-threads environment
+    curl_easy_setopt(handle_, CURLOPT_NOSIGNAL, 1L);
+
+    curl_easy_setopt(handle_, CURLOPT_TIMEOUT, options.timeoutInSeconds);
+    if (!options.userAgent.empty()) {
+        curl_easy_setopt(handle_, CURLOPT_USERAGENT, options.userAgent.c_str());
+    }
+    curl_easy_setopt(handle_, CURLOPT_FAILONERROR, 1L);
+
+    // Redirects
+    curl_easy_setopt(handle_, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(handle_, CURLOPT_MAXREDIRS, options.maxLookupRedirects);
+
+    char errorBuffer[CURL_ERROR_SIZE] = "";
+    curl_easy_setopt(handle_, CURLOPT_ERRORBUFFER, errorBuffer);
+
+    curl_slist* headers = nullptr;
+    CurlListGuard headersGuard{headers};
+    if (!header.empty()) {
+        headers = curl_slist_append(headers, header.c_str());
+        curl_easy_setopt(handle_, CURLOPT_HTTPHEADER, headers);
+    }
+
+    if (tlsContext) {
+        CURLcode code;
+        code = curl_easy_setopt(handle_, CURLOPT_SSLENGINE, nullptr);
+        if (code != CURLE_OK) {
+            return {code, "", -1, "",
+                    "Unable to load SSL engine for url " + url + ": " + curl_easy_strerror(code)};
+        }
+        code = curl_easy_setopt(handle_, CURLOPT_SSLENGINE_DEFAULT, 1L);
+        if (code != CURLE_OK) {
+            return {code, "", -1, "",
+                    "Unable to load SSL engine as default for url " + url + ": " + curl_easy_strerror(code)};
+        }
+        curl_easy_setopt(handle_, CURLOPT_SSL_VERIFYHOST, tlsContext->validateHostname ? 1L : 0L);
+        curl_easy_setopt(handle_, CURLOPT_SSL_VERIFYPEER, tlsContext->allowInsecure ? 0L : 1L);
+        if (!tlsContext->trustCertsFilePath.empty()) {
+            curl_easy_setopt(handle_, CURLOPT_CAINFO, tlsContext->trustCertsFilePath.c_str());
+        }
+        if (!tlsContext->certPath.empty() && !tlsContext->keyPath.empty()) {
+            curl_easy_setopt(handle_, CURLOPT_SSLCERT, tlsContext->certPath.c_str());
+            curl_easy_setopt(handle_, CURLOPT_SSLKEY, tlsContext->keyPath.c_str());
+        }
+    }
+
+    auto res = curl_easy_perform(handle_);
+    long responseCode;
+    curl_easy_getinfo(handle_, CURLINFO_RESPONSE_CODE, &responseCode);
+    Result result{res, response, responseCode, "", "", std::string(errorBuffer)};
+    if (responseCode == 307 || responseCode == 302 || responseCode == 301) {
+        char* url;
+        curl_easy_getinfo(handle_, CURLINFO_REDIRECT_URL, &url);
+        result.redirectUrl = url;
+    }
+    return result;
+}
+
+}  // namespace pulsar

--- a/lib/HTTPLookupService.h
+++ b/lib/HTTPLookupService.h
@@ -31,13 +31,6 @@ using NamespaceTopicsPromisePtr = std::shared_ptr<NamespaceTopicsPromise>;
 using GetSchemaPromise = Promise<Result, SchemaInfo>;
 
 class HTTPLookupService : public LookupService, public std::enable_shared_from_this<HTTPLookupService> {
-    class CurlInitializer {
-       public:
-        CurlInitializer();
-        ~CurlInitializer();
-    };
-    static CurlInitializer curlInitializer;
-
     enum RequestType
     {
         Lookup,

--- a/lib/auth/athenz/ZTSClient.cc
+++ b/lib/auth/athenz/ZTSClient.cc
@@ -20,6 +20,7 @@
 
 #include <sstream>
 
+#include "lib/CurlWrapper.h"
 #include "lib/LogUtils.h"
 
 #ifndef _MSC_VER
@@ -27,7 +28,6 @@
 #else
 #include <stdio.h>
 #endif
-#include <curl/curl.h>
 #include <openssl/ec.h>
 #include <openssl/pem.h>
 #include <openssl/rsa.h>
@@ -287,11 +287,6 @@ const std::string ZTSClient::getPrincipalToken() const {
     return principalToken;
 }
 
-static size_t curlWriteCallback(void *contents, size_t size, size_t nmemb, void *responseDataPtr) {
-    ((std::string *)responseDataPtr)->append((char *)contents, size * nmemb);
-    return size * nmemb;
-}
-
 std::mutex cacheMtx_;
 const std::string ZTSClient::getRoleToken() {
     RoleToken roleToken;
@@ -311,72 +306,59 @@ const std::string ZTSClient::getRoleToken() {
     completeUrl += "?minExpiryTime=" + std::to_string(ROLE_TOKEN_EXPIRATION_MIN_TIME_SEC);
     completeUrl += "&maxExpiryTime=" + std::to_string(ROLE_TOKEN_EXPIRATION_MAX_TIME_SEC);
 
-    CURL *handle;
-    CURLcode res;
-    std::string responseData;
-
-    handle = curl_easy_init();
-
-    // set URL
-    curl_easy_setopt(handle, CURLOPT_URL, completeUrl.c_str());
-
-    // Write callback
-    curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlWriteCallback);
-    curl_easy_setopt(handle, CURLOPT_WRITEDATA, &responseData);
-
-    // New connection is made for each call
-    curl_easy_setopt(handle, CURLOPT_FRESH_CONNECT, 1L);
-    curl_easy_setopt(handle, CURLOPT_FORBID_REUSE, 1L);
-
-    // Skipping signal handling - results in timeouts not honored during the DNS lookup
-    curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
-
-    // Timer
-    curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, REQUEST_TIMEOUT);
-
-    // Redirects
-    curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
-    curl_easy_setopt(handle, CURLOPT_MAXREDIRS, MAX_HTTP_REDIRECTS);
-
-    // Fail if HTTP return code >= 400
-    curl_easy_setopt(handle, CURLOPT_FAILONERROR, 1L);
-
+    std::string trustCertsFilePath;
+    std::unique_ptr<CurlWrapper::TlsContext> tlsContext;
     if (!caCert_.scheme.empty()) {
         if (caCert_.scheme == "file") {
-            curl_easy_setopt(handle, CURLOPT_CAINFO, caCert_.path.c_str());
+            tlsContext.reset(new CurlWrapper::TlsContext);
+            tlsContext->trustCertsFilePath = caCert_.path;
         } else {
             LOG_ERROR("URI scheme not supported in caCert: " << caCert_.scheme);
         }
     }
 
-    struct curl_slist *list = NULL;
+    std::string header;
     if (enableX509CertChain_) {
         if (x509CertChain_.scheme == "file") {
-            curl_easy_setopt(handle, CURLOPT_SSLCERT, x509CertChain_.path.c_str());
+            if (!tlsContext) {
+                tlsContext.reset(new CurlWrapper::TlsContext);
+            }
+            tlsContext->certPath = x509CertChain_.path;
         } else {
             LOG_ERROR("URI scheme not supported in x509CertChain: " << x509CertChain_.scheme);
         }
         if (privateKeyUri_.scheme == "file") {
-            curl_easy_setopt(handle, CURLOPT_SSLKEY, privateKeyUri_.path.c_str());
+            if (!tlsContext) {
+                tlsContext.reset(new CurlWrapper::TlsContext);
+            }
+            tlsContext->keyPath = privateKeyUri_.path;
         } else {
             LOG_ERROR("URI scheme not supported in privateKey: " << privateKeyUri_.scheme);
         }
     } else {
-        std::string httpHeader = principalHeader_ + ": " + getPrincipalToken();
-        list = curl_slist_append(list, httpHeader.c_str());
-        curl_easy_setopt(handle, CURLOPT_HTTPHEADER, list);
+        header = principalHeader_ + ": " + getPrincipalToken();
     }
 
-    // Make get call to server
-    res = curl_easy_perform(handle);
+    CurlWrapper curl;
+    if (!curl.init()) {
+        LOG_ERROR("Failed to init curl");
+        return "";
+    }
 
-    // Free header list
-    curl_slist_free_all(list);
+    CurlWrapper::Options options;
+    options.timeoutInSeconds = REQUEST_TIMEOUT;
+    options.maxLookupRedirects = MAX_HTTP_REDIRECTS;
+    auto result = curl.get(completeUrl, header, options, tlsContext.get());
+    if (!result.error.empty()) {
+        LOG_ERROR(completeUrl << " failed: " << result.error);
+        return "";
+    }
+    auto res = result.code;
+    const auto &responseData = result.responseData;
+    long response_code = result.responseCode;
 
     switch (res) {
         case CURLE_OK:
-            long response_code;
-            curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &response_code);
             LOG_DEBUG("Response received for url " << completeUrl << " code " << response_code);
             if (response_code == 200) {
                 ptree::ptree root;
@@ -403,7 +385,6 @@ const std::string ZTSClient::getRoleToken() {
             LOG_ERROR("Response failed for url " << completeUrl << ". Error Code " << res);
             break;
     }
-    curl_easy_cleanup(handle);
 
     return roleToken.token;
 }


### PR DESCRIPTION
### Motivation

When libcurl is used in `AuthOauth2`, the `CURLOPT_NOSIGNAL` option is not set, i.e. it will be the default value so that the `Curl_resolv_timeout` function might crash in multi-threading environment.

```
#2 0xf630 in _L_unlock_13 from /lib64/libpthread.so.0 (0x34)
#3 0x2e6c7f in Curl_failf from /usr/local/bin/***/libpulsar.so (0x6f)
#4 0x30a285 in Curl_resolv_timeout from /usr/local/bin/***/libpulsar.so (0x95)
```

Since there are many duplicated code when calling curl C APIs, it's hard to notice that `CURLOPT_NOSIGNAL` is not configured in `AuthOauth2`.

### Modifications

Introduce a `CurlWrapper` class that sets the same options to reduce the duplicated code and adapting consistent behaviors unless a few options.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
