### PR TITLE
Fix broken wireshark build workflow on macOS

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: Install deps (macOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
+          brew update
           brew install pkg-config wireshark protobuf
       - name: Build wireshark plugin
         run: |


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/314

We need to run `brew update` to have the fix of
https://github.com/Homebrew/homebrew-core/pull/142254 included.