### PR TITLE
[fix] Fix issue where custom logger setting is ignored

### DIFF
--- a/lib/ClientImpl.cc
+++ b/lib/ClientImpl.cc
@@ -92,11 +92,9 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
       consumerIdGenerator_(0),
       closingError(ResultOk) {
     std::unique_ptr<LoggerFactory> loggerFactory = clientConfiguration_.impl_->takeLogger();
-    if (!loggerFactory) {
-        // Use default simple console logger
-        loggerFactory.reset(new ConsoleLoggerFactory);
+    if (loggerFactory) {
+        LogUtils::setLoggerFactory(std::move(loggerFactory));
     }
-    LogUtils::setLoggerFactory(std::move(loggerFactory));
 
     LookupServicePtr underlyingLookupServicePtr;
     if (serviceNameResolver_.useHttp()) {

--- a/lib/LogUtils.cc
+++ b/lib/LogUtils.cc
@@ -25,6 +25,7 @@
 
 namespace pulsar {
 
+static std::atomic<LoggerFactory*> s_defaultLoggerFactory(new ConsoleLoggerFactory());
 static std::atomic<LoggerFactory*> s_loggerFactory(nullptr);
 
 void LogUtils::setLoggerFactory(std::unique_ptr<LoggerFactory> loggerFactory) {
@@ -37,10 +38,10 @@ void LogUtils::setLoggerFactory(std::unique_ptr<LoggerFactory> loggerFactory) {
 
 LoggerFactory* LogUtils::getLoggerFactory() {
     if (s_loggerFactory.load() == nullptr) {
-        std::unique_ptr<LoggerFactory> newFactory(new ConsoleLoggerFactory());
-        setLoggerFactory(std::move(newFactory));
+        return s_defaultLoggerFactory.load();
+    } else {
+        return s_loggerFactory.load();
     }
-    return s_loggerFactory.load();
 }
 
 std::string LogUtils::getLoggerName(const std::string& path) {

--- a/lib/LogUtils.h
+++ b/lib/LogUtils.h
@@ -34,16 +34,19 @@ namespace pulsar {
 #define PULSAR_UNLIKELY(expr) (expr)
 #endif
 
-#define DECLARE_LOG_OBJECT()                                                                     \
-    static pulsar::Logger* logger() {                                                            \
-        static thread_local std::unique_ptr<pulsar::Logger> threadSpecificLogPtr;                \
-        pulsar::Logger* ptr = threadSpecificLogPtr.get();                                        \
-        if (PULSAR_UNLIKELY(!ptr)) {                                                             \
-            std::string logger = pulsar::LogUtils::getLoggerName(__FILE__);                      \
-            threadSpecificLogPtr.reset(pulsar::LogUtils::getLoggerFactory()->getLogger(logger)); \
-            ptr = threadSpecificLogPtr.get();                                                    \
-        }                                                                                        \
-        return ptr;                                                                              \
+#define DECLARE_LOG_OBJECT()                                                                        \
+    static pulsar::Logger* logger() {                                                               \
+        static thread_local uintptr_t loggerFactoryPtr = 0;                                         \
+        static thread_local std::unique_ptr<pulsar::Logger> threadSpecificLogPtr;                   \
+        pulsar::Logger* ptr = threadSpecificLogPtr.get();                                           \
+        if (PULSAR_UNLIKELY(loggerFactoryPtr != (uintptr_t)pulsar::LogUtils::getLoggerFactory()) || \
+            PULSAR_UNLIKELY(!ptr)) {                                                                \
+            std::string logger = pulsar::LogUtils::getLoggerName(__FILE__);                         \
+            threadSpecificLogPtr.reset(pulsar::LogUtils::getLoggerFactory()->getLogger(logger));    \
+            ptr = threadSpecificLogPtr.get();                                                       \
+            loggerFactoryPtr = (uintptr_t)pulsar::LogUtils::getLoggerFactory();                     \
+        }                                                                                           \
+        return ptr;                                                                                 \
     }
 
 #define LOG_DEBUG(message)                                                       \

--- a/tests/CustomLoggerTest.cc
+++ b/tests/CustomLoggerTest.cc
@@ -107,3 +107,13 @@ TEST(CustomLoggerTest, testConsoleLoggerFactory) {
     ASSERT_FALSE(logger->isEnabled(Logger::LEVEL_WARN));
     ASSERT_TRUE(logger->isEnabled(Logger::LEVEL_ERROR));
 }
+
+TEST(CustomLoggerTest, testSetAndGetLoggerFactory) {
+    LoggerFactory *oldFactory = LogUtils::getLoggerFactory();
+    LoggerFactory *newFactory = new ConsoleLoggerFactory(Logger::LEVEL_ERROR);
+    std::unique_ptr<LoggerFactory> newFactoryPtr(newFactory);
+    LogUtils::setLoggerFactory(std::move(newFactoryPtr));
+    ASSERT_NE(oldFactory, LogUtils::getLoggerFactory());
+    ASSERT_EQ(newFactory, LogUtils::getLoggerFactory());
+    LogUtils::resetLoggerFactory();
+}


### PR DESCRIPTION
### Motivation

I noticed that there are cases where the specified logger factory is not used. For example, if we compile and run the following code, it expects `FileLoggerFactory` to be used, but it actually uses the default `ConsoleLoggerFactory`.
```cpp
ClientConfiguration config = ClientConfiguration();
config.setLogger(new FileLoggerFactory(Logger::LEVEL_INFO, "pulsar-client-cpp.log"));

ParamMap params;
params["providerDomain"]    = "provider.foo.bar";
params["tenantDomain"]      = "tenant.foo.bar";
params["tenantService"]     = "test-service";
params["privateKey"]        = "file:///path/to/private.key";
params["keyId"]             = "0";
params["ztsUrl"]            = "https://zts.athenz.example.com:443";

AuthenticationPtr auth = AuthAthenz::create(params);
config.setAuth(auth);

Client client("pulsar://localhost:6650", config);
```

This happens if logging is performed before `LogUtils::setLoggerFactory` is executed in the constructor of `ClientImpl`.
https://github.com/apache/pulsar-client-cpp/blob/25ea451eb3a79d48966689ec64460ae03d5d57da/lib/ClientImpl.cc#L94-L99

When logging is performed, `LogUtils::getLoggerFactory` is called.
1. https://github.com/apache/pulsar-client-cpp/blob/25ea451eb3a79d48966689ec64460ae03d5d57da/lib/LogUtils.h#L60
1. https://github.com/apache/pulsar-client-cpp/blob/25ea451eb3a79d48966689ec64460ae03d5d57da/lib/LogUtils.h#L43

If the constructor of `ClientImpl` has not been executed at this point, the default `ConsoleLoggerFactory` is instantiated, set to the static variable `s_loggerFactory`, and returned to the caller.
https://github.com/apache/pulsar-client-cpp/blob/25ea451eb3a79d48966689ec64460ae03d5d57da/lib/LogUtils.cc#L38-L44

Loggers generated from the returned `LoggerFactory` will be set to the static and thread_local variable `threadSpecificLogPtr`, and reused from now on.
https://github.com/apache/pulsar-client-cpp/blob/25ea451eb3a79d48966689ec64460ae03d5d57da/lib/LogUtils.h#L38-L47

After that, `LogUtils::setLoggerFactory` is executed again in the constructor of `ClientImpl`, but the value can only be set to `s_loggerFactory` once, and it will be ignored from the second time. This is clearly stated in [the comments](https://github.com/apache/pulsar-client-cpp/blob/25ea451eb3a79d48966689ec64460ae03d5d57da/include/pulsar/ClientConfiguration.h#L183-L186).
https://github.com/apache/pulsar-client-cpp/blob/25ea451eb3a79d48966689ec64460ae03d5d57da/lib/LogUtils.cc#L30-L36

Even if we can set it again, if a logger is already set to `threadSpecificLogPtr`, a new logger will not be generated from the new `LoggerFactory`.

### Modifications

Keep an instance of the default `ConsoleLoggerFactory` in `s_defaultLoggerFactory`, a variable separate from `s_loggerFactory`, and return it if `LoggerFactory` is not set yet.

In addition, keep the pointer value of the `LoggerFactory` that generated the logger cached in `threadSpecificLogPtr`, and regenerate the logger if the `LoggerFactory` pointer changes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed`