### PR TITLE
Retry on new partition producer creation failure

### DIFF
--- a/lib/PartitionedProducerImpl.h
+++ b/lib/PartitionedProducerImpl.h
@@ -135,7 +135,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
 
     unsigned int getNumPartitions() const;
     unsigned int getNumPartitionsWithLock() const;
-    ProducerImplPtr newInternalProducer(unsigned int partition, bool lazy);
+    ProducerImplPtr newInternalProducer(unsigned int partition, bool lazy, bool retryOnCreationError);
     MessageRoutingPolicyPtr getMessageRouter();
     void runPartitionUpdateTask();
     void getPartitionMetadata();

--- a/lib/ProducerImpl.h
+++ b/lib/ProducerImpl.h
@@ -66,7 +66,8 @@ class ProducerImpl : public HandlerBase, public ProducerImplBase {
    public:
     ProducerImpl(ClientImplPtr client, const TopicName& topic,
                  const ProducerConfiguration& producerConfiguration,
-                 const ProducerInterceptorsPtr& interceptors, int32_t partition = -1);
+                 const ProducerInterceptorsPtr& interceptors, int32_t partition = -1,
+                 bool retryOnCreationError = false);
     ~ProducerImpl();
 
     // overrided methods from ProducerImplBase
@@ -202,6 +203,8 @@ class ProducerImpl : public HandlerBase, public ProducerImplBase {
     boost::optional<uint64_t> topicEpoch;
 
     ProducerInterceptorsPtr interceptors_;
+
+    bool retryOnCreationError_;
 };
 
 struct ProducerImplCmp {

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -663,20 +663,19 @@ TEST(ProducerTest, testFailedToCreateNewPartitionProducer) {
     ProducerConfiguration conf;
     Producer producer;
     client.createProducer(topic, conf, producer);
-    waitUntil(std::chrono::seconds(1), [&producer]() -> bool { return producer.isConnected(); });
-    ASSERT_TRUE(producer.isConnected());
+    ASSERT_TRUE(waitUntil(std::chrono::seconds(1), [&producer]() -> bool { return producer.isConnected(); }));
 
     PartitionedProducerImpl& partitionedProducer = PulsarFriend::getPartitionedProducerImpl(producer);
     PulsarFriend::updatePartitions(partitionedProducer, 3);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    auto& new_producer = PulsarFriend::getInternalProducerImpl(producer, 2);
-    ASSERT_FALSE(new_producer.isConnected());  // should fail with topic not found
+    auto& newProducer = PulsarFriend::getInternalProducerImpl(producer, 2);
+    ASSERT_FALSE(newProducer.isConnected());  // should fail with topic not found
 
     res = makePostRequest(topicOperateUrl, "3");
     ASSERT_TRUE(res == 204 || res == 409) << "res: " << res;
 
-    waitUntil(std::chrono::seconds(5), [&new_producer]() -> bool { return new_producer.isConnected(); });
-    ASSERT_TRUE(new_producer.isConnected());
+    ASSERT_TRUE(
+        waitUntil(std::chrono::seconds(5), [&newProducer]() -> bool { return newProducer.isConnected(); }));
 
     producer.close();
     client.close();


### PR DESCRIPTION
Fixes #319

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Already created producer should not fail after new partition producers creation failure.

### Modifications

`ProducerImpl`: Add an option retryOnCreationError to control whether to retry on creation error
`PartitionedProducerImpl`: Use retryOnCreationError=true to create new partition producers

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - Added test for new partition producer creation failure

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
Bug fix only.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
