### PR TITLE
Fix segmentation fault when sending messages after receiving an error

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -640,11 +640,11 @@ void ClientConnection::handleResolve(const boost::system::error_code& err,
 
 void ClientConnection::readNextCommand() {
     const static uint32_t minReadSize = sizeof(uint32_t);
-    auto weak_self = weak_from_this();
+    auto weakSelf = weak_from_this();
     asyncReceive(
         incomingBuffer_.asio_buffer(),
-        customAllocReadHandler([weak_self](const boost::system::error_code& err, size_t bytesTransferred) {
-            auto self = weak_self.lock();
+        customAllocReadHandler([weakSelf](const boost::system::error_code& err, size_t bytesTransferred) {
+            auto self = weakSelf.lock();
             if (self) {
                 self->handleRead(err, bytesTransferred, minReadSize);
             }
@@ -672,12 +672,12 @@ void ClientConnection::handleRead(const boost::system::error_code& err, size_t b
         // Read the remaining part, use a slice of buffer to write on the next
         // region
         SharedBuffer buffer = incomingBuffer_.slice(bytesTransferred);
-        auto weak_self = weak_from_this();
+        auto weakSelf = weak_from_this();
         auto nextMinReadSize = minReadSize - bytesTransferred;
         asyncReceive(buffer.asio_buffer(),
-                     customAllocReadHandler([weak_self, nextMinReadSize](const boost::system::error_code& err,
-                                                                         size_t bytesTransferred) {
-                         auto self = weak_self.lock();
+                     customAllocReadHandler([weakSelf, nextMinReadSize](const boost::system::error_code& err,
+                                                                        size_t bytesTransferred) {
+                         auto self = weakSelf.lock();
                          if (self) {
                              self->handleRead(err, bytesTransferred, nextMinReadSize);
                          }
@@ -707,12 +707,12 @@ void ClientConnection::processIncomingBuffer() {
                 uint32_t newBufferSize = std::max<uint32_t>(DefaultBufferSize, frameSize + sizeof(uint32_t));
                 incomingBuffer_ = SharedBuffer::copyFrom(incomingBuffer_, newBufferSize);
             }
-            auto weak_self = weak_from_this();
+            auto weakSelf = weak_from_this();
             asyncReceive(
                 incomingBuffer_.asio_buffer(),
-                customAllocReadHandler([weak_self, bytesToReceive](const boost::system::error_code& err,
-                                                                   size_t bytesTransferred) {
-                    auto self = weak_self.lock();
+                customAllocReadHandler([weakSelf, bytesToReceive](const boost::system::error_code& err,
+                                                                  size_t bytesTransferred) {
+                    auto self = weakSelf.lock();
                     if (self) {
                         self->handleRead(err, bytesTransferred, bytesToReceive);
                     }
@@ -793,11 +793,11 @@ void ClientConnection::processIncomingBuffer() {
         // At least we need to read 4 bytes to have the complete frame size
         uint32_t minReadSize = sizeof(uint32_t) - incomingBuffer_.readableBytes();
 
-        auto weak_self = weak_from_this();
+        auto weakSelf = weak_from_this();
         asyncReceive(incomingBuffer_.asio_buffer(),
-                     customAllocReadHandler([weak_self, minReadSize](const boost::system::error_code& err,
-                                                                     size_t bytesTransferred) {
-                         auto self = weak_self.lock();
+                     customAllocReadHandler([weakSelf, minReadSize](const boost::system::error_code& err,
+                                                                    size_t bytesTransferred) {
+                         auto self = weakSelf.lock();
                          if (self) {
                              self->handleRead(err, bytesTransferred, minReadSize);
                          }

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -40,9 +40,16 @@ docker compose -f tests/oauth2/docker-compose.yml down
 
 # Run BrokerMetadata tests
 docker compose -f tests/brokermetadata/docker-compose.yml up -d
-sleep 15
+until curl http://localhost:8080/metrics > /dev/null 2>&1 ; do sleep 1; done
+sleep 5
 $CMAKE_BUILD_DIRECTORY/tests/BrokerMetadataTest
 docker compose -f tests/brokermetadata/docker-compose.yml down
+
+docker compose -f tests/chunkdedup/docker-compose.yml up -d
+until curl http://localhost:8080/metrics > /dev/null 2>&1 ; do sleep 1; done
+sleep 5
+$CMAKE_BUILD_DIRECTORY/tests/ChunkDedupTest --gtest_repeat=10
+docker compose -f tests/chunkdedup/docker-compose.yml down
 
 ./pulsar-test-service-start.sh
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,3 +71,6 @@ target_link_libraries(BrokerMetadataTest ${CLIENT_LIBS} pulsarStatic ${GTEST_LIB
 add_executable(Oauth2Test oauth2/Oauth2Test.cc)
 target_compile_options(Oauth2Test PRIVATE "-DTEST_ROOT_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
 target_link_libraries(Oauth2Test ${CLIENT_LIBS} pulsarStatic ${GTEST_LIBRARY_PATH})
+
+add_executable(ChunkDedupTest chunkdedup/ChunkDedupTest.cc)
+target_link_libraries(ChunkDedupTest ${CLIENT_LIBS} pulsarStatic ${GTEST_LIBRARY_PATH})

--- a/tests/chunkdedup/ChunkDedupTest.cc
+++ b/tests/chunkdedup/ChunkDedupTest.cc
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/Client.h>
+
+#include "lib/Latch.h"
+#include "lib/LogUtils.h"
+
+DECLARE_LOG_OBJECT()
+
+using namespace pulsar;
+
+// Before https://github.com/apache/pulsar/pull/20948, when message deduplication is enabled, sending chunks
+// to the broker will receive send error response.
+TEST(ChunkDedupTest, testSendChunks) {
+    Client client{"pulsar://localhost:6650"};
+    ProducerConfiguration conf;
+    conf.setBatchingEnabled(false);
+    conf.setChunkingEnabled(true);
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer("test-send-chunks", conf, producer));
+
+    Latch latch{1};
+    std::string value(1024000 /* max message size */ * 100, 'a');
+    producer.sendAsync(MessageBuilder().setContent(value).build(),
+                       [&latch](Result result, const MessageId& msgId) {
+                           LOG_INFO("Send to " << msgId << ": " << result);
+                           latch.countdown();
+                       });
+    ASSERT_TRUE(latch.wait(std::chrono::seconds(10)));
+    client.close();
+}
+
+int main(int argc, char* argv[]) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/chunkdedup/docker-compose.yml
+++ b/tests/chunkdedup/docker-compose.yml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version: '3'
+networks:
+  pulsar:
+    driver: bridge
+services:
+  standalone:
+    image: apachepulsar/pulsar:3.1.0 # Ensure https://github.com/apache/pulsar/pull/20948 is not included
+    container_name: standalone
+    hostname: local
+    restart: "no"
+    networks:
+      - pulsar
+    environment:
+      - metadataStoreUrl=zk:localhost:2181
+      - clusterName=standalone
+      - advertisedAddress=localhost
+      - advertisedListeners=external:pulsar://localhost:6650
+      - PULSAR_MEM=-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m
+      - PULSAR_PREFIX_maxMessageSize=1024000
+      - PULSAR_PREFIX_brokerDeduplicationEnabled=true
+    ports:
+      - "6650:6650"
+      - "8080:8080"
+    command: bash -c "bin/apply-config-from-env.py conf/standalone.conf && exec bin/pulsar standalone -nss -nfw"
+

--- a/tests/chunkdedup/docker-compose.yml
+++ b/tests/chunkdedup/docker-compose.yml
@@ -23,7 +23,8 @@ networks:
     driver: bridge
 services:
   standalone:
-    image: apachepulsar/pulsar:3.1.0 # Ensure https://github.com/apache/pulsar/pull/20948 is not included
+    # Don't change the version here to ensure https://github.com/apache/pulsar/pull/20948 is not included
+    image: apachepulsar/pulsar:3.1.0
     container_name: standalone
     hostname: local
     restart: "no"


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/325

### Motivation

https://github.com/apache/pulsar-client-cpp/pull/317 introduces a bug that might cause segmentation fault when sending messages after receiving an error, see
https://github.com/apache/pulsar-client-cpp/issues/325#issuecomment-1751914150 for the detailed explanation.

### Modifications

When calling `asyncWrite`, capture the `shared_ptr` instead of the `weak_ptr` to extend the lifetime of the `socket_` or `tlsSocket_` field in `ClientConnection`. Since the lifetime is extended, in some callbacks, check `isClosed()` before other logic.

Add a `ChunkDedupTest` to reproduce this issue based on Pulsar 3.1.0. Run the test for 10 times to ensure it won't crash after this patch.