### PR TITLE
Depend on the independent Asio instead of Boost.Asio by default

### DIFF
--- a/.github/workflows/ci-build-binary-artifacts.yaml
+++ b/.github/workflows/ci-build-binary-artifacts.yaml
@@ -148,6 +148,7 @@ jobs:
           mkdir -p $BUILD_DIR
           cmake -B $BUILD_DIR \
             -G "${{ matrix.generator }}" ${{ matrix.arch }} \
+            -DUSE_ASIO=ON \
             -DBUILD_TESTS=OFF \
             -DVCPKG_TRIPLET=${{ matrix.triplet }} \
             -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} \
@@ -174,6 +175,7 @@ jobs:
           mkdir -p $BUILD_DIR
           cmake -B $BUILD_DIR \
             -G "${{ matrix.generator }}" ${{ matrix.arch }} \
+            -DUSE_ASIO=ON \
             -DBUILD_TESTS=OFF \
             -DVCPKG_TRIPLET=${{ matrix.triplet }} \
             -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR_DEBUG \

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -191,6 +191,7 @@ jobs:
             cmake \
               -B ./build-1 \
               -G "${{ matrix.generator }}" ${{ matrix.arch }} \
+              -DUSE_ASIO=ON \
               -DBUILD_TESTS=OFF \
               -DVCPKG_TRIPLET="${{ matrix.triplet }}" \
               -DCMAKE_INSTALL_PREFIX="${{ env.INSTALL_DIR }}" \
@@ -232,6 +233,7 @@ jobs:
             cmake \
               -B ./build-2 \
               -G "${{ matrix.generator }}" ${{ matrix.arch }} \
+              -DUSE_ASIO=ON \
               -DBUILD_TESTS=OFF \
               -DVCPKG_TRIPLET="${{ matrix.triplet }}" \
               -DCMAKE_INSTALL_PREFIX="${{ env.INSTALL_DIR }}" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,11 @@
 
 cmake_minimum_required(VERSION 3.13)
 
+option(USE_ASIO "Use Asio instead of Boost.Asio" OFF)
+
 option(INTEGRATE_VCPKG "Integrate with Vcpkg" OFF)
 if (INTEGRATE_VCPKG)
+    set(USE_ASIO ON)
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 endif ()
 
@@ -129,6 +132,10 @@ if (INTEGRATE_VCPKG)
         $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>
         Snappy::snappy
         )
+    if (USE_ASIO)
+        find_package(asio CONFIG REQUIRED)
+        set(COMMON_LIBS ${COMMON_LIBS} asio::asio)
+    endif ()
     add_definitions(-DHAS_ZSTD -DHAS_SNAPPY)
     if (MSVC)
         find_package(dlfcn-win32 CONFIG REQUIRED)
@@ -138,6 +145,10 @@ if (INTEGRATE_VCPKG)
     endif ()
 else ()
     include(./LegacyFindPackages.cmake)
+endif ()
+
+if (USE_ASIO)
+    add_definitions(-DUSE_ASIO)
 endif ()
 
 set(LIB_NAME $ENV{PULSAR_LIBRARY_NAME})

--- a/LegacyFindPackages.cmake
+++ b/LegacyFindPackages.cmake
@@ -176,10 +176,6 @@ if (Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
     MESSAGE(STATUS "Linking with Boost:System")
 endif()
 
-if (MSVC)
-    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} date_time)
-endif()
-
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
     # GCC 4.8.2 implementation of std::regex is buggy
     set(BOOST_COMPONENTS ${BOOST_COMPONENTS} regex)

--- a/lib/AckGroupingTrackerEnabled.cc
+++ b/lib/AckGroupingTrackerEnabled.cc
@@ -117,7 +117,7 @@ void AckGroupingTrackerEnabled::close() {
     this->flush();
     std::lock_guard<std::mutex> lock(this->mutexTimer_);
     if (this->timer_) {
-        boost::system::error_code ec;
+        ASIO_ERROR ec;
         this->timer_->cancel(ec);
     }
 }
