### PR TITLE
Fix segmenatation fault if connection is closed during handshake

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -456,7 +456,11 @@ void ClientConnection::handleTcpConnected(const ASIO_ERROR& err, tcp::resolver::
                 }
             }
             auto weakSelf = weak_from_this();
-            auto callback = [weakSelf](const ASIO_ERROR& err) {
+            auto socket = socket_;
+            auto tlsSocket = tlsSocket_;
+            // socket and ssl::stream objects must exist until async_handshake is done, otherwise segmentation
+            // fault might happen
+            auto callback = [weakSelf, socket, tlsSocket](const ASIO_ERROR& err) {
                 auto self = weakSelf.lock();
                 if (self) {
                     self->handleHandshake(err);


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/398

### Motivation

There is an implicit requirement for the `async_handshake` API that before it's done, the `socket` and `ssl::stream` objects must exist. Otherwise segmenatation fault might happen.

### Modifications

Capture `socket_` and `tlsSocket_` in the handshake callback. It can be verified by modifying the code according to #398 and rerun the test.