### PR TITLE
Log topic lookup result

### DIFF
--- a/lib/BinaryProtoLookupService.cc
+++ b/lib/BinaryProtoLookupService.cc
@@ -83,7 +83,8 @@ auto BinaryProtoLookupService::findBroker(const std::string& address, bool autho
                         }
                     });
             } else {
-                LOG_DEBUG("Lookup response for " << topic << ", lookup-broker-url " << data->getBrokerUrl());
+                LOG_INFO("Lookup response for " << topic << ", lookup-broker-url " << data->getBrokerUrl()
+                                                << ", from " << cnx->cnxString());
                 if (data->shouldProxyThroughServiceUrl()) {
                     // logicalAddress is the proxy's address, we should still connect through proxy
                     promise->setValue({responseBrokerAddress, address});


### PR DESCRIPTION
### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Log topic lookup result to help debug lookup phrase problems, such as when an abnormal broker returns incorrect lookup results.

### Modifications

* Change to use LOG_INFO
* Add connection string to show the response broker

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework  without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
trivial rework

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
