### PR TITLE
Fix crash when removing connection from the pool

### DIFF
--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -129,7 +129,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     ClientConnection(const std::string& logicalAddress, const std::string& physicalAddress,
                      ExecutorServicePtr executor, const ClientConfiguration& clientConfiguration,
                      const AuthenticationPtr& authentication, const std::string& clientVersion,
-                     ConnectionPool& pool);
+                     ConnectionPool& pool, size_t poolIndex);
     ~ClientConnection();
 
 #if __cplusplus < 201703L
@@ -400,6 +400,8 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     const std::string clientVersion_;
     ConnectionPool& pool_;
+    const size_t poolIndex_;
+
     friend class PulsarFriend;
 
     void checkServerError(ServerError error);

--- a/tests/PulsarFriend.h
+++ b/tests/PulsarFriend.h
@@ -140,6 +140,8 @@ class PulsarFriend {
         return connections;
     }
 
+    static ExecutorServicePtr getExecutor(const ClientConnection& cnx) { return cnx.executor_; }
+
     static std::vector<ProducerImplPtr> getProducers(const ClientConnection& cnx) {
         std::vector<ProducerImplPtr> producers;
         std::lock_guard<std::mutex> lock(cnx.mutex_);


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/346

### Motivation

https://github.com/apache/pulsar-client-cpp/pull/336 changes the key of the `ClientConnection` in `ConnectionPool`, while in `ClientConnection::close`, it still passes the old key (logical address) to `ConnectionPool::remove`, which results in the connection could never be removed and destroyed until being deleted as a stale connection.

What's worse, if the key does not exist, the iterator returned by `std::map::find` will still be dereferenced, which might cause crash in some platforms. See
https://github.com/apache/pulsar-client-cpp/blob/8d32fd254e294d1fabba73aed70115a434b341ef/lib/ConnectionPool.cc#L122-L123

### Modifications

- Avoid dereferencing the iterator if it's invalid in `ConnectionPool::remove`.
- Store the key suffix in `ClientConnection` and pass the correct key to `ConnectionPool::remove` in `ClientConnection::close`
- Add `ClientTest.testConnectionClose` to verify `ClientConnection::close` can remove itself from the pool and the connection will be destroyed eventually.