### PR TITLE
Fix broken main branch after Pulsar image was upgraded to 3.2.0

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -81,9 +81,9 @@ static Result getResult(ServerError serverError, const std::string& message) {
             return ResultConsumerBusy;
 
         case ServiceNotReady:
-            // If the error is not caused by a PulsarServerException, treat it as retryable.
-            return (message.find("PulsarServerException") == std::string::npos) ? ResultRetryable
-                                                                                : ResultServiceUnitNotReady;
+            return (message.find("the broker do not have test listener") == std::string::npos)
+                       ? ResultRetryable
+                       : ResultServiceUnitNotReady;
 
         case ProducerBlockedQuotaExceededError:
             return ResultProducerBlockedQuotaExceededError;

--- a/tests/extensibleLM/ExtensibleLoadManagerTest.cc
+++ b/tests/extensibleLM/ExtensibleLoadManagerTest.cc
@@ -169,9 +169,8 @@ TEST(ExtensibleLoadManagerTest, testPubSubWhileUnloading) {
             }));
             LOG_INFO("after lookup responseData:" << responseDataAfterUnload << ",res:" << res);
 
-            // TODO: check lookup counter after pip-307 is released
             auto lookupCountAfterUnload = clientImplPtr->getLookupCount();
-            ASSERT_TRUE(lookupCountBeforeUnload < lookupCountAfterUnload);
+            ASSERT_EQ(lookupCountBeforeUnload, lookupCountAfterUnload);
             break;
         }
     };


### PR DESCRIPTION
The `apachepulsar/pulsar:latest` image was upgraded to 3.2.0 recently, which results the following failed tests:
- ExtensibleLoadManagerTest: there are no more lookup requests after namespace unload
- ClientTest.testWrongListener: the lookup error message from broker does not contain the exception type