### PR TITLE
Fix creating producer or consumer is not retried for connection failure

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -83,7 +83,7 @@ static Result getResult(ServerError serverError, const std::string& message) {
         case ServiceNotReady:
             return (message.find("the broker do not have test listener") == std::string::npos)
                        ? ResultRetryable
-                       : ResultServiceUnitNotReady;
+                       : ResultConnectError;
 
         case ProducerBlockedQuotaExceededError:
             return ResultProducerBlockedQuotaExceededError;

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -504,8 +504,13 @@ void ClientConnection::handleTcpConnected(const ASIO_ERROR& err, tcp::resolver::
 
 void ClientConnection::handleHandshake(const ASIO_ERROR& err) {
     if (err) {
-        LOG_ERROR(cnxString_ << "Handshake failed: " << err.message());
-        close();
+        if (err.value() == ASIO::ssl::error::stream_truncated) {
+            LOG_WARN(cnxString_ << "Handshake failed: " << err.message());
+            close(ResultRetryable);
+        } else {
+            LOG_ERROR(cnxString_ << "Handshake failed: " << err.message());
+            close();
+        }
         return;
     }
 

--- a/lib/ClientConnectionAdaptor.h
+++ b/lib/ClientConnectionAdaptor.h
@@ -37,12 +37,14 @@ inline void checkServerError(Connection& connection, ServerError error, const st
             //   "Namespace bundle ... is being unloaded"
             //   "KeeperException$..."
             //   "Failed to acquire ownership for namespace bundle ..."
+            //   "the broker do not have test listener"
             // Before https://github.com/apache/pulsar/pull/21211, the error of the 1st and 2nd messages
             // is ServiceNotReady. Before https://github.com/apache/pulsar/pull/21993, the error of the 3rd
             // message is ServiceNotReady.
             if (message.find("Failed to acquire ownership") == std::string::npos &&
                 message.find("KeeperException") == std::string::npos &&
-                message.find("is being unloaded") == std::string::npos) {
+                message.find("is being unloaded") == std::string::npos &&
+                message.find("the broker do not have test listener") == std::string::npos) {
                 connection.close(ResultDisconnected);
             }
             break;

--- a/lib/ClientImpl.cc
+++ b/lib/ClientImpl.cc
@@ -517,7 +517,7 @@ void ClientImpl::handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr co
     }
 }
 
-Future<Result, ClientConnectionPtr> ClientImpl::getConnection(const std::string& topic, size_t key) {
+GetConnectionFuture ClientImpl::getConnection(const std::string& topic, size_t key) {
     Promise<Result, ClientConnectionPtr> promise;
 
     const auto topicNamePtr = TopicName::get(topic);
@@ -562,7 +562,7 @@ const std::string& ClientImpl::getPhysicalAddress(const std::string& logicalAddr
     }
 }
 
-Future<Result, ClientConnectionPtr> ClientImpl::connect(const std::string& logicalAddress, size_t key) {
+GetConnectionFuture ClientImpl::connect(const std::string& logicalAddress, size_t key) {
     const auto& physicalAddress = getPhysicalAddress(logicalAddress);
     Promise<Result, ClientConnectionPtr> promise;
     pool_.getConnectionAsync(logicalAddress, physicalAddress, key)

--- a/lib/ClientImpl.h
+++ b/lib/ClientImpl.h
@@ -63,13 +63,14 @@ class TopicName;
 using TopicNamePtr = std::shared_ptr<TopicName>;
 
 using NamespaceTopicsPtr = std::shared_ptr<std::vector<std::string>>;
+using GetConnectionFuture = Future<Result, ClientConnectionPtr>;
 
 std::string generateRandomName();
 
 class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
    public:
     ClientImpl(const std::string& serviceUrl, const ClientConfiguration& clientConfiguration);
-    ~ClientImpl();
+    virtual ~ClientImpl();
 
     /**
      * @param autoDownloadSchema When it is true, Before creating a producer, it will try to get the schema
@@ -95,9 +96,10 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
 
     void getPartitionsForTopicAsync(const std::string& topic, GetPartitionsCallback callback);
 
-    Future<Result, ClientConnectionPtr> getConnection(const std::string& topic, size_t key);
+    // Use virtual method to test
+    virtual GetConnectionFuture getConnection(const std::string& topic, size_t key);
 
-    Future<Result, ClientConnectionPtr> connect(const std::string& logicalAddress, size_t key);
+    GetConnectionFuture connect(const std::string& logicalAddress, size_t key);
 
     void closeAsync(CloseCallback callback);
     void shutdown();

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -277,7 +277,7 @@ void ConsumerImpl::connectionFailed(Result result) {
     // Keep a reference to ensure object is kept alive
     auto ptr = get_shared_this_ptr();
 
-    if (consumerCreatedPromise_.setFailed(result)) {
+    if (!isResultRetryable(result) && consumerCreatedPromise_.setFailed(result)) {
         state_ = Failed;
     }
 }

--- a/lib/Future.h
+++ b/lib/Future.h
@@ -116,6 +116,8 @@ class Future {
 
     Result get(Type &result) { return state_->get(result); }
 
+    static Future<Result, Type> failed(Result result);
+
    private:
     InternalStatePtr<Result, Type> state_;
 
@@ -143,6 +145,13 @@ class Promise {
    private:
     InternalStatePtr<Result, Type> state_;
 };
+
+template <typename Result, typename Type>
+inline Future<Result, Type> Future<Result, Type>::failed(Result result) {
+    Promise<Result, Type> promise;
+    promise.setFailed(result);
+    return promise.getFuture();
+}
 
 }  // namespace pulsar
 

--- a/lib/HandlerBase.h
+++ b/lib/HandlerBase.h
@@ -140,6 +140,7 @@ class HandlerBase : public std::enable_shared_from_this<HandlerBase> {
 
    private:
     DeadlineTimerPtr timer_;
+    DeadlineTimerPtr creationTimer_;
 
     mutable std::mutex connectionMutex_;
     std::atomic<bool> reconnectionPending_;

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -176,7 +176,7 @@ void ProducerImpl::connectionFailed(Result result) {
         // if producers are lazy, then they should always try to restart
         // so don't change the state and allow reconnections
         return;
-    } else if (producerCreatedPromise_.setFailed(result)) {
+    } else if (!isResultRetryable(result) && producerCreatedPromise_.setFailed(result)) {
         state_ = Failed;
     }
 }

--- a/lib/ResultUtils.h
+++ b/lib/ResultUtils.h
@@ -18,12 +18,39 @@
  */
 #pragma once
 
+#include <assert.h>
 #include <pulsar/Result.h>
+
+#include <unordered_set>
 
 namespace pulsar {
 
 inline bool isResultRetryable(Result result) {
-    return result == ResultRetryable || result == ResultDisconnected;
+    assert(result != ResultOk);
+    if (result == ResultRetryable || result == ResultDisconnected) {
+        return true;
+    }
+
+    static const std::unordered_set<Result> fatalResults{ResultConnectError,
+                                                         ResultTimeout,
+                                                         ResultAuthenticationError,
+                                                         ResultAuthorizationError,
+                                                         ResultInvalidUrl,
+                                                         ResultInvalidConfiguration,
+                                                         ResultIncompatibleSchema,
+                                                         ResultTopicNotFound,
+                                                         ResultOperationNotSupported,
+                                                         ResultNotAllowedError,
+                                                         ResultChecksumError,
+                                                         ResultCryptoError,
+                                                         ResultConsumerAssignError,
+                                                         ResultProducerBusy,
+                                                         ResultConsumerBusy,
+                                                         ResultLookupError,
+                                                         ResultTooManyLookupRequestException,
+                                                         ResultProducerBlockedQuotaExceededException,
+                                                         ResultProducerBlockedQuotaExceededError};
+    return fatalResults.find(result) == fatalResults.cend();
 }
 
 }  // namespace pulsar

--- a/lib/ResultUtils.h
+++ b/lib/ResultUtils.h
@@ -31,26 +31,26 @@ inline bool isResultRetryable(Result result) {
         return true;
     }
 
-    static const std::unordered_set<Result> fatalResults{ResultConnectError,
-                                                         ResultTimeout,
-                                                         ResultAuthenticationError,
-                                                         ResultAuthorizationError,
-                                                         ResultInvalidUrl,
-                                                         ResultInvalidConfiguration,
-                                                         ResultIncompatibleSchema,
-                                                         ResultTopicNotFound,
-                                                         ResultOperationNotSupported,
-                                                         ResultNotAllowedError,
-                                                         ResultChecksumError,
-                                                         ResultCryptoError,
-                                                         ResultConsumerAssignError,
-                                                         ResultProducerBusy,
-                                                         ResultConsumerBusy,
-                                                         ResultLookupError,
-                                                         ResultTooManyLookupRequestException,
-                                                         ResultProducerBlockedQuotaExceededException,
-                                                         ResultProducerBlockedQuotaExceededError};
-    return fatalResults.find(result) == fatalResults.cend();
+    static const std::unordered_set<int> fatalResults{ResultConnectError,
+                                                      ResultTimeout,
+                                                      ResultAuthenticationError,
+                                                      ResultAuthorizationError,
+                                                      ResultInvalidUrl,
+                                                      ResultInvalidConfiguration,
+                                                      ResultIncompatibleSchema,
+                                                      ResultTopicNotFound,
+                                                      ResultOperationNotSupported,
+                                                      ResultNotAllowedError,
+                                                      ResultChecksumError,
+                                                      ResultCryptoError,
+                                                      ResultConsumerAssignError,
+                                                      ResultProducerBusy,
+                                                      ResultConsumerBusy,
+                                                      ResultLookupError,
+                                                      ResultTooManyLookupRequestException,
+                                                      ResultProducerBlockedQuotaExceededException,
+                                                      ResultProducerBlockedQuotaExceededError};
+    return fatalResults.find(static_cast<int>(result)) == fatalResults.cend();
 }
 
 }  // namespace pulsar

--- a/tests/MockClientImpl.h
+++ b/tests/MockClientImpl.h
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <gmock/gmock.h>
+#include <sys/stat.h>
+
+#include <chrono>
+#include <future>
+#include <memory>
+
+#include "lib/ClientImpl.h"
+
+namespace pulsar {
+
+class MockClientImpl : public ClientImpl {
+   public:
+    struct SyncOpResult {
+        Result result;
+        long timeMs;
+    };
+    using PromisePtr = std::shared_ptr<std::promise<SyncOpResult>>;
+    MockClientImpl(const std::string& serviceUrl, ClientConfiguration conf = {})
+        : ClientImpl(serviceUrl, conf) {}
+
+    MOCK_METHOD((Future<Result, ClientConnectionPtr>), getConnection, (const std::string&, size_t),
+                (override));
+
+    SyncOpResult createProducer(const std::string& topic) {
+        using namespace std::chrono;
+        auto start = high_resolution_clock::now();
+        auto promise = createPromise();
+        createProducerAsync(topic, {}, [&start, promise](Result result, Producer) {
+            auto timeMs = duration_cast<milliseconds>(high_resolution_clock::now() - start).count();
+            promise->set_value({result, timeMs});
+        });
+        return wait(promise);
+    }
+
+    SyncOpResult subscribe(const std::string& topic) {
+        using namespace std::chrono;
+        auto start = std::chrono::high_resolution_clock::now();
+        auto promise = createPromise();
+        subscribeAsync(topic, "sub", {}, [&start, &promise](Result result, Consumer) {
+            auto timeMs = duration_cast<milliseconds>(high_resolution_clock::now() - start).count();
+            promise->set_value({result, timeMs});
+        });
+        return wait(promise);
+    }
+
+    GetConnectionFuture getConnectionReal(const std::string& topic, size_t key) {
+        return ClientImpl::getConnection(topic, key);
+    }
+
+    Result close() {
+        auto promise = createPromise();
+        closeAsync([promise](Result result) { promise->set_value({result, 0L}); });
+        return wait(promise).result;
+    }
+
+   private:
+    static PromisePtr createPromise() { return std::make_shared<std::promise<SyncOpResult>>(); }
+
+    static SyncOpResult wait(const PromisePtr& promise) {
+        using namespace std::chrono;
+        auto future = promise->get_future();
+        auto status = future.wait_for(std::chrono::seconds(10));
+        if (status == std::future_status::ready) {
+            return future.get();
+        } else {
+            return {ResultUnknownError, -1L};
+        }
+    }
+};
+
+}  // namespace pulsar


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/391

### Motivation

When `connectionFailed` is called, no matter if the result is retryable the creation of producer or consumer will fail without retry.

### Modifications

Check if the result is retryable in `connectionFailed` for `ProducerImpl` and `ConsumerImpl` and only fail for non-retryable errors or the timeout error. Register another timer in `HandlerBase` to propagate the timeout error to `connectionFailed`.

Add `testRetryUntilSucceed`, `testRetryTimeout`, `testNoRetry` to verify client could retry according to the result returned by `ClientImpl::getConnection`.