### PR TITLE
[PIP-60] [Proxy-Client] Support SNI routing for Pulsar CPP client

### DIFF
--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -32,6 +32,10 @@ class PULSAR_PUBLIC ClientConfiguration {
     ~ClientConfiguration();
     ClientConfiguration(const ClientConfiguration&);
     ClientConfiguration& operator=(const ClientConfiguration&);
+    enum ProxyProtocol
+    {
+        SNI = 0
+    };
 
     /**
      * Configure a limit on the amount of memory that will be allocated by this client instance.
@@ -319,6 +323,31 @@ class PULSAR_PUBLIC ClientConfiguration {
      * @return
      */
     ClientConfiguration& setConnectionTimeout(int timeoutMs);
+
+    /**
+     * Set proxy-service url when client would like to connect to broker via proxy. Client must configure both
+     * proxyServiceUrl and appropriate proxyProtocol.
+     *
+     * Example: pulsar+ssl://ats-proxy.example.com:4443
+     *
+     * @param proxyServiceUrl proxy url to connect with broker
+     * @return
+     */
+    ClientConfiguration& setProxyServiceUrl(const std::string& proxyServiceUrl);
+
+    const std::string& getProxyServiceUrl() const;
+
+    /**
+     * Set appropriate proxy-protocol along with proxy-service url. Currently Pulsar supports SNI proxy routing.
+     *
+     * SNI routing: https://docs.trafficserver.apache.org/en/latest/admin-guide/layer-4-routing.en.html#sni-routing.
+     *
+     * @param proxyProtocol possible options (SNI)
+     * @return
+     */
+    ClientConfiguration& setProxyProtocol(const ProxyProtocol proxyProtocol);
+
+    const ProxyProtocol getProxyProtocol() const;
 
     /**
      * The getter associated with setConnectionTimeout().

--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -338,9 +338,11 @@ class PULSAR_PUBLIC ClientConfiguration {
     const std::string& getProxyServiceUrl() const;
 
     /**
-     * Set appropriate proxy-protocol along with proxy-service url. Currently Pulsar supports SNI proxy routing.
+     * Set appropriate proxy-protocol along with proxy-service url. Currently Pulsar supports SNI proxy
+     * routing.
      *
-     * SNI routing: https://docs.trafficserver.apache.org/en/latest/admin-guide/layer-4-routing.en.html#sni-routing.
+     * SNI routing:
+     * https://docs.trafficserver.apache.org/en/latest/admin-guide/layer-4-routing.en.html#sni-routing.
      *
      * @param proxyProtocol possible options (SNI)
      * @return

--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -347,9 +347,9 @@ class PULSAR_PUBLIC ClientConfiguration {
      * @param proxyProtocol possible options (SNI)
      * @return
      */
-    ClientConfiguration& setProxyProtocol(const ProxyProtocol proxyProtocol);
+    ClientConfiguration& setProxyProtocol(ProxyProtocol proxyProtocol);
 
-    const ProxyProtocol getProxyProtocol() const;
+    ProxyProtocol getProxyProtocol() const;
 
     /**
      * The getter associated with setConnectionTimeout().

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -134,6 +134,24 @@ ClientConfiguration& ClientConfiguration::setConcurrentLookupRequest(int concurr
     return *this;
 }
 
+ClientConfiguration& ClientConfiguration::setProxyServiceUrl(const std::string& proxyServiceUrl) {
+    impl_->proxyServiceUrl = proxyServiceUrl;
+    return *this;
+}
+
+const std::string& ClientConfiguration::getProxyServiceUrl() const {
+	return impl_->proxyServiceUrl;
+}
+
+ClientConfiguration& ClientConfiguration::setProxyProtocol(const ClientConfiguration::ProxyProtocol proxyProtocol) {
+    impl_->proxyProtocol = proxyProtocol;
+    return *this;
+}
+
+const ClientConfiguration::ProxyProtocol ClientConfiguration::getProxyProtocol() const {
+	return impl_->proxyProtocol;
+}
+
 int ClientConfiguration::getConcurrentLookupRequest() const { return impl_->concurrentLookupRequest; }
 
 ClientConfiguration& ClientConfiguration::setMaxLookupRedirects(int maxLookupRedirects) {

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -139,17 +139,16 @@ ClientConfiguration& ClientConfiguration::setProxyServiceUrl(const std::string& 
     return *this;
 }
 
-const std::string& ClientConfiguration::getProxyServiceUrl() const {
-	return impl_->proxyServiceUrl;
-}
+const std::string& ClientConfiguration::getProxyServiceUrl() const { return impl_->proxyServiceUrl; }
 
-ClientConfiguration& ClientConfiguration::setProxyProtocol(const ClientConfiguration::ProxyProtocol proxyProtocol) {
+ClientConfiguration& ClientConfiguration::setProxyProtocol(
+    const ClientConfiguration::ProxyProtocol proxyProtocol) {
     impl_->proxyProtocol = proxyProtocol;
     return *this;
 }
 
 const ClientConfiguration::ProxyProtocol ClientConfiguration::getProxyProtocol() const {
-	return impl_->proxyProtocol;
+    return impl_->proxyProtocol;
 }
 
 int ClientConfiguration::getConcurrentLookupRequest() const { return impl_->concurrentLookupRequest; }

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -142,12 +142,12 @@ ClientConfiguration& ClientConfiguration::setProxyServiceUrl(const std::string& 
 const std::string& ClientConfiguration::getProxyServiceUrl() const { return impl_->proxyServiceUrl; }
 
 ClientConfiguration& ClientConfiguration::setProxyProtocol(
-    const ClientConfiguration::ProxyProtocol proxyProtocol) {
+    ClientConfiguration::ProxyProtocol proxyProtocol) {
     impl_->proxyProtocol = proxyProtocol;
     return *this;
 }
 
-const ClientConfiguration::ProxyProtocol ClientConfiguration::getProxyProtocol() const {
+ClientConfiguration::ProxyProtocol ClientConfiguration::getProxyProtocol() const {
     return impl_->proxyProtocol;
 }
 

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -141,8 +141,7 @@ ClientConfiguration& ClientConfiguration::setProxyServiceUrl(const std::string& 
 
 const std::string& ClientConfiguration::getProxyServiceUrl() const { return impl_->proxyServiceUrl; }
 
-ClientConfiguration& ClientConfiguration::setProxyProtocol(
-    ClientConfiguration::ProxyProtocol proxyProtocol) {
+ClientConfiguration& ClientConfiguration::setProxyProtocol(ClientConfiguration::ProxyProtocol proxyProtocol) {
     impl_->proxyProtocol = proxyProtocol;
     return *this;
 }

--- a/lib/ClientConfigurationImpl.h
+++ b/lib/ClientConfigurationImpl.h
@@ -46,6 +46,8 @@ struct ClientConfigurationImpl {
     std::string listenerName;
     int connectionTimeoutMs{10000};  // 10 seconds
     std::string description;
+    std::string proxyServiceUrl;
+    ClientConfiguration::ProxyProtocol proxyProtocol;
 
     std::unique_ptr<LoggerFactory> takeLogger() { return std::move(loggerFactory); }
 };

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -265,8 +265,7 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
 
         if (!clientConfiguration.isTlsAllowInsecureConnection() && clientConfiguration.isValidateHostName()) {
             LOG_DEBUG("Validating hostname for " << serviceUrl.host() << ":" << serviceUrl.port());
-			std::string urlHost =
-					isSniProxy_ ? proxyUrl.host() : serviceUrl.host();
+            std::string urlHost = isSniProxy_ ? proxyUrl.host() : serviceUrl.host();
             tlsSocket_->set_verify_callback(boost::asio::ssl::rfc2818_verification(urlHost));
         }
 
@@ -413,8 +412,8 @@ void ClientConnection::handleTcpConnected(const boost::system::error_code& err,
         if (logicalAddress_ == physicalAddress_) {
             LOG_INFO(cnxString_ << "Connected to broker");
         } else {
-            LOG_INFO(cnxString_ << "Connected to broker through proxy. Logical broker: " <<
-            		logicalAddress_ << ", proxy: " << proxyServiceUrl_);
+            LOG_INFO(cnxString_ << "Connected to broker through proxy. Logical broker: " << logicalAddress_
+                                << ", proxy: " << proxyServiceUrl_);
         }
 
         Lock lock(mutex_);
@@ -612,7 +611,7 @@ void ClientConnection::tcpConnectAsync() {
 void ClientConnection::handleResolve(const boost::system::error_code& err,
                                      tcp::resolver::iterator endpointIterator) {
     if (err) {
-        std::string hostUrl = isSniProxy_? cnxString_ : proxyServiceUrl_;
+        std::string hostUrl = isSniProxy_ ? cnxString_ : proxyServiceUrl_;
         LOG_ERROR(hostUrl << "Resolve error: " << err << " : " << err.message());
         close();
         return;

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -333,6 +333,10 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
      */
     const std::string physicalAddress_;
 
+    std::string proxyServiceUrl_;
+
+    ClientConfiguration::ProxyProtocol proxyProtocol_;
+
     // Represent both endpoint of the tcp connection. eg: [client:1234 -> server:6650]
     std::string cnxString_;
 
@@ -384,6 +388,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     // Signals whether we're waiting for a response from broker
     bool havePendingPingRequest_ = false;
+    bool isSniProxy_ = false;
     DeadlineTimerPtr keepAliveTimer_;
     DeadlineTimerPtr consumerStatsRequestTimer_;
 

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -1480,28 +1480,14 @@ TEST(ConsumerTest, testConsumerName) {
 
 TEST(ConsumerTest, testSNIProxyConnect) {
     ClientConfiguration clientConfiguration;
-	clientConfiguration.setProxyServiceUrl(lookupUrl);
+    clientConfiguration.setProxyServiceUrl(lookupUrl);
     clientConfiguration.setProxyProtocol(ClientConfiguration::SNI);
 
     Client client(lookupUrl, clientConfiguration);
-    const std::string topic =
-        "testSNIProxy-" + std::to_string(time(nullptr));
+    const std::string topic = "testSNIProxy-" + std::to_string(time(nullptr));
 
     Consumer consumer;
     ASSERT_EQ(ResultOk, client.subscribe(topic, "test-sub", consumer));
-}
-
-TEST(ConsumerTest, testSNIProxyInValidConnect) {
-    ClientConfiguration clientConfiguration;
-    const std::string proxyUrl = "pulsar+ssl://invalid-url:6651";
-	clientConfiguration.setProxyServiceUrl(proxyUrl);
-    clientConfiguration.setProxyProtocol(ClientConfiguration::SNI);
-
-    Client client(lookupUrl, clientConfiguration);
-    const std::string topic =
-        "testSNIProxy-" + std::to_string(time(nullptr));
-
-    Consumer consumer;
-    ASSERT_NE(ResultOk, client.subscribe(topic, "test-sub", consumer));
+    client.close();
 }
 }  // namespace pulsar

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -1478,4 +1478,30 @@ TEST(ConsumerTest, testConsumerName) {
     client.close();
 }
 
+TEST(ConsumerTest, testSNIProxyConnect) {
+    ClientConfiguration clientConfiguration;
+	clientConfiguration.setProxyServiceUrl(lookupUrl);
+    clientConfiguration.setProxyProtocol(ClientConfiguration::SNI);
+
+    Client client(lookupUrl, clientConfiguration);
+    const std::string topic =
+        "testSNIProxy-" + std::to_string(time(nullptr));
+
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, "test-sub", consumer));
+}
+
+TEST(ConsumerTest, testSNIProxyInValidConnect) {
+    ClientConfiguration clientConfiguration;
+    const std::string proxyUrl = "pulsar+ssl://invalid-url:6651";
+	clientConfiguration.setProxyServiceUrl(proxyUrl);
+    clientConfiguration.setProxyProtocol(ClientConfiguration::SNI);
+
+    Client client(lookupUrl, clientConfiguration);
+    const std::string topic =
+        "testSNIProxy-" + std::to_string(time(nullptr));
+
+    Consumer consumer;
+    ASSERT_NE(ResultOk, client.subscribe(topic, "test-sub", consumer));
+}
 }  // namespace pulsar


