### PR TITLE
Upgrade libcurl to 8.4.0 to fix CVEs

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -24,4 +24,4 @@ zlib: 1.2.12
 zstd: 1.5.2
 snappy: 1.1.9
 openssl: 1.1.1q
-curl: 7.85.0
+curl: 8.4.0


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/327

See https://curl.se/docs/security.html