### PR TITLE
Fix pending requests failed with ResultConnectError when disconnecting

### DIFF
--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -142,6 +142,16 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
      */
     void tcpConnectAsync();
 
+    /**
+     * Close the connection.
+     *
+     * @param result all pending futures will complete with this result
+     * @param detach remove it from the pool if it's true
+     *
+     * `detach` should only be false when:
+     * 1. Before the connection is put into the pool, i.e. during the construction.
+     * 2. When the connection pool is closed
+     */
     void close(Result result = ResultConnectError, bool detach = true);
 
     bool isClosed() const;
@@ -392,7 +402,6 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     ConnectionPool& pool_;
     friend class PulsarFriend;
 
-    void closeSocket();
     void checkServerError(ServerError error);
 
     void handleSendReceipt(const proto::CommandSendReceipt&);

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -42,6 +42,7 @@
 #include "MessagesImpl.h"
 #include "ProducerConfigurationImpl.h"
 #include "PulsarApi.pb.h"
+#include "ResultUtils.h"
 #include "TimeUtils.h"
 #include "TopicName.h"
 #include "UnAckedMessageTrackerDisabled.h"
@@ -319,7 +320,7 @@ void ConsumerImpl::handleCreateConsumer(const ClientConnectionPtr& cnx, Result r
         } else {
             // Consumer was not yet created, retry to connect to broker if it's possible
             result = convertToTimeoutIfNecessary(result, creationTimestamp_);
-            if (result == ResultRetryable) {
+            if (isResultRetryable(result)) {
                 LOG_WARN(getName() << "Temporary error in creating consumer: " << strResult(result));
                 scheduleReconnection();
             } else {

--- a/lib/HandlerBase.cc
+++ b/lib/HandlerBase.cc
@@ -22,6 +22,7 @@
 #include "ClientImpl.h"
 #include "ExecutorService.h"
 #include "LogUtils.h"
+#include "ResultUtils.h"
 #include "TimeUtils.h"
 
 DECLARE_LOG_OBJECT()
@@ -117,7 +118,7 @@ void HandlerBase::handleDisconnection(Result result, const ClientConnectionPtr& 
 
     resetCnx();
 
-    if (result == ResultRetryable) {
+    if (isResultRetryable(result)) {
         scheduleReconnection();
         return;
     }
@@ -169,7 +170,7 @@ void HandlerBase::handleTimeout(const boost::system::error_code& ec) {
 }
 
 Result HandlerBase::convertToTimeoutIfNecessary(Result result, ptime startTimestamp) const {
-    if (result == ResultRetryable && (TimeUtils::now() - startTimestamp >= operationTimeut_)) {
+    if (isResultRetryable(result) && (TimeUtils::now() - startTimestamp >= operationTimeut_)) {
         return ResultTimeout;
     } else {
         return result;

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -36,6 +36,7 @@
 #include "OpSendMsg.h"
 #include "ProducerConfigurationImpl.h"
 #include "PulsarApi.pb.h"
+#include "ResultUtils.h"
 #include "Semaphore.h"
 #include "TimeUtils.h"
 #include "TopicName.h"
@@ -272,7 +273,7 @@ void ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result r
         } else {
             // Producer was not yet created, retry to connect to broker if it's possible
             result = convertToTimeoutIfNecessary(result, creationTimestamp_);
-            if (result == ResultRetryable) {
+            if (isResultRetryable(result)) {
                 LOG_WARN(getName() << "Temporary error in creating producer: " << strResult(result));
                 scheduleReconnection();
             } else {

--- a/lib/ResultUtils.h
+++ b/lib/ResultUtils.h
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <pulsar/Result.h>
+
+namespace pulsar {
+
+inline bool isResultRetryable(Result result) {
+    return result == ResultRetryable || result == ResultDisconnected;
+}
+
+}  // namespace pulsar

--- a/lib/RetryableOperation.h
+++ b/lib/RetryableOperation.h
@@ -29,6 +29,7 @@
 #include "ExecutorService.h"
 #include "Future.h"
 #include "LogUtils.h"
+#include "ResultUtils.h"
 
 namespace pulsar {
 
@@ -95,7 +96,7 @@ class RetryableOperation : public std::enable_shared_from_this<RetryableOperatio
                 promise_.setValue(value);
                 return;
             }
-            if (result != ResultRetryable) {
+            if (!isResultRetryable(result)) {
                 promise_.setFailed(result);
                 return;
             }


### PR DESCRIPTION
### Motivation

When there are multiple pending requests in the same `ClientConnection`, if one request failed with a retryable error, e.g. the `ServiceUnitNotReady` error when finding the owner broker of a topic, the socket will be closed in `checkServerError` and `close()` will be called subsequently in `handleRead` (`err` is `eof` or `operation_failed`). However, the default value of 1st parameter is `ResultConnectError` for `close`, which is not retryable.

### Modifications

If the connection is disconnected by the client, pass `ResultDisconnected` to `close` and treat it as retryable.

`closeSocket` is replaced with `close(ResultDisconnected)` to avoid the connection being the status that socket is closed but TLS stream is not closed.