### PR TITLE
[fix] Fix consumer doesn't acknowledge all chunk message Ids

### DIFF
--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -38,8 +38,6 @@ class ChunkMessageIdImpl : public MessageIdImpl, public std::enable_shared_from_
 
     const std::vector<MessageId>& getChunkedMessageIds() const noexcept { return chunkedMessageIds_; }
 
-    std::vector<MessageId> moveChunkedMessageIds() noexcept { return std::move(chunkedMessageIds_); }
-
     MessageId build() { return MessageId{std::dynamic_pointer_cast<MessageIdImpl>(shared_from_this())}; }
 
    private:

--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -28,26 +28,21 @@ class ChunkMessageIdImpl;
 typedef std::shared_ptr<ChunkMessageIdImpl> ChunkMessageIdImplPtr;
 class ChunkMessageIdImpl : public MessageIdImpl, public std::enable_shared_from_this<ChunkMessageIdImpl> {
    public:
-    ChunkMessageIdImpl() : firstChunkMsgId_(std::make_shared<MessageIdImpl>()) {}
-
-    void setChunkedMessageIds(std::vector<MessageId>&& chunkedMessageIds) {
-        chunkedMessageIds_ = std::move(chunkedMessageIds);
+    explicit ChunkMessageIdImpl(std::vector<MessageId>&& chunkedMessageIds)
+        : chunkedMessageIds_(std::move(chunkedMessageIds)) {
         auto lastChunkMsgId = chunkedMessageIds_.back();
         this->ledgerId_ = lastChunkMsgId.ledgerId();
         this->entryId_ = lastChunkMsgId.entryId();
         this->partition_ = lastChunkMsgId.partition();
     }
 
-    std::shared_ptr<const MessageIdImpl> getFirstChunkMessageId() const {
-        return chunkedMessageIds_.front().impl_;
-    }
+    const std::vector<MessageId>& getChunkedMessageIds() const noexcept { return chunkedMessageIds_; }
 
     std::vector<MessageId> moveChunkedMessageIds() noexcept { return std::move(chunkedMessageIds_); }
 
     MessageId build() { return MessageId{std::dynamic_pointer_cast<MessageIdImpl>(shared_from_this())}; }
 
    private:
-    std::shared_ptr<MessageIdImpl> firstChunkMsgId_;
     std::vector<MessageId> chunkedMessageIds_;
 };
 }  // namespace pulsar

--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -38,11 +38,11 @@ class ChunkMessageIdImpl : public MessageIdImpl, public std::enable_shared_from_
         this->partition_ = lastChunkMsgId.partition();
     }
 
-    std::shared_ptr<const MessageIdImpl> getFirstChunkMessageId() const { return chunkedMessageIds_.front().impl_; }
-
-    std::vector<MessageId> moveChunkedMessageIds() noexcept {
-        return std::move(chunkedMessageIds_);
+    std::shared_ptr<const MessageIdImpl> getFirstChunkMessageId() const {
+        return chunkedMessageIds_.front().impl_;
     }
+
+    std::vector<MessageId> moveChunkedMessageIds() noexcept { return std::move(chunkedMessageIds_); }
 
     MessageId build() { return MessageId{std::dynamic_pointer_cast<MessageIdImpl>(shared_from_this())}; }
 

--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -30,23 +30,17 @@ class ChunkMessageIdImpl : public MessageIdImpl, public std::enable_shared_from_
    public:
     ChunkMessageIdImpl() : firstChunkMsgId_(std::make_shared<MessageIdImpl>()) {}
 
-    void setFirstChunkMessageId(const MessageId& msgId) { *firstChunkMsgId_ = *msgId.impl_; }
-
-    void setLastChunkMessageId(const MessageId& msgId) {
-        this->ledgerId_ = msgId.ledgerId();
-        this->entryId_ = msgId.entryId();
-        this->partition_ = msgId.partition();
-    }
-
     void setChunkedMessageIds(std::vector<MessageId>&& chunkedMessageIds) {
         chunkedMessageIds_ = std::move(chunkedMessageIds);
-        setFirstChunkMessageId(chunkedMessageIds_.front());
-        setLastChunkMessageId(chunkedMessageIds_.back());
+        auto lastChunkMsgId = chunkedMessageIds_.back();
+        this->ledgerId_ = lastChunkMsgId.ledgerId();
+        this->entryId_ = lastChunkMsgId.entryId();
+        this->partition_ = lastChunkMsgId.partition();
     }
 
-    std::shared_ptr<const MessageIdImpl> getFirstChunkMessageId() const { return firstChunkMsgId_; }
+    std::shared_ptr<const MessageIdImpl> getFirstChunkMessageId() const { return chunkedMessageIds_.front().impl_; }
 
-    std::vector<MessageId> moveChunkedMessageIds() const noexcept {
+    std::vector<MessageId> moveChunkedMessageIds() noexcept {
         return std::move(chunkedMessageIds_);
     }
 

--- a/lib/ChunkMessageIdImpl.h
+++ b/lib/ChunkMessageIdImpl.h
@@ -38,11 +38,22 @@ class ChunkMessageIdImpl : public MessageIdImpl, public std::enable_shared_from_
         this->partition_ = msgId.partition();
     }
 
+    void setChunkedMessageIds(std::vector<MessageId>&& chunkedMessageIds) {
+        chunkedMessageIds_ = std::move(chunkedMessageIds);
+        setFirstChunkMessageId(chunkedMessageIds_.front());
+        setLastChunkMessageId(chunkedMessageIds_.back());
+    }
+
     std::shared_ptr<const MessageIdImpl> getFirstChunkMessageId() const { return firstChunkMsgId_; }
+
+    std::vector<MessageId> moveChunkedMessageIds() const noexcept {
+        return std::move(chunkedMessageIds_);
+    }
 
     MessageId build() { return MessageId{std::dynamic_pointer_cast<MessageIdImpl>(shared_from_this())}; }
 
    private:
     std::shared_ptr<MessageIdImpl> firstChunkMsgId_;
+    std::vector<MessageId> chunkedMessageIds_;
 };
 }  // namespace pulsar

