### PR TITLE
Fix bad_weak_ptr when close a ClientConnection during construction

### DIFF
--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -148,9 +148,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
      * @param result all pending futures will complete with this result
      * @param detach remove it from the pool if it's true
      *
-     * `detach` should only be false when:
-     * 1. Before the connection is put into the pool, i.e. during the construction.
-     * 2. When the connection pool is closed
+     * `detach` should only be false when the connection pool is closed.
      */
     void close(Result result = ResultConnectError, bool detach = true);
 

--- a/lib/ConnectionPool.cc
+++ b/lib/ConnectionPool.cc
@@ -99,6 +99,10 @@ Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(const
         cnx.reset(new ClientConnection(logicalAddress, physicalAddress, executorProvider_->get(keySuffix),
                                        clientConfiguration_, authentication_, clientVersion_, *this,
                                        keySuffix));
+    } catch (Result result) {
+        Promise<Result, ClientConnectionWeakPtr> promise;
+        promise.setFailed(result);
+        return promise.getFuture();
     } catch (const std::runtime_error& e) {
         lock.unlock();
         LOG_ERROR("Failed to create connection: " << e.what())

--- a/tests/AuthPluginTest.cc
+++ b/tests/AuthPluginTest.cc
@@ -581,3 +581,19 @@ TEST(AuthPluginTest, testOauth2Failure) {
     ASSERT_EQ(client5.createProducer(topic, producer), ResultAuthenticationError);
     client5.close();
 }
+
+TEST(AuthPluginTest, testInvalidPlugin) {
+    Client client("pulsar://localhost:6650", ClientConfiguration{}.setAuth(AuthFactory::create("invalid")));
+    Producer producer;
+    ASSERT_EQ(ResultAuthenticationError, client.createProducer("my-topic", producer));
+    client.close();
+}
+
+TEST(AuthPluginTest, testTlsConfigError) {
+    Client client(serviceUrlTls, ClientConfiguration{}
+                                     .setAuth(AuthTls::create(clientPublicKeyPath, clientPrivateKeyPath))
+                                     .setTlsTrustCertsFilePath("invalid"));
+    Producer producer;
+    ASSERT_EQ(ResultAuthenticationError, client.createProducer("my-topic", producer));
+    client.close();
+}


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/348

Fixes https://github.com/apache/pulsar-client-cpp/issues/349

### Motivation

When `close` is called in `ClientConnection`'s constructor,
`shared_from_this()` will be called, which results in a
`std::bad_weak_ptr` error. This error does not happen before
https://github.com/apache/pulsar-client-cpp/pull/317 because
`shared_from_this()` could only be called when the `producers` or
`consumers` field is not empty.

### Modifications

Add a `ResultException` and throw it if there is a failure in
`ClientConnection`'s constructor and catch it in
`ConnectionPool::getConnectionAsync`. Then retrieve the result and
return the failed future.

Since `close` is now always called on a constructed `ClientConnection`
object, remove the 2nd parameter.

In addition, check `authentication_` even for non-TLS URLs. Otherwise,
the null authentication will be used to construct `CommandConnect`.

Add `testInvalidPlugin` and `testTlsConfigError` to verify the changes.