### PR TITLE
Use absolute path to find credential files in unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,8 @@ if (BUILD_DYNAMIC_LIB)
 endif()
 
 if (BUILD_TESTS)
+    set(TOKEN_PATH "${PROJECT_SOURCE_DIR}/.test-token.txt")
+    set(TEST_CONF_DIR "${PROJECT_SOURCE_DIR}/test-conf")
     add_subdirectory(tests)
 endif()
 

--- a/pulsar-test-service-start.sh
+++ b/pulsar-test-service-start.sh
@@ -20,8 +20,8 @@
 
 set -e
 
-SRC_DIR=$(git rev-parse --show-toplevel)
-cd $SRC_DIR
+cd `dirname $0`
+SRC_DIR=$PWD
 
 ./pulsar-test-service-stop.sh
 

--- a/pulsar-test-service-stop.sh
+++ b/pulsar-test-service-stop.sh
@@ -20,8 +20,8 @@
 
 set -e
 
-SRC_DIR=$(git rev-parse --show-toplevel)
-cd $SRC_DIR
+cd `dirname $0`
+SRC_DIR=$PWD
 
 CONTAINER_ID_PATH=".tests-container-id.txt"
 

--- a/tests/AuthBasicTest.cc
+++ b/tests/AuthBasicTest.cc
@@ -25,13 +25,17 @@
 
 using namespace pulsar;
 
+#ifndef TEST_CONF_DIR
+#error "TEST_CONF_DIR is not specified"
+#endif
+
 static const std::string serviceUrl = "pulsar://localhost:6650";
 static const std::string serviceUrlHttp = "http://localhost:8080";
 static const std::string serviceUrlTls = "pulsar+ssl://localhost:6651";
 static const std::string serviceUrlHttps = "https://localhost:8443";