### PR DESCRIPTION
### Motivation

#8957 was added incorrectly and it was not supporting SNI routing for CPP client library.
This PR adds support of SNI roting to Pulsar CPP client library and allows users to connect with Pulsar broker using SNI Proxy.
User can configure Pulsar client lib to use SNI routing and proxy by adding below configuration
```
const std::string lookupUrl = "pulsar+ssl://broker-url:6651";
const std::string proxyUrl = "pulsar+ssl://sni-proxy-url:6651";
const std::string topicName = "persistent://pulsar/stg-use1/ns1/t1";
const std::string certFile = "/client-cert.pem";
const std::string keyFile = "/client-key.pem";
const std::string trustFile = "/trust-store.pem";

ClientConfiguration conf;
conf.setUseTls(true);
conf.setTlsAllowInsecureConnection(false);
conf.setTlsTrustCertsFilePath(trustFile);
conf.setAuth(AuthTls::create(std::move(certFile), std::move(keyFile)));
conf.setProxyServiceUrl(proxyUrl);
conf.setProxyProtocol(ClientConfiguration::SNI);

Client client(lookupUrl, conf);
```

### Modifications

Added a support of SNI routing by adding new APIs to configure proxy URL and protocol.
```
ClientConfiguration::setProxyServiceUrl(..)
ClientConfiguration::setProxyProtocol(..)
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
