### PR TITLE
Fix wrong TimeUtils::currentTimeMillis() implementation

### DIFF
--- a/lib/TimeUtils.h
+++ b/lib/TimeUtils.h
@@ -35,8 +35,9 @@ inline decltype(std::chrono::milliseconds(0).count()) toMillis(TimeDuration dura
 class PULSAR_PUBLIC TimeUtils {
    public:
     static ptime now() { return std::chrono::high_resolution_clock::now(); }
+
     static int64_t currentTimeMillis() {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(now().time_since_epoch()).count();
+        return toMillis(std::chrono::system_clock::now().time_since_epoch());
     }
 };
 

--- a/tests/BackoffTest.cc
+++ b/tests/BackoffTest.cc
@@ -17,12 +17,14 @@
  * under the License.
  */
 #include <gtest/gtest.h>
+#include <time.h>
 
 #include <thread>
 
 #include "PulsarFriend.h"
 #include "lib/Backoff.h"
 #include "lib/ClientConnection.h"
+#include "lib/TimeUtils.h"
 #include "lib/stats/ProducerStatsImpl.h"
 
 using namespace pulsar;
@@ -41,6 +43,12 @@ static bool withinTenPercentAndDecrementTimer(Backoff& backoff, const unsigned i
     auto& firstBackOffTime = PulsarFriend::getFirstBackoffTime(backoff);
     firstBackOffTime -= milliseconds(t2);
     return (t1 >= t2 * 0.9 && t1 <= t2);
+}
+
+TEST(BackoffTest, testCurrentTimeMillis) {
+    auto t1 = TimeUtils::currentTimeMillis();
+    auto t2 = 1000L * time(nullptr);
+    ASSERT_TRUE(t1 - t2 < 1000L) << "t1: " << t1 << ", t2: " << t2;
 }
 
 TEST(BackoffTest, mandatoryStopTestNegativeTest) {


### PR DESCRIPTION
### Motivation

`TimeUtils::currentTimeMillis()` is used to get the timestamp since 1970 but `high_resolution_clock` does not necessarily represent the system clock. For example, given the following code:

```c++
template <typename Clock>
inline int64_t getTimestamp() {
    using namespace std::chrono;
    return duration_cast<milliseconds>(Clock::now().time_since_epoch()).count();
}

int main() {
    std::cout << time(nullptr) << std::endl;
    std::cout << getTimestamp<std::chrono::system_clock>() << std::endl;
    std::cout << getTimestamp<std::chrono::high_resolution_clock>() << std::endl;
}
```

The outputs could be:

```
1705584279
1705584279351
38566832
```

### Modifications

Use `std::system_clock` for `currentTimeMillis()`. Add `BackoffTest.testCurrentTimeMillis` to verify the result is similar to 1000 times of `time(nullptr)` (the timestamp in seconds from the C API).