### PR TITLE
Fix Boost source code download failure

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-boost : 1.80.0
+boost : 1.83.0
 cmake: 3.24.2
 protobuf: 3.20.0
 zlib: 1.2.12

--- a/pkg/apk/Dockerfile
+++ b/pkg/apk/Dockerfile
@@ -43,13 +43,12 @@ ADD .build/dep-version.py /usr/local/bin
 
 # Download and compile boost
 RUN BOOST_VERSION=$(dep-version.py boost) && \
-    BOOST_VERSION_UNDESRSCORE=$(echo $BOOST_VERSION | sed 's/\./_/g') && \
-    curl -O -L https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz && \
-    tar xfz boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz && \
-    cd boost_${BOOST_VERSION_UNDESRSCORE} && \
+    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz && \
+    tar zxf boost-${BOOST_VERSION}.tar.gz && \
+    cd boost-${BOOST_VERSION} && \
     ./bootstrap.sh --with-libraries=regex && \
     ./b2 -d0 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
-    rm -rf /boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz /boost_${BOOST_VERSION_UNDESRSCORE}
+    rm -rf /boost-${BOOST_VERSION}.tar.gz /boost-${BOOST_VERSION}
 
 # Download and compile protobuf
 RUN PROTOBUF_VERSION=$(dep-version.py protobuf) && \

--- a/pkg/deb/Dockerfile
+++ b/pkg/deb/Dockerfile
@@ -41,13 +41,12 @@ ADD .build/dep-version.py /usr/local/bin
 
 # Download and compile boost
 RUN BOOST_VERSION=$(dep-version.py boost) && \
-    BOOST_VERSION_UNDESRSCORE=$(echo $BOOST_VERSION | sed 's/\./_/g') && \
-    curl -O -L https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz && \
-    tar xfz boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz && \
-    cd boost_${BOOST_VERSION_UNDESRSCORE} && \
+    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz && \
+    tar zxf boost-${BOOST_VERSION}.tar.gz && \
+    cd boost-${BOOST_VERSION} && \
     ./bootstrap.sh --with-libraries=regex && \
     ./b2 -d0 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
-    rm -rf /boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz /boost_${BOOST_VERSION_UNDESRSCORE}
+    rm -rf /boost-${BOOST_VERSION}.tar.gz /boost-${BOOST_VERSION}
 
 RUN CMAKE_VERSION=$(dep-version.py cmake) && \
     curl -O -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${PLATFORM}.tar.gz && \

--- a/pkg/mac/build-static-library.sh
+++ b/pkg/mac/build-static-library.sh
@@ -51,7 +51,7 @@ if [ ! -f boost/.done ]; then
     tar zxf boost-${BOOST_VERSION}.tar.gz
     mkdir -p $PREFIX/include
     pushd boost-${BOOST_VERSION}
-      ./bootstrap.sh --with-libraries
+      ./bootstrap.sh
       ./b2 headers
       cp -rf boost $PREFIX/include/
     popd

--- a/pkg/mac/build-static-library.sh
+++ b/pkg/mac/build-static-library.sh
@@ -45,13 +45,16 @@ ZSTD_VERSION=$(./dep-version.py zstd)
 SNAPPY_VERSION=$(./dep-version.py snappy)
 CURL_VERSION=$(./dep-version.py curl)
 
-BOOST_VERSION_=${BOOST_VERSION//./_}
 if [ ! -f boost/.done ]; then
     echo "Building Boost $BOOST_VERSION"
-    curl -O -L https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_}.tar.gz
-    tar zxf boost_${BOOST_VERSION_}.tar.gz
+    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz
+    tar zxf boost-${BOOST_VERSION}.tar.gz
     mkdir -p $PREFIX/include
-    cp -rf boost_${BOOST_VERSION_}/boost $PREFIX/include/
+    pushd boost-${BOOST_VERSION}
+      ./bootstrap.sh --with-libraries
+      ./b2 headers
+      cp -rf boost $PREFIX/include/
+    popd
     mkdir -p boost
     touch boost/.done
 else

--- a/pkg/rpm/Dockerfile
+++ b/pkg/rpm/Dockerfile
@@ -42,13 +42,12 @@ ADD .build/dep-version.py /usr/local/bin
 # GCC 4.8.2 implementation of std::regex is buggy, so we install boost::regex here
 RUN BOOST_VERSION=$(dep-version.py boost) && \
     echo "BOOST VERSION: '${BOOST_VERSION}'" && \
-    BOOST_VERSION_UNDESRSCORE=$(echo $BOOST_VERSION | sed 's/\./_/g') && \
-    curl -O -L https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz && \
-    tar xfz boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz && \
-    cd boost_${BOOST_VERSION_UNDESRSCORE} && \
+    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz && \
+    tar zxf boost-${BOOST_VERSION}.tar.gz && \
+    cd boost-${BOOST_VERSION} && \
     ./bootstrap.sh --with-libraries=regex && \
     ./b2 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
-    rm -rf /boost_${BOOST_VERSION_UNDESRSCORE}.tar.gz /boost_${BOOST_VERSION_UNDESRSCORE}
+    rm -rf /boost-${BOOST_VERSION}.tar.gz /boost-${BOOST_VERSION}
 
 RUN CMAKE_VERSION=$(dep-version.py cmake) && \
     curl -O -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${PLATFORM}.tar.gz && \


### PR DESCRIPTION
### Motivation

The main branch is broken because Boost is downloaded from JFrog, which now requires log in.

### Modifications

Switch to Github to download Boost. Since GitHub only has the Boost release since 1.81.0, upgrade the version to 1.83.0, which is also consistent with vcpkg.json.
