### PR TITLE
Fix possible deadlock of Future when adding a listener after completed

### DIFF
--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -23,6 +23,7 @@
 
 #include <boost/optional.hpp>
 #include <functional>
+#include <list>
 #include <memory>
 #include <utility>
 

--- a/lib/Future.h
+++ b/lib/Future.h
@@ -71,6 +71,8 @@ class InternalState {
         status_ = COMPLETED;
         cond_.notify_all();
 
+        lock.unlock();
+        lock.lock();
         if (!listeners_.empty()) {
             auto listeners = std::move(listeners_);
             lock.unlock();

--- a/lib/Future.h
+++ b/lib/Future.h
@@ -71,8 +71,6 @@ class InternalState {
         status_ = COMPLETED;
         cond_.notify_all();
 
-        lock.unlock();
-        lock.lock();
         if (!listeners_.empty()) {
             auto listeners = std::move(listeners_);
             lock.unlock();
@@ -100,7 +98,7 @@ class InternalState {
     decltype(listeners_.before_begin()) tailListener_{listeners_.before_begin()};
     Result result_;
     Type value_;
-    std::atomic<Status> status_;
+    std::atomic<Status> status_{INITIAL};
 };
 
 template <typename Result, typename Type>

--- a/lib/ProducerImpl.h
+++ b/lib/ProducerImpl.h
@@ -20,6 +20,7 @@
 #define LIB_PRODUCERIMPL_H_
 
 #include <boost/optional.hpp>
+#include <list>
 #include <memory>
 
 #include "Future.h"

--- a/tests/WaitUtils.h
+++ b/tests/WaitUtils.h
@@ -25,13 +25,13 @@
 namespace pulsar {
 
 template <typename Rep, typename Period>
-inline void waitUntil(std::chrono::duration<Rep, Period> timeout, const std::function<bool()>& condition,
+inline bool waitUntil(std::chrono::duration<Rep, Period> timeout, const std::function<bool()>& condition,
                       long durationMs = 10) {
     auto timeoutMs = std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
     while (timeoutMs > 0) {
         auto now = std::chrono::high_resolution_clock::now();
         if (condition()) {
-            break;
+            return true;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(durationMs));
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -39,6 +39,7 @@ inline void waitUntil(std::chrono::duration<Rep, Period> timeout, const std::fun
                            .count();
         timeoutMs -= elapsed;
     }
+    return false;
 }
 
 }  // namespace pulsar


### PR DESCRIPTION
### Motivation

There is a case that deadlock could happen for a `Future`. Assume there is a `Promise` and its `Future`.

1. Call `Future::addListener` to add a listener that tries to acquire a user-provided mutex (`lock`).
2. Thread 1: Acquire `lock` first.
3. Thread 2: Call `Promise::setValue`, the listener will be triggered first before completed. Since `lock` is held by Thread 1, the listener will be blocked.
4. Thread 1: Call `Future::addListener`, since it detects the `InternalState::completed_` is true, it will call `get` to retrieve the result and value.

Then, deadlock happens:
- Thread 1 waits for `lock` is released, and then complete `InternalState::future_`.
- Thread 2 holds `lock` but wait for `InternalState::future_` is completed.

In a real world case, if we acquire a lock before
`ProducerImpl::closeAsync`, then another thread call `setValue` in `ClientConnection::handleSuccess` and the callback of `createProducerAsync` tries to acquire the lock, `handleSuccess` will be blocked. Then in `closeAsync`, the current thread will be blocked in:

```c++
    cnx->sendRequestWithId(Commands::newCloseProducer(producerId_, requestId), requestId)
        .addListener([self, callback](Result result, const ResponseData&) { callback(result); });
```

The stacks:

```
Thread 1:
#11 0x00007fab80da2173 in pulsar::InternalState<...>::complete (this=0x3d53e7a10, result=..., value=...) at lib/Futre.h:61
#13 pulsar::ClientConnection::handleSuccess (this=this@entry=0x2214bc000, success=...) at lib/ClientConnection.cc:1552

Thread 2:
#8  get (result=..., this=0x3d53e7a10) at lib/Future.h:69
#9  pulsar::InternalState<...>::addListener (this=this@entry=0x3d53e7a10, listener=...) at lib/Future.h:51
#11 0x00007fab80e8dc4e in pulsar::ProducerImpl::closeAsync at lib/ProducerImpl.cc:794
```

There are two points that make the deadlock:
1. We use `completed_` to represent if the future is completed. However, after it's true, the future might not be completed because the value is not set and the listeners are not completed.
2. If `addListener` is called after it's completed, we still push the listener to `listeners_` so that previous listeners could be executed before the new listener. This guarantee is unnecessarily strong.

### Modifications

First, complete the future before calling the listeners.

Then, use an enum to represent the status:
- INITIAL: `complete` has not been called
- COMPLETING: when the 1st time `complete` is called, the status will change from INITIAL to COMPLETING
- COMPLETED: the future is completed.

Besides, implementation of `Future` is simplified. https://github.com/apache/pulsar-client-cpp/pull/299 fixes a possible mutex crash by introducing the `std::future`. However, the root cause is the conditional variable is not used correctly:

> Even if the shared variable is atomic, it must be modified while owning the mutex to correctly publish the modification to the waiting thread.

See https://en.cppreference.com/w/cpp/thread/condition_variable

The simplest way to fix
https://github.com/apache/pulsar-client-cpp/pull/298 is just adding `lock.lock()` before `state->condition.notify_all();`.