### PR TITLE
Remove the Boost.Random dependency

### DIFF
--- a/lib/Backoff.cc
+++ b/lib/Backoff.cc
@@ -21,7 +21,6 @@
 #include <time.h> /* time */
 
 #include <algorithm>
-#include <boost/random/uniform_int_distribution.hpp>
 
 namespace pulsar {
 
@@ -47,7 +46,7 @@ TimeDuration Backoff::next() {
         }
     }
     // Add Randomness
-    boost::random::uniform_int_distribution<int> dist;
+    std::uniform_int_distribution<int> dist;
     int randomNumber = dist(rng_);
 
     current = current - (current * (randomNumber % 10) / 100);

--- a/lib/Backoff.h
+++ b/lib/Backoff.h
@@ -21,7 +21,7 @@
 #include <pulsar/defines.h>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/random/mersenne_twister.hpp>
+#include <random>
 
 namespace pulsar {
 
@@ -39,7 +39,7 @@ class PULSAR_PUBLIC Backoff {
     TimeDuration next_;
     TimeDuration mandatoryStop_;
     boost::posix_time::ptime firstBackoffTime_;
-    boost::random::mt19937 rng_;
+    std::mt19937 rng_;
     bool mandatoryStopMade_ = false;
 
     friend class PulsarFriend;

--- a/lib/RoundRobinMessageRouter.cc
+++ b/lib/RoundRobinMessageRouter.cc
@@ -18,8 +18,7 @@
  */
 #include "RoundRobinMessageRouter.h"
 
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
+#include <random>
 
 #include "Hash.h"
 #include "TimeUtils.h"
@@ -37,8 +36,8 @@ RoundRobinMessageRouter::RoundRobinMessageRouter(ProducerConfiguration::HashingS
       lastPartitionChange_(TimeUtils::currentTimeMillis()),
       msgCounter_(0),
       cumulativeBatchSize_(0) {
-    boost::random::mt19937 rng(time(nullptr));
-    boost::random::uniform_int_distribution<int> dist;
+    std::mt19937 rng(time(nullptr));
+    std::uniform_int_distribution<int> dist;
     currentPartitionCursor_ = dist(rng);
 }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,10 +37,6 @@
       "version>=": "1.83.0"
     },
     {
-      "name": "boost-random",
-      "version>=": "1.83.0"
-    },
-    {
       "name": "boost-serialization",
       "version>=": "1.83.0"
     },


### PR DESCRIPTION
Master issue: https://github.com/apache/pulsar-client-cpp/issues/367

### Motivation

We still depends on the Boost.Random dependency on some places, which could be replaced by the C++ standard random library.

### Modifications

- Replace Boost.Random usages with the standard `<random>` header
- Remove the `boost-random` dependency from `vcpkg.json`