### PR TITLE
Fix tlsTrustCertsFilePath config is not applied for OAuth2

### DIFF
--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include "ClientConfigurationImpl.h"
+#include "auth/AuthOauth2.h"
 
 namespace pulsar {
 

--- a/lib/auth/AuthOauth2.cc
+++ b/lib/auth/AuthOauth2.cc
@@ -342,8 +342,13 @@ Oauth2TokenResultPtr ClientCredentialFlow::authenticate() {
 
     CurlWrapper::Options options;
     options.postFields = std::move(postData);
-    auto result =
-        curl.get(tokenEndPoint_, "Content-Type: application/x-www-form-urlencoded", options, nullptr);
+    std::unique_ptr<CurlWrapper::TlsContext> tlsContext;
+    if (!tlsTrustCertsFilePath_.empty()) {
+        tlsContext.reset(new CurlWrapper::TlsContext);
+        tlsContext->trustCertsFilePath = tlsTrustCertsFilePath_;
+    }
+    auto result = curl.get(tokenEndPoint_, "Content-Type: application/x-www-form-urlencoded", options,
+                           tlsContext.get());
     if (!result.error.empty()) {
         LOG_ERROR("Failed to get the well-known configuration " << issuerUrl_ << ": " << result.error);
         return resultPtr;

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -35,7 +35,14 @@ docker compose -f tests/oauth2/docker-compose.yml up -d
 # Wait until the namespace is created, currently there is no good way to check it
 # because it's hard to configure OAuth2 authentication via CLI.
 sleep 15
-$CMAKE_BUILD_DIRECTORY/tests/Oauth2Test
+$CMAKE_BUILD_DIRECTORY/tests/Oauth2Test --gtest_filter='-*testTlsTrustFilePath'
+if [[ -f /etc/ssl/certs/ca-certificates.crt ]]; then
+    sudo mv /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/my-cert.crt
+fi
+$CMAKE_BUILD_DIRECTORY/tests/Oauth2Test --gtest_filter='*testTlsTrustFilePath'
+if [[ -f /etc/ssl/certs/my-cert.crt ]]; then
+    sudo mv /etc/ssl/certs/my-cert.crt /etc/ssl/certs/ca-certificates.crt
+fi
 docker compose -f tests/oauth2/docker-compose.yml down
 
 # Run BrokerMetadata tests


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/363

### Motivation

https://github.com/apache/pulsar-client-cpp/pull/313 has reverted the fix of https://github.com/apache/pulsar-client-cpp/pull/190, which applies the `tlsTrustCertsFilePath` config for OAuth2 authentication.

The macOS pre-built libraries are affected most because the bundled CA path is empty.

### Modification

Apply the `tlsTrustCertsFilePath` for OAuth2.