### PR TITLE
Fix lazy partitioned producer might send duplicated messages

### DIFF
--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -234,8 +234,7 @@ void PartitionedProducerImpl::sendAsync(const Message& msg, SendCallback callbac
         producer->getProducerCreatedFuture().addListener(
             [msg, callback](Result result, ProducerImplBaseWeakPtr weakProducer) {
                 if (result == ResultOk) {
-                    std::dynamic_pointer_cast<ProducerImpl>(weakProducer.lock())
-                        ->sendAsync(msg, std::move(callback));
+                    weakProducer.lock()->sendAsync(msg, std::move(callback));
                 } else if (callback) {
                     callback(result, {});
                 }

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -60,8 +60,9 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const TopicName& topicName,
       userProvidedProducerName_(false),
       producerStr_("[" + topic() + ", " + producerName_ + "] "),
       producerId_(client->newProducerId()),
-      msgSequenceGenerator_(0),
       batchTimer_(executor_->createDeadlineTimer()),
+      lastSequenceIdPublished_(conf.getInitialSequenceId()),
+      msgSequenceGenerator_(lastSequenceIdPublished_ + 1),
       sendTimer_(executor_->createDeadlineTimer()),
       dataKeyRefreshTask_(*executor_, 4 * 60 * 60 * 1000),
       memoryLimitController_(client->getMemoryLimitController()),
@@ -69,11 +70,6 @@ ProducerImpl::ProducerImpl(ClientImplPtr client, const TopicName& topicName,
       interceptors_(interceptors) {
     LOG_DEBUG("ProducerName - " << producerName_ << " Created producer on topic " << topic()
                                 << " id: " << producerId_);
-
-    int64_t initialSequenceId = conf.getInitialSequenceId();
-    lastSequenceIdPublished_ = initialSequenceId;
-    msgSequenceGenerator_ = initialSequenceId + 1;
-
     if (!producerName_.empty()) {
         userProvidedProducerName_ = true;
     }

--- a/lib/ProducerImpl.h
+++ b/lib/ProducerImpl.h
@@ -19,6 +19,7 @@
 #ifndef LIB_PRODUCERIMPL_H_
 #define LIB_PRODUCERIMPL_H_
 
+#include <atomic>
 #include <boost/optional.hpp>
 #include <list>
 #include <memory>
@@ -103,6 +104,8 @@ class ProducerImpl : public HandlerBase, public ProducerImplBase {
 
     ProducerImplWeakPtr weak_from_this() noexcept { return shared_from_this(); }
 
+    bool ready() const { return producerCreatedPromise_.isComplete(); }
+
    protected:
     ProducerStatsBasePtr producerStatsBasePtr_;
 
@@ -169,13 +172,13 @@ class ProducerImpl : public HandlerBase, public ProducerImplBase {
     bool userProvidedProducerName_;
     std::string producerStr_;
     uint64_t producerId_;
-    int64_t msgSequenceGenerator_;
 
     std::unique_ptr<BatchMessageContainerBase> batchMessageContainer_;
     DeadlineTimerPtr batchTimer_;
     PendingFailures batchMessageAndSend(const FlushCallback& flushCallback = nullptr);
 
-    volatile int64_t lastSequenceIdPublished_;
+    std::atomic_int64_t lastSequenceIdPublished_;
+    std::atomic_int64_t msgSequenceGenerator_;
     std::string schemaVersion_;
 
     DeadlineTimerPtr sendTimer_;

--- a/lib/ProducerImpl.h
+++ b/lib/ProducerImpl.h
@@ -177,8 +177,8 @@ class ProducerImpl : public HandlerBase, public ProducerImplBase {
     DeadlineTimerPtr batchTimer_;
     PendingFailures batchMessageAndSend(const FlushCallback& flushCallback = nullptr);
 
-    std::atomic_int64_t lastSequenceIdPublished_;
-    std::atomic_int64_t msgSequenceGenerator_;
+    std::atomic<int64_t> lastSequenceIdPublished_;
+    std::atomic<int64_t> msgSequenceGenerator_;
     std::string schemaVersion_;
 
     DeadlineTimerPtr sendTimer_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,5 +72,5 @@ add_executable(Oauth2Test oauth2/Oauth2Test.cc)
 target_compile_options(Oauth2Test PRIVATE -DTEST_CONF_DIR="${TEST_CONF_DIR}")
 target_link_libraries(Oauth2Test ${CLIENT_LIBS} pulsarStatic ${GTEST_LIBRARY_PATH})
 
-add_executable(ChunkDedupTest chunkdedup/ChunkDedupTest.cc)
+add_executable(ChunkDedupTest chunkdedup/ChunkDedupTest.cc HttpHelper.cc)
 target_link_libraries(ChunkDedupTest ${CLIENT_LIBS} pulsarStatic ${GTEST_LIBRARY_PATH})


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/341

### Motivation

When a lazy partitioned producer sends two messages, the flow is:
1. `start` is called to grab the connection via `grab()`.
2. Generate 0 as the sequence id of the 1st message.
3. Add the 1st message into the queue.
4. The connection is established, `msgSequenceGenerator_` is reset from 1 to 0.
5. When sending the 2nd message, 0 is also generated as the sequence id.

Then two messages have the same sequence id.

### Modifications

For lazy partitioned producers, if the internal producer is not started, sending the message in the callback of its future.

Add `ChunkDedupTest#testLazyPartitionedProducer` to verify it since only the `tests/chunkdedup/docker-compose.yml` enables the deduplication.