### PR TITLE
Fix the flush callback might be called repeatedly

### DIFF
--- a/lib/BatchMessageKeyBasedContainer.cc
+++ b/lib/BatchMessageKeyBasedContainer.cc
@@ -77,11 +77,16 @@ std::vector<std::unique_ptr<OpSendMsg>> BatchMessageKeyBasedContainer::createOpS
     // Store raw pointers to use std::sort
     std::vector<OpSendMsg*> rawOpSendMsgs;
     for (auto& kv : batches_) {
-        rawOpSendMsgs.emplace_back(createOpSendMsgHelper(kv.second).release());
+        if (!kv.second.empty()) {
+            rawOpSendMsgs.emplace_back(createOpSendMsgHelper(kv.second).release());
+        }
     }
     std::sort(rawOpSendMsgs.begin(), rawOpSendMsgs.end(), [](const OpSendMsg* lhs, const OpSendMsg* rhs) {
         return lhs->sendArgs->sequenceId < rhs->sendArgs->sequenceId;
     });
+    if (rawOpSendMsgs.empty()) {
+        return {};
+    }
     rawOpSendMsgs.back()->addTrackerCallback(flushCallback);
 
     std::vector<std::unique_ptr<OpSendMsg>> opSendMsgs{rawOpSendMsgs.size()};


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/352

### Motivation

https://github.com/apache/pulsar-client-cpp/pull/303 adds the flush callback to the last `OpSendMsg` instead of adding to the batch message container. However, `batchMessageAndSend` will create an `OpSendMsg` and add it to the `pendingMessagesQueue_`.

https://github.com/apache/pulsar-client-cpp/blob/7bb94f45b917ed30b5302ac93ffa1f1942fc6313/lib/ProducerImpl.cc#L384-L389

In the code above, `pendingMessagesQueue_` could never be empty and the callback will be added again by `opSendMsg->addTrackerCallback`. The 1st time it's added in `createOpSendMsg` or `createOpSendMsgs` called by `batchMessageAndSend`.

### Motivation

Add the callback to the last `OpSendMsg only when the batch message container is empty.

In `testFlushBatch`, replace the `flush` call with the `flushAsync` call and verify the callback is only called once after it's completed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
