### PR TITLE
Install Version.h when installing by CMakeLists

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -156,3 +156,4 @@ if (BUILD_DYNAMIC_LIB)
 endif()
 
 install(DIRECTORY "../include/pulsar" DESTINATION include)
+install(FILES "${PROJECT_BINARY_DIR}/include/pulsar/Version.h" DESTINATION include/pulsar/)


### PR DESCRIPTION
### Motivation

The macOS pre-built binaries don't include the Version.h generated from CMake. It's because `cmake --target install` does not install the `Version.h`, which is generated by `configure_file`.

### Modifications

Install the `Version.h`.
