### PR TITLE
[feat] [C API] Expose Get/Set Listener Name in C API

### DIFF
--- a/include/pulsar/c/client_configuration.h
+++ b/include/pulsar/c/client_configuration.h
@@ -187,6 +187,11 @@ PULSAR_PUBLIC int pulsar_client_configuration_is_validate_hostname(pulsar_client
 PULSAR_PUBLIC void pulsar_client_configuration_set_validate_hostname(pulsar_client_configuration_t *conf,
                                                                      int validateHostName);
 
+PULSAR_PUBLIC void pulsar_client_configuration_set_listener_name(pulsar_client_configuration_t *conf,
+                                                                 const char *listenerName);
+
+PULSAR_PUBLIC const char *pulsar_client_configuration_get_listener_name(pulsar_client_configuration_t *conf);
+
 /*
  * Get the stats interval set in the client.
  */

--- a/lib/c/c_ClientConfiguration.cc
+++ b/lib/c/c_ClientConfiguration.cc
@@ -189,3 +189,12 @@ void pulsar_client_configuration_set_memory_limit(pulsar_client_configuration_t 
 unsigned long long pulsar_client_configuration_get_memory_limit(pulsar_client_configuration_t *conf) {
     return conf->conf.getMemoryLimit();
 }
+
+void pulsar_client_configuration_set_listener_name(pulsar_client_configuration_t *conf,
+                                                   const char *listenerName) {
+    conf->conf.setListenerName(listenerName);
+}
+
+const char *pulsar_client_configuration_get_listener_name(pulsar_client_configuration_t *conf) {
+    return conf->conf.getListenerName().c_str();
+}

--- a/tests/c/c_ClientConfigurationTest.cc
+++ b/tests/c/c_ClientConfigurationTest.cc
@@ -28,4 +28,7 @@ TEST(C_ClientConfigurationTest, testCApiConfig) {
 
     ASSERT_STREQ(pulsar_client_configuration_get_tls_private_key_file_path(conf), "private.key");
     ASSERT_STREQ(pulsar_client_configuration_get_tls_certificate_file_path(conf), "certificate.pem");
+
+    pulsar_client_configuration_set_listener_name(conf, "listenerName");
+    ASSERT_STREQ(pulsar_client_configuration_get_listener_name(conf), "listenerName");
 }


### PR DESCRIPTION
Fixes #369

### Motivation

The NodeJS client relies on the C API, which does not yet include the `getListener` and `setListener` methods. This means that using the NodeJS client, one is unable to choose which listener to create a client for.

### Modifications

Exposed `getListener` and `setListener` via the C API.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
  - Added test for newly exposed methods

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)