--- a/lib/Commands.cc
+++ b/lib/Commands.cc
@@ -583,9 +583,9 @@ SharedBuffer Commands::newSeek(uint64_t consumerId, uint64_t requestId, const Me
 
     auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(messageId.impl_);
     if (chunkMsgId) {
-        auto firstId = chunkMsgId->getFirstChunkMessageId();
-        messageIdData.set_ledgerid(firstId->ledgerId_);
-        messageIdData.set_entryid(firstId->entryId_);
+        const auto& firstId = chunkMsgId->getChunkedMessageIds().front();
+        messageIdData.set_ledgerid(firstId.ledgerId());
+        messageIdData.set_entryid(firstId.entryId());
     } else {
         messageIdData.set_ledgerid(messageId.ledgerId());
         messageIdData.set_entryid(messageId.entryId());

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -479,8 +479,7 @@ boost::optional<SharedBuffer> ConsumerImpl::processMessageChunk(const SharedBuff
     }
 
     ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
-    chunkMsgId->setFirstChunkMessageId(chunkedMsgCtx.getChunkedMessageIds().front());
-    chunkMsgId->setLastChunkMessageId(chunkedMsgCtx.getChunkedMessageIds().back());
+    chunkMsgId->setChunkedMessageIds(chunkedMsgCtx.moveChunkedMessageIds());
     messageId = chunkMsgId->build();
 
     LOG_DEBUG("Chunked message completed chunkId: " << chunkId << ", ChunkedMessageCtx: " << chunkedMsgCtx
@@ -1165,6 +1164,9 @@ bool ConsumerImpl::isCumulativeAcknowledgementAllowed(ConsumerType consumerType)
 
 std::pair<MessageId, bool> ConsumerImpl::prepareIndividualAck(const MessageId& messageId) {
     auto messageIdImpl = Commands::getMessageIdImpl(messageId);
+    if (std::dynamic_pointer_cast<ChunkMessageIdImpl>(messageIdImpl)) {
+        return std::make_pair(messageId, true);
+    }
     auto batchedMessageIdImpl = std::dynamic_pointer_cast<BatchedMessageIdImpl>(messageIdImpl);
 
     auto batchSize = messageId.batchSize();

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -270,7 +270,7 @@ class ConsumerImpl : public ConsumerImplBase {
 
         const std::vector<MessageId>& getChunkedMessageIds() const noexcept { return chunkedMessageIds_; }
 
-        std::vector<MessageId> moveChunkedMessageIds() const noexcept {
+        std::vector<MessageId> moveChunkedMessageIds() noexcept {
             return std::move(chunkedMessageIds_);
         }
 

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -294,8 +294,6 @@ class ConsumerImpl : public ConsumerImplBase {
     // concurrently on the topic) then it guards against broken chunked message which was not fully published
     const bool autoAckOldestChunkedMessageOnQueueFull_;
 
-    // The key is UUID, value is the associated ChunkedMessageCtx of the chunked message.
-    std::unordered_map<std::string, ChunkedMessageCtx> chunkedMessagesMap_;
     // This list contains all the keys of `chunkedMessagesMap_`, each key is an UUID that identifies a pending
     // chunked message. Once the number of pending chunked messages exceeds the limit, the oldest UUIDs and
     // the associated ChunkedMessageCtx will be removed.

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -270,9 +270,7 @@ class ConsumerImpl : public ConsumerImplBase {
 
         const std::vector<MessageId>& getChunkedMessageIds() const noexcept { return chunkedMessageIds_; }
 
-        std::vector<MessageId> moveChunkedMessageIds() noexcept {
-            return std::move(chunkedMessageIds_);
-        }
+        std::vector<MessageId> moveChunkedMessageIds() noexcept { return std::move(chunkedMessageIds_); }
 
         long getReceivedTimeMs() const noexcept { return receivedTimeMs_; }
 

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -270,6 +270,10 @@ class ConsumerImpl : public ConsumerImplBase {
 
         const std::vector<MessageId>& getChunkedMessageIds() const noexcept { return chunkedMessageIds_; }
 
+        std::vector<MessageId> moveChunkedMessageIds() const noexcept {
+            return std::move(chunkedMessageIds_);
+        }
+
         long getReceivedTimeMs() const noexcept { return receivedTimeMs_; }
 
         friend std::ostream& operator<<(std::ostream& os, const ChunkedMessageCtx& ctx) {

--- a/lib/MessageId.cc
+++ b/lib/MessageId.cc
@@ -100,8 +100,8 @@ MessageId MessageId::deserialize(const std::string& serializedMessageId) {
 
     if (idData.has_first_chunk_message_id()) {
         ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
-        chunkMsgId->setFirstChunkMessageId(MessageIdBuilder::from(idData.first_chunk_message_id()).build());
-        chunkMsgId->setLastChunkMessageId(msgId);
+        chunkMsgId->setChunkedMessageIds(
+            {MessageIdBuilder::from(idData.first_chunk_message_id()).build(), msgId});
         return chunkMsgId->build();
     }
 

--- a/lib/MessageId.cc
+++ b/lib/MessageId.cc
@@ -76,11 +76,11 @@ void MessageId::serialize(std::string& result) const {
     auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(impl_);
     if (chunkMsgId) {
         proto::MessageIdData& firstChunkIdData = *idData.mutable_first_chunk_message_id();
-        auto firstChunkId = chunkMsgId->getFirstChunkMessageId();
-        firstChunkIdData.set_ledgerid(firstChunkId->ledgerId_);
-        firstChunkIdData.set_entryid(firstChunkId->entryId_);
+        const auto& firstChunkId = chunkMsgId->getChunkedMessageIds().front();
+        firstChunkIdData.set_ledgerid(firstChunkId.ledgerId());
+        firstChunkIdData.set_entryid(firstChunkId.entryId());
         if (chunkMsgId->partition_ != -1) {
-            firstChunkIdData.set_partition(firstChunkId->partition_);
+            firstChunkIdData.set_partition(firstChunkId.partition());
         }
     }
 
@@ -99,9 +99,8 @@ MessageId MessageId::deserialize(const std::string& serializedMessageId) {
     MessageId msgId = MessageIdBuilder::from(idData).build();
 
     if (idData.has_first_chunk_message_id()) {
-        ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
-        chunkMsgId->setChunkedMessageIds(
-            {MessageIdBuilder::from(idData.first_chunk_message_id()).build(), msgId});
+        ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>(
+            std::vector<MessageId>({MessageIdBuilder::from(idData.first_chunk_message_id()).build(), msgId}));
         return chunkMsgId->build();
     }
 
@@ -121,9 +120,9 @@ int32_t MessageId::batchSize() const { return impl_->batchSize_; }
 PULSAR_PUBLIC std::ostream& operator<<(std::ostream& s, const pulsar::MessageId& messageId) {
     auto chunkMsgId = std::dynamic_pointer_cast<ChunkMessageIdImpl>(messageId.impl_);
     if (chunkMsgId) {
-        auto firstId = chunkMsgId->getFirstChunkMessageId();
-        s << '(' << firstId->ledgerId_ << ',' << firstId->entryId_ << ',' << firstId->partition_ << ','
-          << firstId->batchIndex_ << ");";
+        const auto& firstId = chunkMsgId->getChunkedMessageIds().front();
+        s << '(' << firstId.ledgerId() << ',' << firstId.entryId() << ',' << firstId.partition() << ','
+          << firstId.batchIndex() << ");";
     }
     s << '(' << messageId.impl_->ledgerId_ << ',' << messageId.impl_->entryId_ << ','
       << messageId.impl_->partition_ << ',' << messageId.impl_->batchIndex_ << ')';

--- a/lib/OpSendMsg.h
+++ b/lib/OpSendMsg.h
@@ -45,6 +45,8 @@ struct SendArguments {
     SendArguments& operator=(const SendArguments&) = delete;
 };
 
+typedef std::shared_ptr<std::vector<MessageId>> ChunkMessageIdListPtr;
+
 struct OpSendMsg {
     const Result result;
     const int32_t chunkId;
@@ -54,8 +56,7 @@ struct OpSendMsg {
     const boost::posix_time::ptime timeout;
     const SendCallback sendCallback;
     std::vector<std::function<void(Result)>> trackerCallbacks;
-    ChunkMessageIdImplPtr chunkedMessageId;
-    std::vector<MessageId> chunkMessageIdList;
+    ChunkMessageIdListPtr chunkMessageIdList;
     // Use shared_ptr here because producer might resend the message with the same arguments
     const std::shared_ptr<SendArguments> sendArgs;
 
@@ -90,7 +91,7 @@ struct OpSendMsg {
           sendArgs(nullptr) {}
 
     OpSendMsg(const proto::MessageMetadata& metadata, uint32_t messagesCount, uint64_t messagesSize,
-              int sendTimeoutMs, SendCallback&& callback, ChunkMessageIdImplPtr chunkedMessageId,
+              int sendTimeoutMs, SendCallback&& callback, ChunkMessageIdListPtr chunkMessageIdList,
               uint64_t producerId, SharedBuffer payload)
         : result(ResultOk),
           chunkId(metadata.chunk_id()),
@@ -99,7 +100,7 @@ struct OpSendMsg {
           messagesSize(messagesSize),
           timeout(TimeUtils::now() + boost::posix_time::milliseconds(sendTimeoutMs)),
           sendCallback(std::move(callback)),
-          chunkedMessageId(chunkedMessageId),
+          chunkMessageIdList(std::move(chunkMessageIdList)),
           sendArgs(new SendArguments(producerId, metadata.sequence_id(), metadata, payload)) {}
 };
 

--- a/lib/OpSendMsg.h
+++ b/lib/OpSendMsg.h
@@ -55,6 +55,7 @@ struct OpSendMsg {
     const SendCallback sendCallback;
     std::vector<std::function<void(Result)>> trackerCallbacks;
     ChunkMessageIdImplPtr chunkedMessageId;
+    std::vector<MessageId> chunkMessageIdList;
     // Use shared_ptr here because producer might resend the message with the same arguments
     const std::shared_ptr<SendArguments> sendArgs;
 

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -910,7 +910,7 @@ bool ProducerImpl::ackReceived(uint64_t sequenceId, MessageId& rawMessageId) {
     // Message was persisted correctly
     LOG_DEBUG(getName() << "Received ack for msg " << sequenceId);
 
-    if (op.numChunks > 1) {
+    if (op.chunkMessageIdList) {
         // Handling the chunk message id.
         op.chunkMessageIdList->push_back(messageId);
         if (op.chunkId == op.numChunks - 1) {

--- a/tests/MessageChunkingTest.cc
+++ b/tests/MessageChunkingTest.cc
@@ -154,10 +154,8 @@ TEST_P(MessageChunkingTest, testEndToEnd) {
     waitUntil(
         std::chrono::seconds(10),
         [&] {
-            if (consumer.getBrokerConsumerStats(consumerStats) != ResultOk) {
-                return false;
-            }
-            return consumerStats.getMsgBacklog() == 0;
+            return consumer.getBrokerConsumerStats(consumerStats) == ResultOk &&
+                   consumerStats.getMsgBacklog() == 0;
         },
         1000);
     ASSERT_EQ(consumerStats.getMsgBacklog(), 0);
@@ -333,8 +331,8 @@ TEST(ChunkMessageIdTest, testSetChunkMessageId) {
     MessageId msgId;
     {
         ChunkMessageIdImplPtr chunkMsgId = std::make_shared<ChunkMessageIdImpl>();
-        chunkMsgId->setFirstChunkMessageId(MessageIdBuilder().ledgerId(1).entryId(2).partition(3).build());
-        chunkMsgId->setLastChunkMessageId(MessageIdBuilder().ledgerId(4).entryId(5).partition(6).build());
+        chunkMsgId->setChunkedMessageIds({MessageIdBuilder().ledgerId(1).entryId(2).partition(3).build(),
+                                          MessageIdBuilder().ledgerId(4).entryId(5).partition(6).build()});
         msgId = chunkMsgId->build();
         // Test the destructor of the underlying message id should also work for the generated messageId.
     }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes #320


### Motivation

Currently, the consumer only acknowledges the last chunk message ID. This will lead to some messages not being acknowledged and the message backlog doesn't get cleaned up.

### Modifications

Add the chunk message Id list into the ChunkedMessageIdImpl. When the consumer acknowledges a chunked message , it will acknowledge all message Ids in that list

### Verifying this change

This change is already covered by existing tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