-static const std::string caPath = "../test-conf/cacert.pem";
-static const std::string clientCertificatePath = "../test-conf/client-cert.pem";
-static const std::string clientPrivateKeyPath = "../test-conf/client-key.pem";
+static const std::string caPath = TEST_CONF_DIR "/cacert.pem";
+static const std::string clientCertificatePath = TEST_CONF_DIR "/client-cert.pem";
+static const std::string clientPrivateKeyPath = TEST_CONF_DIR "/client-key.pem";
 
 TEST(AuthPluginBasic, testBasic) {
     ClientConfiguration config = ClientConfiguration();

--- a/tests/AuthPluginTest.cc
+++ b/tests/AuthPluginTest.cc
@@ -37,15 +37,19 @@ int globalTestTlsMessagesCounter = 0;
 static const std::string serviceUrlTls = "pulsar+ssl://localhost:6651";
 static const std::string serviceUrlHttps = "https://localhost:8443";
 
-static const std::string caPath = "../test-conf/cacert.pem";
-static const std::string clientPublicKeyPath = "../test-conf/client-cert.pem";
-static const std::string clientPrivateKeyPath = "../test-conf/client-key.pem";
+#ifndef TEST_CONF_DIR
+#error "TEST_CONF_DIR is not specified"
+#endif
+
+static const std::string caPath = TEST_CONF_DIR "/cacert.pem";
+static const std::string clientPublicKeyPath = TEST_CONF_DIR "/client-cert.pem";
+static const std::string clientPrivateKeyPath = TEST_CONF_DIR "/client-key.pem";
 
 // Man in middle certificate which tries to act as a broker by sending its own valid certificate
 static const std::string mimServiceUrlTls = "pulsar+ssl://localhost:6653";
 static const std::string mimServiceUrlHttps = "https://localhost:8444";
 
-static const std::string mimCaPath = "../test-conf/hn-verification/cacert.pem";
+static const std::string mimCaPath = TEST_CONF_DIR "/hn-verification/cacert.pem";
 
 static void sendCallBackTls(Result r, const MessageId& msgId) {
     ASSERT_EQ(r, ResultOk);
@@ -468,11 +472,15 @@ TEST(AuthPluginTest, testOauth2WrongSecret) {
 TEST(AuthPluginTest, testOauth2CredentialFile) {
     // test success get token from oauth2 server.
     pulsar::AuthenticationDataPtr data;
-    std::string params = R"({
+    const char* paramsTemplate = R"({
         "type": "client_credentials",
         "issuer_url": "https://dev-kt-aa9ne.us.auth0.com",
-        "private_key": "../test-conf/cpp_credentials_file.json",
+        "private_key": "%s/cpp_credentials_file.json",
         "audience": "https://dev-kt-aa9ne.us.auth0.com/api/v2/"})";
+
+    char params[4096];
+    int numWritten = snprintf(params, sizeof(params), paramsTemplate, TEST_CONF_DIR);
+    ASSERT_TRUE(numWritten < sizeof(params));
 
     int expectedTokenLength = 3379;
     LOG_INFO("PARAMS: " << params);

--- a/tests/AuthTokenTest.cc
+++ b/tests/AuthTokenTest.cc
@@ -37,7 +37,11 @@ using namespace pulsar;
 static const std::string serviceUrl = "pulsar://localhost:6650";
 static const std::string serviceUrlHttp = "http://localhost:8080";
 
-static const std::string tokenPath = "../.test-token.txt";
+#ifndef TOKEN_PATH
+#error "TOKEN_PATH is not specified"
+#endif
+
+static const std::string tokenPath = TOKEN_PATH;
 
 static std::string getToken() {
     std::ifstream file(tokenPath);

--- a/tests/BasicEndToEndTest.cc
+++ b/tests/BasicEndToEndTest.cc
@@ -54,6 +54,10 @@ DECLARE_LOG_OBJECT()
 
 using namespace pulsar;
 
+#ifndef TEST_CONF_DIR
+#error "TEST_CONF_DIR is not specified"
+#endif
+
 std::mutex mutex_;
 static int globalCount = 0;
 static long globalResendMessageCount = 0;
@@ -1341,9 +1345,9 @@ TEST(BasicEndToEndTest, testRSAEncryption) {
     std::string subName = "my-sub-name";
     Producer producer;
 
-    std::string PUBLIC_CERT_FILE_PATH = "../test-conf/public-key.client-rsa.pem";
+    std::string PUBLIC_CERT_FILE_PATH = TEST_CONF_DIR "/public-key.client-rsa.pem";
 
-    std::string PRIVATE_CERT_FILE_PATH = "../test-conf//private-key.client-rsa.pem";
+    std::string PRIVATE_CERT_FILE_PATH = TEST_CONF_DIR "/private-key.client-rsa.pem";
 
     std::shared_ptr<pulsar::DefaultCryptoKeyReader> keyReader =
         std::make_shared<pulsar::DefaultCryptoKeyReader>(PUBLIC_CERT_FILE_PATH, PRIVATE_CERT_FILE_PATH);
@@ -1407,9 +1411,9 @@ TEST(BasicEndToEndTest, testEncryptionFailure) {
     std::string subName = "my-sub-name";
     Producer producer;
 
-    std::string PUBLIC_CERT_FILE_PATH = "../test-conf/public-key.client-rsa-test.pem";
+    std::string PUBLIC_CERT_FILE_PATH = TEST_CONF_DIR "/public-key.client-rsa-test.pem";
 
-    std::string PRIVATE_CERT_FILE_PATH = "../test-conf//private-key.client-rsa-test.pem";
+    std::string PRIVATE_CERT_FILE_PATH = TEST_CONF_DIR "/private-key.client-rsa-test.pem";
 
     std::shared_ptr<pulsar::DefaultCryptoKeyReader> keyReader =
         std::make_shared<pulsar::DefaultCryptoKeyReader>(PUBLIC_CERT_FILE_PATH, PRIVATE_CERT_FILE_PATH);
@@ -1449,9 +1453,9 @@ TEST(BasicEndToEndTest, testEncryptionFailure) {
 
     // 2. Add valid key
     {
-        PUBLIC_CERT_FILE_PATH = "../test-conf/public-key.client-rsa.pem";
+        PUBLIC_CERT_FILE_PATH = TEST_CONF_DIR "/public-key.client-rsa.pem";
 
-        PRIVATE_CERT_FILE_PATH = "../test-conf/private-key.client-rsa.pem";
+        PRIVATE_CERT_FILE_PATH = TEST_CONF_DIR "/private-key.client-rsa.pem";
         keyReader =
             std::make_shared<pulsar::DefaultCryptoKeyReader>(PUBLIC_CERT_FILE_PATH, PRIVATE_CERT_FILE_PATH);
         ProducerConfiguration prodConf;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,7 +57,7 @@ file(GLOB TEST_SOURCES *.cc c/*.cc)
 add_executable(pulsar-tests ${TEST_SOURCES} ${PROTO_SOURCES})
 
 target_include_directories(pulsar-tests PRIVATE ${AUTOGEN_DIR}/lib)
-
+target_compile_options(pulsar-tests PRIVATE -DTOKEN_PATH="${TOKEN_PATH}" -DTEST_CONF_DIR="${TEST_CONF_DIR}")
 target_link_libraries(pulsar-tests ${CLIENT_LIBS} pulsarStatic $<$<CONFIG:Debug>:${GMOCKD_LIBRARY_PATH}> $<$<CONFIG:Debug>:${GTESTD_LIBRARY_PATH}> $<$<NOT:$<CONFIG:Debug>>:${GMOCK_LIBRARY_PATH}> $<$<NOT:$<CONFIG:Debug>>:${GTEST_LIBRARY_PATH}>)
 
 if (UNIX)
@@ -69,7 +69,7 @@ add_executable(BrokerMetadataTest brokermetadata/BrokerMetadataTest.cc)
 target_link_libraries(BrokerMetadataTest ${CLIENT_LIBS} pulsarStatic ${GTEST_LIBRARY_PATH})
 
 add_executable(Oauth2Test oauth2/Oauth2Test.cc)
-target_compile_options(Oauth2Test PRIVATE "-DTEST_ROOT_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
+target_compile_options(Oauth2Test PRIVATE -DTEST_CONF_DIR="${TEST_CONF_DIR}")
 target_link_libraries(Oauth2Test ${CLIENT_LIBS} pulsarStatic ${GTEST_LIBRARY_PATH})
 
 add_executable(ChunkDedupTest chunkdedup/ChunkDedupTest.cc)

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -50,6 +50,10 @@ static const std::string adminUrl = "http://localhost:8080/";
 
 DECLARE_LOG_OBJECT()
 
+#ifndef TEST_CONF_DIR
+#error "TEST_CONF_DIR is not specified"
+#endif
+
 namespace pulsar {
 
 class ConsumerStateEventListener : public ConsumerEventListener {
@@ -960,8 +964,8 @@ TEST(ConsumerTest, testRedeliveryOfDecryptionFailedMessages) {
     std::string topicName = "testRedeliveryOfDecryptionFailedMessages" + std::to_string(time(nullptr));
     std::string subName = "sub-test";
 
-    std::string PUBLIC_CERT_FILE_PATH = "../test-conf/public-key.client-rsa.pem";
-    std::string PRIVATE_CERT_FILE_PATH = "../test-conf/private-key.client-rsa.pem";
+    std::string PUBLIC_CERT_FILE_PATH = TEST_CONF_DIR "/public-key.client-rsa.pem";
+    std::string PRIVATE_CERT_FILE_PATH = TEST_CONF_DIR "/private-key.client-rsa.pem";
     std::shared_ptr<pulsar::DefaultCryptoKeyReader> keyReader =
         std::make_shared<pulsar::DefaultCryptoKeyReader>(PUBLIC_CERT_FILE_PATH, PRIVATE_CERT_FILE_PATH);
 

--- a/tests/oauth2/Oauth2Test.cc
+++ b/tests/oauth2/Oauth2Test.cc
@@ -27,11 +27,11 @@
 
 using namespace pulsar;
 
-#ifndef TEST_ROOT_PATH
-#define TEST_ROOT_PATH "."
+#ifndef TEST_CONF_DIR
+#error "TEST_CONF_DIR is not specified"
 #endif
 
-static const std::string gKeyPath = std::string(TEST_ROOT_PATH) + "/../test-conf/cpp_credentials_file.json";
+static const std::string gKeyPath = TEST_CONF_DIR "/cpp_credentials_file.json";
 static std::string gClientId;
 static std::string gClientSecret;
 static ParamMap gCommonParams;


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/339

### Motivation

Currently the relative path is used in unit tests to specify the token file (`.test-token.txt`) and the credential directory (`./test-conf`). If we don't run the `pulsar-tests` binary in a subdirectory, it won't be able to read these files.

### Modifications

Add the macro `-DTOKEN_PATH="..." -DTEST_CONF_DIR="..."` to specify absolute paths according to the `PROJECT_SOURCE_DIR`, which is defined by CMake as the absolute path of the project directory.

### Verifications

```bash
cmake -B build
cmake --build build -j8
# Run the test in project directory
./build/tests/pulsar-tests --gtest_filter='AuthPlugin*:*testRSAEncryption:*testEncryptionFailure:*DecryptionFailedMessages'
# Run the test in a subdirectory
cd build
./tests/pulsar-tests --gtest_filter='AuthPlugin*:*testRSAEncryption:*testEncryptionFailure:*DecryptionFailedMessages'
```