### PR TITLE
Fix the incompatibility with Clang and C++20

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -289,7 +289,6 @@ jobs:
     timeout-minutes: 120
     name: Build CPP Client on macOS
     runs-on: macos-12
-    needs: unit-tests
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -305,6 +304,12 @@ jobs:
         shell: bash
         run: |
           cmake --build ./build-macos --parallel --config Release
+
+      - name: Build with C++20
+        shell: bash
+        run: |
+          cmake -B build-macos-cpp20 -DCMAKE_CXX_STANDARD=20
+          cmake --build build-macos-cpp20 -j8
 
   cpp-build-macos-static:
     timeout-minutes: 120

--- a/lib/NamespaceName.cc
+++ b/lib/NamespaceName.cc
@@ -93,7 +93,7 @@ std::shared_ptr<NamespaceName> NamespaceName::getNamespaceObject() {
     return std::shared_ptr<NamespaceName>(this);
 }
 
-bool NamespaceName::operator==(const NamespaceName& namespaceName) {
+bool NamespaceName::operator==(const NamespaceName& namespaceName) const {
     return this->namespace_.compare(namespaceName.namespace_) == 0;
 }
 

--- a/lib/NamespaceName.h
+++ b/lib/NamespaceName.h
@@ -37,7 +37,7 @@ class PULSAR_PUBLIC NamespaceName : public ServiceUnitId {
     static std::shared_ptr<NamespaceName> get(const std::string& property, const std::string& cluster,
                                               const std::string& namespaceName);
     static std::shared_ptr<NamespaceName> get(const std::string& property, const std::string& namespaceName);
-    bool operator==(const NamespaceName& namespaceName);
+    bool operator==(const NamespaceName& namespaceName) const;
     bool isV2();
     std::string toString();
 

--- a/lib/TopicName.cc
+++ b/lib/TopicName.cc
@@ -164,7 +164,7 @@ std::string TopicName::getLocalName() { return localName_; }
 
 std::string TopicName::getEncodedLocalName() const { return getEncodedName(localName_); }
 
-bool TopicName::operator==(const TopicName& other) {
+bool TopicName::operator==(const TopicName& other) const {
     return (this->topicName_.compare(other.topicName_) == 0);
 }
 

--- a/lib/TopicName.h
+++ b/lib/TopicName.h
@@ -65,7 +65,7 @@ class PULSAR_PUBLIC TopicName : public ServiceUnitId {
     NamespaceNamePtr getNamespaceName();
     int getPartitionIndex() const noexcept { return partition_; }
     static std::shared_ptr<TopicName> get(const std::string& topicName);
-    bool operator==(const TopicName& other);
+    bool operator==(const TopicName& other) const;
     static std::string getEncodedName(const std::string& nameBeforeEncoding);
     static std::string removeDomain(const std::string& topicName);
     static bool containsDomain(const std::string& topicName);


### PR DESCRIPTION
### Motivation

When I built with Clang and C++20, there were the following errors:

> ISO C++20 considers use of overloaded operator '==' (with operand types 'pulsar::NamespaceName' and 'pulsar::NamespaceName') to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]

See the detailed answer here: https://stackoverflow.com/questions/60386792/c20-comparison-warning-about-ambiguous-reversed-operator

### Modifications

Make the member functions of `operator=` const in `TopicName` and `NamespaceName` and add a workflow to cover this case.