### PR TITLE
Pin the Pulsar version to 3.1.1 temporarily for the regression in Pulsar

### DIFF
--- a/pulsar-test-service-start.sh
+++ b/pulsar-test-service-start.sh
@@ -25,12 +25,12 @@ SRC_DIR=$PWD
 
 ./pulsar-test-service-stop.sh
 
-CONTAINER_ID=$(docker run -i --user $(id -u) -p 8080:8080 -p 6650:6650 -p 8443:8443 -p 6651:6651 --rm --detach apachepulsar/pulsar:latest sleep 3600)
+CONTAINER_ID=$(docker run -i --user $(id -u) -p 8080:8080 -p 6650:6650 -p 8443:8443 -p 6651:6651 --rm --detach apachepulsar/pulsar:3.1.1 sleep 3600)
 build-support/setup-test-service-container.sh $CONTAINER_ID start-test-service-inside-container.sh
 
 docker cp $CONTAINER_ID:/pulsar/data/tokens/token.txt .test-token.txt
 
-CONTAINER_ID=$(docker run -i --user $(id -u) -p 8081:8081 -p 6652:6652 -p 8444:8444 -p 6653:6653 --rm --detach apachepulsar/pulsar:latest sleep 3600)
+CONTAINER_ID=$(docker run -i --user $(id -u) -p 8081:8081 -p 6652:6652 -p 8444:8444 -p 6653:6653 --rm --detach apachepulsar/pulsar:3.1.1 sleep 3600)
 build-support/setup-test-service-container.sh $CONTAINER_ID start-mim-test-service-inside-container.sh
 
 echo "-- Ready to start tests"


### PR DESCRIPTION
### Motivation

Pulsar 3.1.2 introduces a regression that makes two tests fail:

- AuthPluginTest.testTlsDetectPulsarSslWithInvalidBroker (try #1)
- AuthPluginTest.testTlsDetectHttpsWithInvalidBroker (try #1)

### Modifications

Pin the Pulsar version to 3.1.1 until there is a new Pulsar release that fixes the regression.