### PR TITLE
Fix an unbalanced release of the producer's pending semaphore

### DIFF
--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -630,7 +630,6 @@ void ProducerImpl::sendAsyncWithStatsUpdate(const Message& msg, SendCallback&& c
                 const uint32_t msgHeadersAndPayloadSize = msgMetadataSize + payloadSize;
                 if (msgHeadersAndPayloadSize > maxMessageSize) {
                     lock.unlock();
-                    releaseSemaphoreForSendOp(*op);
                     LOG_WARN(getName()
                              << " - compressed Message size " << msgHeadersAndPayloadSize << " cannot exceed "
                              << maxMessageSize << " bytes unless chunking is enabled");

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -243,6 +243,8 @@ TEST_P(ProducerTest, testMaxMessageSize) {
     ASSERT_EQ(ResultMessageTooBig,
               producer.send(MessageBuilder().setContent(std::string(maxMessageSize, 'b')).build()));
 
+    ASSERT_EQ(ResultOk, producer.send(MessageBuilder().setContent(msg).build()));
+
     client.close();
 }
 


### PR DESCRIPTION
### Motivation

Current code releases the producer's pending semaphore twice when batch is off and message is too big. The unbalanced release overflows the semaphore, and subsequent sends will fail with ProducerQueueIsFull.

### Modifications

Remove the redundant semaphore release as the necessary release will be done in `handleFailedResult`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change modified a existing test and can be verified as follows:
  - ProducerTest.testMaxMessageSize

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
Bug fix.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
