### PR TITLE
Disable batch send for dlq producer.

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -1736,6 +1736,7 @@ void ConsumerImpl::processPossibleToDLQ(const MessageId& messageId, ProcessDLQCa
             ProducerConfiguration producerConfiguration;
             producerConfiguration.setSchema(config_.getSchema());
             producerConfiguration.setBlockIfQueueFull(false);
+            producerConfiguration.setBatchingEnabled(false);
             producerConfiguration.impl_->initialSubscriptionName =
                 deadLetterPolicy_.getInitialSubscriptionName();
             ClientImplPtr client = client_.lock();

--- a/tests/DeadLetterQueueTest.cc
+++ b/tests/DeadLetterQueueTest.cc
@@ -270,6 +270,8 @@ TEST_P(DeadLetterQueueTest, testSendDLQTriggerByRedeliverUnacknowledgedMessages)
         ASSERT_EQ(msg.getPartitionKey(), "p-key");
         ASSERT_EQ(msg.getOrderingKey(), "o-key");
         ASSERT_EQ(msg.getProperty("pk-1"), "pv-1");
+        ASSERT_EQ(msg.getMessageId().batchSize(), 0);
+        ASSERT_EQ(msg.getMessageId().batchIndex(), -1);
         ASSERT_TRUE(msg.getProperty(SYSTEM_PROPERTY_REAL_TOPIC).find(topic_));
         ASSERT_FALSE(msg.getProperty(PROPERTY_ORIGIN_MESSAGE_ID).empty());
     }


### PR DESCRIPTION
### Motivation
https://github.com/apache/pulsar-client-node/issues/366

### Modifications
- Disable batch send for dlq producer.

### Verifying this change
- Add logic to verify that messages are not batched in DeadLetterQueueTest

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
