### PR TITLE
Fix HTTP lookup segfault when the redirect host cannot be resolved

### DIFF
--- a/lib/CurlWrapper.h
+++ b/lib/CurlWrapper.h
@@ -172,7 +172,10 @@ inline CurlWrapper::Result CurlWrapper::get(const std::string& url, const std::s
     if (responseCode == 307 || responseCode == 302 || responseCode == 301) {
         char* url;
         curl_easy_getinfo(handle_, CURLINFO_REDIRECT_URL, &url);
-        result.redirectUrl = url;
+        // `url` is null when the host of the redirect URL cannot be resolved
+        if (url) {
+            result.redirectUrl = url;
+        }
     }
     return result;
 }


### PR DESCRIPTION
### Motivation

When the host of the redirect URL cannot be resolved, segmentation fault will happen:
https://github.com/apache/pulsar-client-cpp/blob/0bbc15502905d19c630d237b5e102bfb996bb098/lib/CurlWrapper.h#L173-L175

In this case, `curl` will be `nullptr`. Assigning a nullptr to a `std::string` is an undefined behavior that might cause segfault.

### Modifications

Check if `url` is nullptr in `CurlWrapper::get` and before assigning it to the `redirectUrl` field. Improve the
`HTTPLookupService::sendHTTPRequest` method by configuring the `maxLookupRedirects` instead of a loop and print more detailed error messages.

### Verifications

It's hard to mock a redirect case so I have to modify the `TopicLookupBase#internalLookupTopicAsync` in broker side and return a 307 response.

When I return a `http://unknown:8080` as the redirect URL:

```
2023-11-23 17:06:12.821 ERROR [0x16d31b000] HTTPLookupService:246 | Response failed for url http://localhost:8080/lookup/v2/topic/persistent/public/default/my-topic: Couldn't resolve host name, curl error: Could not resolve host: unknown
```

Before this patch, it will crash.

When I just return a `http://localhost:8080` as the redirect URL:

```
2023-11-23 17:15:06.267 ERROR [0x16d657000] HTTPLookupService:243 | Response received for url http://localhost:8080/lookup/v2/topic/persistent/public/default/my-topic: Number of redirects hit maximum amount, curl error: Maximum (20) redirects followed, redirect URL: http://localhost:8080/lookup/v2/topic/persistent/public/default/my-topic?authoritative=false
```

Before this patch, it will print similar logs 20 times.