@@ -168,9 +168,9 @@ void AckGroupingTrackerEnabled::scheduleTimer() {
 
     std::lock_guard<std::mutex> lock(this->mutexTimer_);
     this->timer_ = this->executor_->createDeadlineTimer();
-    this->timer_->expires_from_now(boost::posix_time::milliseconds(std::max(1L, this->ackGroupingTimeMs_)));
+    this->timer_->expires_from_now(std::chrono::milliseconds(std::max(1L, this->ackGroupingTimeMs_)));
     auto self = shared_from_this();
-    this->timer_->async_wait([this, self](const boost::system::error_code& ec) -> void {
+    this->timer_->async_wait([this, self](const ASIO_ERROR& ec) -> void {
         if (!ec) {
             this->flush();
             this->scheduleTimer();

--- a/lib/AckGroupingTrackerEnabled.h
+++ b/lib/AckGroupingTrackerEnabled.h
@@ -22,18 +22,17 @@
 #include <pulsar/MessageId.h>
 
 #include <atomic>
-#include <boost/asio/deadline_timer.hpp>
 #include <cstdint>
 #include <mutex>
 #include <set>
 
 #include "AckGroupingTracker.h"
+#include "AsioTimer.h"
 
 namespace pulsar {
 
 class ClientImpl;
 using ClientImplPtr = std::shared_ptr<ClientImpl>;
-using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
 class ExecutorService;
 using ExecutorServicePtr = std::shared_ptr<ExecutorService>;
 class HandlerBase;

--- a/lib/AsioDefines.h
+++ b/lib/AsioDefines.h
@@ -16,17 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+// This header defines common macros to use Asio or Boost.Asio.
+#pragma once
 
-#include "TimeUtils.h"
-
-namespace pulsar {
-
-ptime TimeUtils::now() { return microsec_clock::universal_time(); }
-
-int64_t TimeUtils::currentTimeMillis() {
-    static ptime time_t_epoch(boost::gregorian::date(1970, 1, 1));
-
-    time_duration diff = now() - time_t_epoch;
-    return diff.total_milliseconds();
-}
-}  // namespace pulsar
+#ifdef USE_ASIO
+#define ASIO ::asio
+#define ASIO_ERROR asio::error_code
+#define ASIO_SUCCESS (ASIO_ERROR{})
+#define ASIO_SYSTEM_ERROR asio::system_error
+#else
+#define ASIO boost::asio
+#define ASIO_ERROR boost::system::error_code
+#define ASIO_SUCCESS boost::system::errc::make_error_code(boost::system::errc::success)
+#define ASIO_SYSTEM_ERROR boost::system::system_error
+#endif

--- a/lib/AsioTimer.h
+++ b/lib/AsioTimer.h
@@ -16,24 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#pragma once
 
-#ifndef PULSAR_PRODUCER_STATS_BASE_HEADER
-#define PULSAR_PRODUCER_STATS_BASE_HEADER
-#include <pulsar/Message.h>
-#include <pulsar/Result.h>
+#ifdef USE_ASIO
+#include <asio/steady_timer.hpp>
+#else
+#include <boost/asio/steady_timer.hpp>
+#endif
 
-#include "lib/TimeUtils.h"
+#include <memory>
 
-namespace pulsar {
-class ProducerStatsBase {
-   public:
-    virtual void start() {}
-    virtual void messageSent(const Message& msg) = 0;
-    virtual void messageReceived(Result, const ptime&) = 0;
-    virtual ~ProducerStatsBase(){};
-};
+#include "AsioDefines.h"
 
-typedef std::shared_ptr<ProducerStatsBase> ProducerStatsBasePtr;
-}  // namespace pulsar
-
-#endif  // PULSAR_PRODUCER_STATS_BASE_HEADER
+using DeadlineTimerPtr = std::shared_ptr<ASIO::steady_timer>;

--- a/lib/Backoff.cc
+++ b/lib/Backoff.cc
@@ -21,6 +21,9 @@
 #include <time.h> /* time */
 
 #include <algorithm>
+#include <chrono>
+
+#include "TimeUtils.h"
 
 namespace pulsar {
 
@@ -33,8 +36,8 @@ TimeDuration Backoff::next() {
 
     // Check for mandatory stop
     if (!mandatoryStopMade_) {
-        const boost::posix_time::ptime& now = boost::posix_time::microsec_clock::universal_time();
-        TimeDuration timeElapsedSinceFirstBackoff = boost::posix_time::milliseconds(0);
+        auto now = TimeUtils::now();
+        TimeDuration timeElapsedSinceFirstBackoff = std::chrono::nanoseconds(0);
         if (initial_ == current) {
             firstBackoffTime_ = now;
         } else {

--- a/lib/Backoff.h
+++ b/lib/Backoff.h
@@ -20,12 +20,12 @@
 #define _PULSAR_BACKOFF_HEADER_
 #include <pulsar/defines.h>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
 #include <random>
 
-namespace pulsar {
+#include "TimeUtils.h"
 
-using TimeDuration = boost::posix_time::time_duration;
+namespace pulsar {
 
 class PULSAR_PUBLIC Backoff {
    public:
@@ -38,7 +38,7 @@ class PULSAR_PUBLIC Backoff {
     const TimeDuration max_;
     TimeDuration next_;
     TimeDuration mandatoryStop_;
-    boost::posix_time::ptime firstBackoffTime_;
+    decltype(std::chrono::high_resolution_clock::now()) firstBackoffTime_;
     std::mt19937 rng_;
     bool mandatoryStopMade_ = false;
 

--- a/lib/CompressionCodec.cc
+++ b/lib/CompressionCodec.cc
@@ -45,7 +45,6 @@ CompressionCodec& CompressionCodecProvider::getCodec(CompressionType compression
         default:
             return compressionCodecNone_;
     }
-    BOOST_THROW_EXCEPTION(std::logic_error("Invalid CompressionType enumeration value"));
 }
 
 SharedBuffer CompressionCodecNone::encode(const SharedBuffer& raw) { return raw; }

--- a/lib/ConnectionPool.cc
+++ b/lib/ConnectionPool.cc
@@ -18,15 +18,20 @@
  */
 #include "ConnectionPool.h"
 
+#ifdef USE_ASIO
+#include <asio/ip/tcp.hpp>
+#include <asio/ssl.hpp>
+#else
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
+#endif
 
 #include "ClientConnection.h"
 #include "ExecutorService.h"
 #include "LogUtils.h"
 
-using boost::asio::ip::tcp;
-namespace ssl = boost::asio::ssl;
+using ASIO::ip::tcp;
+namespace ssl = ASIO::ssl;
 typedef ssl::stream<tcp::socket> ssl_socket;
 
 DECLARE_LOG_OBJECT()

--- a/lib/ConsumerImplBase.cc
+++ b/lib/ConsumerImplBase.cc
@@ -51,9 +51,9 @@ ConsumerImplBase::ConsumerImplBase(ClientImplPtr client, const std::string& topi
 
 void ConsumerImplBase::triggerBatchReceiveTimerTask(long timeoutMs) {
     if (timeoutMs > 0) {
-        batchReceiveTimer_->expires_from_now(boost::posix_time::milliseconds(timeoutMs));
+        batchReceiveTimer_->expires_from_now(std::chrono::milliseconds(timeoutMs));
         std::weak_ptr<ConsumerImplBase> weakSelf{shared_from_this()};
-        batchReceiveTimer_->async_wait([weakSelf](const boost::system::error_code& ec) {
+        batchReceiveTimer_->async_wait([weakSelf](const ASIO_ERROR& ec) {
             auto self = weakSelf.lock();
             if (self && !ec) {
                 self->doBatchReceiveTimeTask();

--- a/lib/ExecutorService.cc
+++ b/lib/ExecutorService.cc
@@ -32,7 +32,7 @@ void ExecutorService::start() {
     auto self = shared_from_this();
     std::thread t{[this, self] {
         LOG_DEBUG("Run io_service in a single thread");
-        boost::system::error_code ec;
+        ASIO_ERROR ec;
         while (!closed_) {
             io_service_.restart();
             IOService::work work{getIOService()};
@@ -63,22 +63,22 @@ ExecutorServicePtr ExecutorService::create() {
 }
 
 /*
- *  factory method of boost::asio::ip::tcp::socket associated with io_service_ instance
+ *  factory method of ASIO::ip::tcp::socket associated with io_service_ instance
  *  @ returns shared_ptr to this socket
  */
 SocketPtr ExecutorService::createSocket() {
     try {
-        return SocketPtr(new boost::asio::ip::tcp::socket(io_service_));
-    } catch (const boost::system::system_error &e) {
+        return SocketPtr(new ASIO::ip::tcp::socket(io_service_));
+    } catch (const ASIO_SYSTEM_ERROR &e) {
         restart();
         auto error = std::string("Failed to create socket: ") + e.what();
         throw std::runtime_error(error);
     }
 }
 
-TlsSocketPtr ExecutorService::createTlsSocket(SocketPtr &socket, boost::asio::ssl::context &ctx) {
-    return std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket &>>(
-        new boost::asio::ssl::stream<boost::asio::ip::tcp::socket &>(*socket, ctx));
+TlsSocketPtr ExecutorService::createTlsSocket(SocketPtr &socket, ASIO::ssl::context &ctx) {
+    return std::shared_ptr<ASIO::ssl::stream<ASIO::ip::tcp::socket &>>(
+        new ASIO::ssl::stream<ASIO::ip::tcp::socket &>(*socket, ctx));
 }
 
 /*
@@ -87,8 +87,8 @@ TlsSocketPtr ExecutorService::createTlsSocket(SocketPtr &socket, boost::asio::ss
  */
 TcpResolverPtr ExecutorService::createTcpResolver() {
     try {
-        return TcpResolverPtr(new boost::asio::ip::tcp::resolver(io_service_));
-    } catch (const boost::system::system_error &e) {
+        return TcpResolverPtr(new ASIO::ip::tcp::resolver(io_service_));
+    } catch (const ASIO_SYSTEM_ERROR &e) {
         restart();
         auto error = std::string("Failed to create resolver: ") + e.what();
         throw std::runtime_error(error);
@@ -97,10 +97,10 @@ TcpResolverPtr ExecutorService::createTcpResolver() {
 
 DeadlineTimerPtr ExecutorService::createDeadlineTimer() {
     try {
-        return DeadlineTimerPtr(new boost::asio::deadline_timer(io_service_));
-    } catch (const boost::system::system_error &e) {
+        return DeadlineTimerPtr(new ASIO::steady_timer(io_service_));
+    } catch (const ASIO_SYSTEM_ERROR &e) {
         restart();
-        auto error = std::string("Failed to create deadline_timer: ") + e.what();
+        auto error = std::string("Failed to create steady_timer: ") + e.what();
         throw std::runtime_error(error);
     }
 }

--- a/lib/ExecutorService.h
+++ b/lib/ExecutorService.h
@@ -22,10 +22,15 @@
 #include <pulsar/defines.h>
 
 #include <atomic>
-#include <boost/asio/deadline_timer.hpp>
+#ifdef USE_ASIO
+#include <asio/io_service.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/ssl.hpp>
+#else
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
+#endif
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -33,14 +38,15 @@
 #include <mutex>
 #include <thread>
 
+#include "AsioTimer.h"
+
 namespace pulsar {
-typedef std::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
-typedef std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket &> > TlsSocketPtr;
-typedef std::shared_ptr<boost::asio::ip::tcp::resolver> TcpResolverPtr;
-typedef std::shared_ptr<boost::asio::deadline_timer> DeadlineTimerPtr;
+typedef std::shared_ptr<ASIO::ip::tcp::socket> SocketPtr;
+typedef std::shared_ptr<ASIO::ssl::stream<ASIO::ip::tcp::socket &> > TlsSocketPtr;
+typedef std::shared_ptr<ASIO::ip::tcp::resolver> TcpResolverPtr;
 class PULSAR_PUBLIC ExecutorService : public std::enable_shared_from_this<ExecutorService> {
    public:
-    using IOService = boost::asio::io_service;
+    using IOService = ASIO::io_service;
     using SharedPtr = std::shared_ptr<ExecutorService>;
 
     static SharedPtr create();
@@ -51,7 +57,7 @@ class PULSAR_PUBLIC ExecutorService : public std::enable_shared_from_this<Execut
 
     // throws std::runtime_error if failed
     SocketPtr createSocket();
-    static TlsSocketPtr createTlsSocket(SocketPtr &socket, boost::asio::ssl::context &ctx);
+    static TlsSocketPtr createTlsSocket(SocketPtr &socket, ASIO::ssl::context &ctx);
     // throws std::runtime_error if failed
     TcpResolverPtr createTcpResolver();
     // throws std::runtime_error if failed

--- a/lib/HandlerBase.h
+++ b/lib/HandlerBase.h
@@ -20,19 +20,16 @@
 #define _PULSAR_HANDLER_BASE_HEADER_
 #include <pulsar/Result.h>
 
-#include <boost/asio/deadline_timer.hpp>
 #include <memory>
 #include <mutex>
 #include <string>
 
+#include "AsioTimer.h"
 #include "Backoff.h"
 #include "Future.h"
+#include "TimeUtils.h"
 
 namespace pulsar {
-
-using namespace boost::posix_time;
-using boost::posix_time::milliseconds;
-using boost::posix_time::seconds;
 
 class ClientImpl;
 using ClientImplPtr = std::shared_ptr<ClientImpl>;
@@ -42,7 +39,6 @@ using ClientConnectionPtr = std::shared_ptr<ClientConnection>;
 using ClientConnectionWeakPtr = std::weak_ptr<ClientConnection>;
 class ExecutorService;
 using ExecutorServicePtr = std::shared_ptr<ExecutorService>;
-using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
 
 class HandlerBase : public std::enable_shared_from_this<HandlerBase> {
    public:
@@ -95,7 +91,7 @@ class HandlerBase : public std::enable_shared_from_this<HandlerBase> {
 
     void handleDisconnection(Result result, const ClientConnectionPtr& cnx);
 
-    void handleTimeout(const boost::system::error_code& ec);
+    void handleTimeout(const ASIO_ERROR& ec);
 
    protected:
     ClientImplWeakPtr client_;

--- a/lib/Int64SerDes.h
+++ b/lib/Int64SerDes.h
@@ -20,7 +20,12 @@
 
 #include <stdint.h>
 
-#include <boost/asio.hpp>  // for ntohl
+// for ntohl
+#ifdef USE_ASIO
+#include <asio/detail/socket_ops.hpp>
+#else
+#include <boost/asio/detail/socket_ops.hpp>
+#endif
 
 namespace pulsar {
 

--- a/lib/MultiTopicsConsumerImpl.h
+++ b/lib/MultiTopicsConsumerImpl.h
@@ -32,6 +32,7 @@
 #include "LookupDataResult.h"
 #include "SynchronizedHashMap.h"
 #include "TestUtil.h"
+#include "TimeUtils.h"
 #include "UnboundedBlockingQueue.h"
 
 namespace pulsar {
@@ -119,7 +120,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
     std::atomic_int incomingMessagesSize_ = {0};
     MessageListener messageListener_;
     DeadlineTimerPtr partitionsUpdateTimer_;
-    boost::posix_time::time_duration partitionsUpdateInterval_;
+    TimeDuration partitionsUpdateInterval_;
     LookupServicePtr lookupServicePtr_;
     std::shared_ptr<std::atomic<int>> numberTopicPartitions_;
     std::atomic<Result> failedResult{ResultOk};

--- a/lib/NegativeAcksTracker.h
+++ b/lib/NegativeAcksTracker.h
@@ -23,12 +23,13 @@
 #include <pulsar/MessageId.h>
 
 #include <atomic>
-#include <boost/asio/deadline_timer.hpp>
 #include <chrono>
 #include <map>
 #include <memory>
 #include <mutex>
 
+#include "AsioDefines.h"
+#include "AsioTimer.h"
 #include "TestUtil.h"
 
 namespace pulsar {
@@ -36,7 +37,6 @@ namespace pulsar {
 class ConsumerImpl;
 class ClientImpl;
 using ClientImplPtr = std::shared_ptr<ClientImpl>;
-using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
 class ExecutorService;
 using ExecutorServicePtr = std::shared_ptr<ExecutorService>;
 
@@ -56,13 +56,13 @@ class NegativeAcksTracker : public std::enable_shared_from_this<NegativeAcksTrac
 
    private:
     void scheduleTimer();
-    void handleTimer(const boost::system::error_code &ec);
+    void handleTimer(const ASIO_ERROR &ec);
 
     ConsumerImpl &consumer_;
     std::mutex mutex_;
 
     std::chrono::milliseconds nackDelay_;
-    boost::posix_time::milliseconds timerInterval_;
+    std::chrono::milliseconds timerInterval_;
     typedef typename std::chrono::steady_clock Clock;
     std::map<MessageId, Clock::time_point> nackedMessages_;
 

--- a/lib/OpSendMsg.h
+++ b/lib/OpSendMsg.h
@@ -23,8 +23,6 @@
 #include <pulsar/Producer.h>
 #include <pulsar/Result.h>
 
-#include <boost/date_time/posix_time/ptime.hpp>
-
 #include "ChunkMessageIdImpl.h"
 #include "PulsarApi.pb.h"
 #include "SharedBuffer.h"
@@ -53,7 +51,7 @@ struct OpSendMsg {
     const int32_t numChunks;
     const uint32_t messagesCount;
     const uint64_t messagesSize;
-    const boost::posix_time::ptime timeout;
+    const ptime timeout;
     const SendCallback sendCallback;
     std::vector<std::function<void(Result)>> trackerCallbacks;
     ChunkMessageIdListPtr chunkMessageIdList;
@@ -98,7 +96,7 @@ struct OpSendMsg {
           numChunks(metadata.num_chunks_from_msg()),
           messagesCount(messagesCount),
           messagesSize(messagesSize),
-          timeout(TimeUtils::now() + boost::posix_time::milliseconds(sendTimeoutMs)),
+          timeout(TimeUtils::now() + std::chrono::milliseconds(sendTimeoutMs)),
           sendCallback(std::move(callback)),
           chunkMessageIdList(std::move(chunkMessageIdList)),
           sendArgs(new SendArguments(producerId, metadata.sequence_id(), metadata, payload)) {}

--- a/lib/PartitionedProducerImpl.h
+++ b/lib/PartitionedProducerImpl.h
@@ -20,21 +20,21 @@
 #include <pulsar/TopicMetadata.h>
 
 #include <atomic>
-#include <boost/asio/deadline_timer.hpp>
 #include <memory>
 #include <mutex>
 #include <vector>
 
+#include "AsioTimer.h"
 #include "LookupDataResult.h"
 #include "ProducerImplBase.h"
 #include "ProducerInterceptors.h"
+#include "TimeUtils.h"
 
 namespace pulsar {
 
 class ClientImpl;
 using ClientImplPtr = std::shared_ptr<ClientImpl>;
 using ClientImplWeakPtr = std::weak_ptr<ClientImpl>;
-using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
 class ExecutorService;
 using ExecutorServicePtr = std::shared_ptr<ExecutorService>;
 class LookupService;
@@ -128,7 +128,7 @@ class PartitionedProducerImpl : public ProducerImplBase,
 
     ExecutorServicePtr listenerExecutor_;
     DeadlineTimerPtr partitionsUpdateTimer_;
-    boost::posix_time::time_duration partitionsUpdateInterval_;
+    TimeDuration partitionsUpdateInterval_;
     LookupServicePtr lookupServicePtr_;
 
     ProducerInterceptorsPtr interceptors_;

--- a/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/lib/PatternMultiTopicsConsumerImpl.cc
@@ -27,6 +27,8 @@ DECLARE_LOG_OBJECT()
 
 using namespace pulsar;
 
+using std::chrono::seconds;
+
 PatternMultiTopicsConsumerImpl::PatternMultiTopicsConsumerImpl(
     ClientImplPtr client, const std::string pattern, CommandGetTopicsOfNamespace_Mode getTopicsMode,
     const std::vector<std::string>& topics, const std::string& subscriptionName,
@@ -49,15 +51,15 @@ void PatternMultiTopicsConsumerImpl::resetAutoDiscoveryTimer() {
     autoDiscoveryTimer_->expires_from_now(seconds(conf_.getPatternAutoDiscoveryPeriod()));
 
     auto weakSelf = weak_from_this();
-    autoDiscoveryTimer_->async_wait([weakSelf](const boost::system::error_code& err) {
+    autoDiscoveryTimer_->async_wait([weakSelf](const ASIO_ERROR& err) {
         if (auto self = weakSelf.lock()) {
             self->autoDiscoveryTimerTask(err);
         }
     });
 }
 
-void PatternMultiTopicsConsumerImpl::autoDiscoveryTimerTask(const boost::system::error_code& err) {
-    if (err == boost::asio::error::operation_aborted) {
+void PatternMultiTopicsConsumerImpl::autoDiscoveryTimerTask(const ASIO_ERROR& err) {
+    if (err == ASIO::error::operation_aborted) {
         LOG_DEBUG(getName() << "Timer cancelled: " << err.message());
         return;
     } else if (err) {
@@ -228,7 +230,7 @@ void PatternMultiTopicsConsumerImpl::start() {
     if (conf_.getPatternAutoDiscoveryPeriod() > 0) {
         autoDiscoveryTimer_->expires_from_now(seconds(conf_.getPatternAutoDiscoveryPeriod()));
         auto weakSelf = weak_from_this();
-        autoDiscoveryTimer_->async_wait([weakSelf](const boost::system::error_code& err) {
+        autoDiscoveryTimer_->async_wait([weakSelf](const ASIO_ERROR& err) {
             if (auto self = weakSelf.lock()) {
                 self->autoDiscoveryTimerTask(err);
             }
@@ -247,6 +249,6 @@ void PatternMultiTopicsConsumerImpl::closeAsync(ResultCallback callback) {
 }
 
 void PatternMultiTopicsConsumerImpl::cancelTimers() noexcept {
-    boost::system::error_code ec;
+    ASIO_ERROR ec;
     autoDiscoveryTimer_->cancel(ec);
 }

--- a/lib/PatternMultiTopicsConsumerImpl.h
+++ b/lib/PatternMultiTopicsConsumerImpl.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "AsioTimer.h"
 #include "LookupDataResult.h"
 #include "MultiTopicsConsumerImpl.h"
 #include "NamespaceName.h"
@@ -56,7 +57,7 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
 
     const PULSAR_REGEX_NAMESPACE::regex getPattern();
 
-    void autoDiscoveryTimerTask(const boost::system::error_code& err);
+    void autoDiscoveryTimerTask(const ASIO_ERROR& err);
 
     // filter input `topics` with given `pattern`, return matched topics. Do not match topic domain.
     static NamespaceTopicsPtr topicsPatternFilter(const std::vector<std::string>& topics,
@@ -74,7 +75,7 @@ class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
     const std::string patternString_;
     const PULSAR_REGEX_NAMESPACE::regex pattern_;
     const CommandGetTopicsOfNamespace_Mode getTopicsMode_;
-    typedef std::shared_ptr<boost::asio::deadline_timer> TimerPtr;
+    typedef std::shared_ptr<ASIO::steady_timer> TimerPtr;
     TimerPtr autoDiscoveryTimer_;
     bool autoDiscoveryRunning_;
     NamespaceNamePtr namespaceName_;

--- a/lib/PeriodicTask.h
+++ b/lib/PeriodicTask.h
@@ -36,7 +36,7 @@ namespace pulsar {
  */
 class PeriodicTask : public std::enable_shared_from_this<PeriodicTask> {
    public:
-    using ErrorCode = boost::system::error_code;
+    using ErrorCode = ASIO_ERROR;
     using CallbackType = std::function<void(const ErrorCode&)>;
 
     enum State : std::uint8_t

--- a/lib/ProducerImpl.h
+++ b/lib/ProducerImpl.h
@@ -19,6 +19,12 @@
 #ifndef LIB_PRODUCERIMPL_H_
 #define LIB_PRODUCERIMPL_H_
 
+#include "TimeUtils.h"
+#ifdef USE_ASIO
+#include <asio/steady_timer.hpp>
+#else
+#include <boost/asio/steady_timer.hpp>
+#endif
 #include <atomic>
 #include <boost/optional.hpp>
 #include <list>
@@ -30,6 +36,7 @@
 #if defined(_MSC_VER) || defined(__APPLE__)
 #include "OpSendMsg.h"
 #endif
+#include "AsioDefines.h"
 #include "PendingFailures.h"
 #include "PeriodicTask.h"
 #include "ProducerImplBase.h"
@@ -39,7 +46,7 @@ namespace pulsar {
 class BatchMessageContainerBase;
 class ClientImpl;
 using ClientImplPtr = std::shared_ptr<ClientImpl>;
-using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
+using DeadlineTimerPtr = std::shared_ptr<ASIO::steady_timer>;
 class MessageCrypto;
 using MessageCryptoPtr = std::shared_ptr<MessageCrypto>;
 class ProducerImpl;
@@ -137,7 +144,7 @@ class ProducerImpl : public HandlerBase, public ProducerImplBase {
 
     void resendMessages(ClientConnectionPtr cnx);
 
-    void refreshEncryptionKey(const boost::system::error_code& ec);
+    void refreshEncryptionKey(const ASIO_ERROR& ec);
     bool encryptMessage(proto::MessageMetadata& metadata, SharedBuffer& payload,
                         SharedBuffer& encryptedPayload);
 
@@ -183,8 +190,8 @@ class ProducerImpl : public HandlerBase, public ProducerImplBase {
     std::string schemaVersion_;
 
     DeadlineTimerPtr sendTimer_;
-    void handleSendTimeout(const boost::system::error_code& err);
-    using DurationType = typename boost::asio::deadline_timer::duration_type;
+    void handleSendTimeout(const ASIO_ERROR& err);
+    using DurationType = TimeDuration;
     void asyncWaitSendTimeout(DurationType expiryTime);
 
     Promise<Result, ProducerImplBaseWeakPtr> producerCreatedPromise_;

--- a/lib/RoundRobinMessageRouter.cc
+++ b/lib/RoundRobinMessageRouter.cc
@@ -26,8 +26,7 @@
 namespace pulsar {
 RoundRobinMessageRouter::RoundRobinMessageRouter(ProducerConfiguration::HashingScheme hashingScheme,
                                                  bool batchingEnabled, uint32_t maxBatchingMessages,
-                                                 uint32_t maxBatchingSize,
-                                                 boost::posix_time::time_duration maxBatchingDelay)
+                                                 uint32_t maxBatchingSize, TimeDuration maxBatchingDelay)
     : MessageRouterBase(hashingScheme),
       batchingEnabled_(batchingEnabled),
       maxBatchingMessages_(maxBatchingMessages),
@@ -74,7 +73,7 @@ int RoundRobinMessageRouter::getPartition(const Message& msg, const TopicMetadat
     int64_t now = TimeUtils::currentTimeMillis();
 
     if (messageCount >= maxBatchingMessages_ || (messageSize >= maxBatchingSize_ - batchSize) ||
-        (now - lastPartitionChange >= maxBatchingDelay_.total_milliseconds())) {
+        (now - lastPartitionChange >= toMillis(maxBatchingDelay_))) {
         uint32_t currentPartitionCursor = ++currentPartitionCursor_;
         lastPartitionChange_ = now;
         cumulativeBatchSize_ = messageSize;

--- a/lib/RoundRobinMessageRouter.h
+++ b/lib/RoundRobinMessageRouter.h
@@ -23,16 +23,16 @@
 #include <pulsar/TopicMetadata.h>
 
 #include <atomic>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include "MessageRouterBase.h"
+#include "TimeUtils.h"
 
 namespace pulsar {
 class PULSAR_PUBLIC RoundRobinMessageRouter : public MessageRouterBase {
    public:
     RoundRobinMessageRouter(ProducerConfiguration::HashingScheme hashingScheme, bool batchingEnabled,
                             uint32_t maxBatchingMessages, uint32_t maxBatchingSize,
-                            boost::posix_time::time_duration maxBatchingDelay);
+                            TimeDuration maxBatchingDelay);
     virtual ~RoundRobinMessageRouter();
     virtual int getPartition(const Message& msg, const TopicMetadata& topicMetadata);
 
@@ -40,7 +40,7 @@ class PULSAR_PUBLIC RoundRobinMessageRouter : public MessageRouterBase {
     const bool batchingEnabled_;
     const uint32_t maxBatchingMessages_;
     const uint32_t maxBatchingSize_;
-    const boost::posix_time::time_duration maxBatchingDelay_;
+    const TimeDuration maxBatchingDelay_;
 
     std::atomic<uint32_t> currentPartitionCursor_;
     std::atomic<int64_t> lastPartitionChange_;

--- a/lib/SharedBuffer.h
+++ b/lib/SharedBuffer.h
@@ -22,11 +22,18 @@
 #include <assert.h>
 
 #include <array>
+#ifdef USE_ASIO
+#include <asio/buffer.hpp>
+#include <asio/detail/socket_ops.hpp>
+#else
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/detail/socket_ops.hpp>
+#endif
 #include <memory>
 #include <string>
 #include <utility>
+
+#include "AsioDefines.h"
 
 namespace pulsar {
 
@@ -144,13 +151,13 @@ class SharedBuffer {
 
     inline bool writable() const { return writableBytes() > 0; }
 
-    boost::asio::const_buffers_1 const_asio_buffer() const {
-        return boost::asio::const_buffers_1(ptr_ + readIdx_, readableBytes());
+    ASIO::const_buffers_1 const_asio_buffer() const {
+        return ASIO::const_buffers_1(ptr_ + readIdx_, readableBytes());
     }
 
-    boost::asio::mutable_buffers_1 asio_buffer() {
+    ASIO::mutable_buffers_1 asio_buffer() {
         assert(data_);
-        return boost::asio::buffer(ptr_ + writeIdx_, writableBytes());
+        return ASIO::buffer(ptr_ + writeIdx_, writableBytes());
     }
 
     void write(const char* data, uint32_t size) {
@@ -239,17 +246,17 @@ class CompositeSharedBuffer {
     }
 
     // Implement the ConstBufferSequence requirements.
-    typedef boost::asio::const_buffer value_type;
-    typedef boost::asio::const_buffer* iterator;
-    typedef const boost::asio::const_buffer* const_iterator;
+    typedef ASIO::const_buffer value_type;
+    typedef ASIO::const_buffer* iterator;
+    typedef const ASIO::const_buffer* const_iterator;
 
-    const boost::asio::const_buffer* begin() const { return &(asioBuffers_.at(0)); }
+    const ASIO::const_buffer* begin() const { return &(asioBuffers_.at(0)); }
 
-    const boost::asio::const_buffer* end() const { return begin() + Size; }
+    const ASIO::const_buffer* end() const { return begin() + Size; }
 
    private:
     std::array<SharedBuffer, Size> sharedBuffers_;
-    std::array<boost::asio::const_buffer, Size> asioBuffers_;
+    std::array<ASIO::const_buffer, Size> asioBuffers_;
 };
 
 typedef CompositeSharedBuffer<2> PairSharedBuffer;

--- a/lib/TimeUtils.h
+++ b/lib/TimeUtils.h
@@ -21,19 +21,23 @@
 #include <pulsar/defines.h>
 
 #include <atomic>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <chrono>
 
 namespace pulsar {
 
-using namespace boost::posix_time;
-using boost::posix_time::milliseconds;
-using boost::posix_time::seconds;
+using ptime = decltype(std::chrono::high_resolution_clock::now());
+using TimeDuration = std::chrono::nanoseconds;
+
+inline decltype(std::chrono::milliseconds(0).count()) toMillis(TimeDuration duration) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+}
 
 class PULSAR_PUBLIC TimeUtils {
    public:
-    static ptime now();
-    static int64_t currentTimeMillis();
+    static ptime now() { return std::chrono::high_resolution_clock::now(); }
+    static int64_t currentTimeMillis() {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(now().time_since_epoch()).count();
+    }
 };
 
 // This class processes a timeout with the following semantics:

--- a/lib/UnAckedMessageTrackerEnabled.cc
+++ b/lib/UnAckedMessageTrackerEnabled.cc
@@ -34,9 +34,9 @@ void UnAckedMessageTrackerEnabled::timeoutHandler() {
     timeoutHandlerHelper();
     ExecutorServicePtr executorService = client_->getIOExecutorProvider()->get();
     timer_ = executorService->createDeadlineTimer();
-    timer_->expires_from_now(boost::posix_time::milliseconds(tickDurationInMs_));
+    timer_->expires_from_now(std::chrono::milliseconds(tickDurationInMs_));
     std::weak_ptr<UnAckedMessageTrackerEnabled> weakSelf{shared_from_this()};
-    timer_->async_wait([weakSelf](const boost::system::error_code& ec) {
+    timer_->async_wait([weakSelf](const ASIO_ERROR& ec) {
         auto self = weakSelf.lock();
         if (self && !ec) {
             self->timeoutHandler();
@@ -173,7 +173,7 @@ void UnAckedMessageTrackerEnabled::clear() {
 }
 
 void UnAckedMessageTrackerEnabled::stop() {
-    boost::system::error_code ec;
+    ASIO_ERROR ec;
     if (timer_) {
         timer_->cancel(ec);
     }

--- a/lib/UnAckedMessageTrackerEnabled.h
+++ b/lib/UnAckedMessageTrackerEnabled.h
@@ -18,13 +18,13 @@
  */
 #ifndef LIB_UNACKEDMESSAGETRACKERENABLED_H_
 #define LIB_UNACKEDMESSAGETRACKERENABLED_H_
-#include <boost/asio/deadline_timer.hpp>
 #include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <set>
 
+#include "AsioTimer.h"
 #include "TestUtil.h"
 #include "UnAckedMessageTrackerInterface.h"
 
@@ -33,7 +33,6 @@ namespace pulsar {
 class ClientImpl;
 class ConsumerImplBase;
 using ClientImplPtr = std::shared_ptr<ClientImpl>;
-using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
 
 class UnAckedMessageTrackerEnabled : public std::enable_shared_from_this<UnAckedMessageTrackerEnabled>,
                                      public UnAckedMessageTrackerInterface {

--- a/lib/auth/athenz/ZTSClient.cc
+++ b/lib/auth/athenz/ZTSClient.cc
@@ -44,8 +44,6 @@ namespace ptree = boost::property_tree;
 #pragma clang diagnostic ignored "-Wunknown-warning-option"
 #endif
 
-#include <boost/xpressive/xpressive.hpp>
-
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/lib/stats/ConsumerStatsImpl.cc
+++ b/lib/stats/ConsumerStatsImpl.cc
@@ -46,7 +46,7 @@ ConsumerStatsImpl::ConsumerStatsImpl(const ConsumerStatsImpl& stats)
       totalAckedMsgMap_(stats.totalAckedMsgMap_),
       statsIntervalInSeconds_(stats.statsIntervalInSeconds_) {}
 
-void ConsumerStatsImpl::flushAndReset(const boost::system::error_code& ec) {
+void ConsumerStatsImpl::flushAndReset(const ASIO_ERROR& ec) {
     if (ec) {
         LOG_DEBUG("Ignoring timer cancelled event, code[" << ec << "]");
         return;
@@ -85,9 +85,9 @@ void ConsumerStatsImpl::messageAcknowledged(Result res, CommandAck_AckType ackTy
 }
 
 void ConsumerStatsImpl::scheduleTimer() {
-    timer_->expires_from_now(boost::posix_time::seconds(statsIntervalInSeconds_));
+    timer_->expires_from_now(std::chrono::seconds(statsIntervalInSeconds_));
     std::weak_ptr<ConsumerStatsImpl> weakSelf{shared_from_this()};
-    timer_->async_wait([this, weakSelf](const boost::system::error_code& ec) {
+    timer_->async_wait([this, weakSelf](const ASIO_ERROR& ec) {
         auto self = weakSelf.lock();
         if (!self) {
             return;

--- a/lib/stats/ConsumerStatsImpl.h
+++ b/lib/stats/ConsumerStatsImpl.h
@@ -20,17 +20,16 @@
 #ifndef PULSAR_CONSUMER_STATS_IMPL_H_
 #define PULSAR_CONSUMER_STATS_IMPL_H_
 
-#include <boost/asio/deadline_timer.hpp>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <utility>
 
 #include "ConsumerStatsBase.h"
+#include "lib/AsioTimer.h"
 #include "lib/ExecutorService.h"
 namespace pulsar {
 
-using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
 class ExecutorService;
 using ExecutorServicePtr = std::shared_ptr<ExecutorService>;
 
@@ -58,7 +57,7 @@ class ConsumerStatsImpl : public std::enable_shared_from_this<ConsumerStatsImpl>
    public:
     ConsumerStatsImpl(std::string, ExecutorServicePtr, unsigned int);
     ConsumerStatsImpl(const ConsumerStatsImpl& stats);
-    void flushAndReset(const boost::system::error_code&);
+    void flushAndReset(const ASIO_ERROR&);
     void start() override;
     void receivedMessage(Message&, Result) override;
     void messageAcknowledged(Result, CommandAck_AckType, uint32_t ackNums) override;

--- a/lib/stats/ProducerStatsDisabled.h
+++ b/lib/stats/ProducerStatsDisabled.h
@@ -25,7 +25,7 @@ namespace pulsar {
 class ProducerStatsDisabled : public ProducerStatsBase {
    public:
     virtual void messageSent(const Message& msg){};
-    virtual void messageReceived(Result, const boost::posix_time::ptime&){};
+    virtual void messageReceived(Result, const ptime&){};
 };
 }  // namespace pulsar
 #endif  // PULSAR_PRODUCER_STATS_DISABLED_HEADER

--- a/lib/stats/ProducerStatsImpl.h
+++ b/lib/stats/ProducerStatsImpl.h
@@ -30,20 +30,18 @@
 #include <boost/accumulators/framework/features.hpp>
 #include <boost/accumulators/statistics.hpp>
 #include <boost/accumulators/statistics/extended_p_square.hpp>
-#include <boost/asio/deadline_timer.hpp>
-#include <boost/date_time/local_time/local_time.hpp>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <vector>
 
 #include "ProducerStatsBase.h"
+#include "lib/AsioTimer.h"
 
 namespace pulsar {
 
 class ExecutorService;
 using ExecutorServicePtr = std::shared_ptr<ExecutorService>;
-using DeadlineTimerPtr = std::shared_ptr<boost::asio::deadline_timer>;
 
 typedef boost::accumulators::accumulator_set<
     double,
@@ -83,11 +81,11 @@ class ProducerStatsImpl : public std::enable_shared_from_this<ProducerStatsImpl>
 
     void start() override;
 
-    void flushAndReset(const boost::system::error_code&);
+    void flushAndReset(const ASIO_ERROR&);
 
     void messageSent(const Message&) override;
 
-    void messageReceived(Result, const boost::posix_time::ptime&) override;
+    void messageReceived(Result, const ptime&) override;
 
     ~ProducerStatsImpl();
 

--- a/tests/AuthPluginTest.cc
+++ b/tests/AuthPluginTest.cc
@@ -21,9 +21,14 @@
 #include <pulsar/Client.h>
 
 #include <boost/algorithm/string.hpp>
+#ifdef USE_ASIO
+#include <asio.hpp>
+#else
 #include <boost/asio.hpp>
+#endif
 #include <thread>
 
+#include "lib/AsioDefines.h"
 #include "lib/Future.h"
 #include "lib/Latch.h"
 #include "lib/LogUtils.h"
@@ -287,10 +292,9 @@ namespace testAthenz {
 std::string principalToken;
 void mockZTS(Latch& latch, int port) {
     LOG_INFO("-- MockZTS started");
-    boost::asio::io_service io;
-    boost::asio::ip::tcp::iostream stream;
-    boost::asio::ip::tcp::acceptor acceptor(io,
-                                            boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port));
+    ASIO::io_service io;
+    ASIO::ip::tcp::iostream stream;
+    ASIO::ip::tcp::acceptor acceptor(io, ASIO::ip::tcp::endpoint(ASIO::ip::tcp::v4(), port));
 
     LOG_INFO("-- MockZTS waiting for connnection");
     latch.countdown();

--- a/tests/AuthTokenTest.cc
+++ b/tests/AuthTokenTest.cc
@@ -22,7 +22,6 @@
 #include <pulsar/Client.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/asio.hpp>
 #include <fstream>
 #include <streambuf>
 #include <string>

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -955,7 +955,7 @@ TEST(ConsumerTest, testGetLastMessageIdBlockWhenConnectionDisconnected) {
     auto elapsed = TimeUtils::now() - start;
 
     // getLastMessageIdAsync should be blocked until operationTimeout when the connection is disconnected.
-    ASSERT_GE(elapsed.seconds(), operationTimeout);
+    ASSERT_GE(std::chrono::duration_cast<std::chrono::seconds>(elapsed).count(), operationTimeout);
 }
 
 TEST(ConsumerTest, testRedeliveryOfDecryptionFailedMessages) {

--- a/tests/PulsarFriend.h
+++ b/tests/PulsarFriend.h
@@ -170,7 +170,7 @@ class PulsarFriend {
         handler.connection_ = conn;
     }
 
-    static boost::posix_time::ptime& getFirstBackoffTime(Backoff& backoff) {
+    static auto getFirstBackoffTime(Backoff& backoff) -> decltype(backoff.firstBackoffTime_)& {
         return backoff.firstBackoffTime_;
     }
 

--- a/tests/RoundRobinMessageRouterTest.cc
+++ b/tests/RoundRobinMessageRouterTest.cc
@@ -31,7 +31,7 @@ TEST(RoundRobinMessageRouterTest, onePartition) {
     const int numPartitions = 1;
 
     RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, false, 1, 1,
-                                   boost::posix_time::milliseconds(0));
+                                   std::chrono::milliseconds(0));
 
     Message msg1 = MessageBuilder().setPartitionKey("my-key-1").setContent("one").build();
     Message msg2 = MessageBuilder().setPartitionKey("my-key-2").setContent("two").build();
@@ -49,7 +49,7 @@ TEST(RoundRobinMessageRouterTest, sameKey) {
     const int numPartitions = 13;
 
     RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, false, 1, 1,
-                                   boost::posix_time::milliseconds(0));
+                                   std::chrono::milliseconds(0));
 
     Message msg1 = MessageBuilder().setPartitionKey("my-key").setContent("one").build();
     Message msg2 = MessageBuilder().setPartitionKey("my-key").setContent("two").build();
@@ -63,7 +63,7 @@ TEST(RoundRobinMessageRouterTest, batchingDisabled) {
     const int numPartitions = 13;
 
     RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, false, 1, 1,
-                                   boost::posix_time::milliseconds(0));
+                                   std::chrono::milliseconds(0));
 
     Message msg1 = MessageBuilder().setContent("one").build();
     Message msg2 = MessageBuilder().setContent("two").build();
@@ -77,7 +77,7 @@ TEST(RoundRobinMessageRouterTest, batchingEnabled) {
     const int numPartitions = 13;
 
     RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, true, 1000, 100000,
-                                   boost::posix_time::seconds(1));
+                                   std::chrono::seconds(1));
 
     int p = -1;
     for (int i = 0; i < 100; i++) {
@@ -96,7 +96,7 @@ TEST(RoundRobinMessageRouterTest, maxDelay) {
     const int numPartitions = 13;
 
     RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, true, 1000, 100000,
-                                   boost::posix_time::seconds(1));
+                                   std::chrono::seconds(1));
 
     int p1 = -1;
     for (int i = 0; i < 100; i++) {
@@ -132,8 +132,7 @@ TEST(RoundRobinMessageRouterTest, maxDelay) {
 TEST(RoundRobinMessageRouterTest, maxNumberOfMessages) {
     const int numPartitions = 13;
 
-    RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, true, 2, 1000,
-                                   boost::posix_time::seconds(1));
+    RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, true, 2, 1000, std::chrono::seconds(1));
 
     Message msg1 = MessageBuilder().setContent("one").build();
     Message msg2 = MessageBuilder().setContent("two").build();
@@ -150,8 +149,7 @@ TEST(RoundRobinMessageRouterTest, maxNumberOfMessages) {
 TEST(RoundRobinMessageRouterTest, maxBatchSize) {
     const int numPartitions = 13;
 
-    RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, true, 10, 8,
-                                   boost::posix_time::seconds(1));
+    RoundRobinMessageRouter router(ProducerConfiguration::BoostHash, true, 10, 8, std::chrono::seconds(1));
 
     Message msg1 = MessageBuilder().setContent("one").build();
     Message msg2 = MessageBuilder().setContent("two").build();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,43 +5,18 @@
   "builtin-baseline": "b051745c68faa6f65c493371d564c4eb8af34dad",
   "dependencies": [
     {
+      "name": "asio",
+      "features": [
+        "openssl"
+      ],
+      "version>=": "1.28.2"
+    },
+    {
       "name": "boost-accumulators",
       "version>=": "1.83.0"
     },
     {
-      "name": "boost-algorithm",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-any",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-asio",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-circular-buffer",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-date-time",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-predef",
-      "version>=": "1.83.0"
-    },
-    {
       "name": "boost-property-tree",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-serialization",
-      "version>=": "1.83.0"
-    },
-    {
-      "name": "boost-xpressive",
       "version>=": "1.83.0"
     },
     {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/367

### Motivation

See the difference of Asio and Boost.Asio here: https://think-async.com/Asio/AsioAndBoostAsio.html

Asio is updated more frequently than Boost.Asio and its release does not need to be synchronous with other Boost components. Depending on the independent Asio could make it easier for a newer Asio release.

### Modifications

Import `asio` 1.28.2 as the dependency and remove the `boost-asio` dependency from the vcpkg.json. Since the latest Asio already removed the `deadline_timer`, this patch replaces all `deadline_timer` with `steady_timer`, which uses `std::chrono` rather than Boost.Date_Time component to compute the timeout.

Add a `USE_ASIO` CMake option to determine whether Asio or Boost.Asio is depended. For vcpkg users, the option is always enabled.

Finally, simplify the vcpkg.json by removing some `boost-*` dependencies depended indirectly by the rest two major dependencies:
- boost-accumulators: latency percentiles computation
- boost-property-tree: JSON operations

These two dependencies are hard to remove for now unless introducing other dependencies so they will be kept from some time.