### PR TITLE
Fix hasMessageAvailable might return true after seeking to latest

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -1685,10 +1685,10 @@ void ConsumerImpl::seekAsyncInternal(long requestId, SharedBuffer seek, const Me
                 LOG_INFO(getName() << "Seek successfully");
                 ackGroupingTrackerPtr_->flushAndClean();
                 incomingMessages_.clear();
-                Lock lock{mutexForMessageId_};
+                Lock lock(mutexForMessageId_);
                 lastDequedMessageId_ = MessageId::earliest();
                 lock.unlock();
-                if (getCnx().expired()) {
+                if (!hasParent_ && getCnx().expired()) {
                     // It's during reconnection, complete the seek future after connection is established
                     seekStatus_ = SeekStatus::COMPLETED;
                 } else {

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -1688,7 +1688,7 @@ void ConsumerImpl::seekAsyncInternal(long requestId, SharedBuffer seek, const Me
                 Lock lock(mutexForMessageId_);
                 lastDequedMessageId_ = MessageId::earliest();
                 lock.unlock();
-                if (!hasParent_ && getCnx().expired()) {
+                if (getCnx().expired()) {
                     // It's during reconnection, complete the seek future after connection is established
                     seekStatus_ = SeekStatus::COMPLETED;
                 } else {

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -236,16 +236,15 @@ Future<Result, bool> ConsumerImpl::connectionOpened(const ClientConnectionPtr& c
     // sending the subscribe request.
     cnx->registerConsumer(consumerId_, get_shared_this_ptr());
 
-    if (duringSeek_) {
+    if (duringSeek()) {
         ackGroupingTrackerPtr_->flushAndClean();
     }
 
     Lock lockForMessageId(mutexForMessageId_);
     // Update startMessageId so that we can discard messages after delivery restarts
-    const auto startMessageId = clearReceiveQueue();
+    clearReceiveQueue();
     const auto subscribeMessageId =
-        (subscriptionMode_ == Commands::SubscriptionModeNonDurable) ? startMessageId : boost::none;
-    startMessageId_ = startMessageId;
+        (subscriptionMode_ == Commands::SubscriptionModeNonDurable) ? startMessageId_.get() : boost::none;
     lockForMessageId.unlock();
 
     unAckedMessageTrackerPtr_->clear();
@@ -1049,13 +1048,19 @@ void ConsumerImpl::messageProcessed(Message& msg, bool track) {
  * was
  * not seen by the application
  */
-boost::optional<MessageId> ConsumerImpl::clearReceiveQueue() {
-    bool expectedDuringSeek = true;
-    if (duringSeek_.compare_exchange_strong(expectedDuringSeek, false)) {
-        return seekMessageId_.get();
+void ConsumerImpl::clearReceiveQueue() {
+    if (duringSeek()) {
+        startMessageId_ = seekMessageId_.get();
+        SeekStatus expected = SeekStatus::COMPLETED;
+        if (seekStatus_.compare_exchange_strong(expected, SeekStatus::NOT_STARTED)) {
+            auto seekCallback = seekCallback_.release();
+            executor_->postWork([seekCallback] { seekCallback(ResultOk); });
+        }
+        return;
     } else if (subscriptionMode_ == Commands::SubscriptionModeDurable) {
-        return startMessageId_.get();
+        return;
     }
+
     Message nextMessageInQueue;
     if (incomingMessages_.peekAndClear(nextMessageInQueue)) {
         // There was at least one message pending in the queue
@@ -1071,16 +1076,12 @@ boost::optional<MessageId> ConsumerImpl::clearReceiveQueue() {
                                            .ledgerId(nextMessageId.ledgerId())
                                            .entryId(nextMessageId.entryId() - 1)
                                            .build();
-        return previousMessageId;
+        startMessageId_ = previousMessageId;
     } else if (lastDequedMessageId_ != MessageId::earliest()) {
         // If the queue was empty we need to restart from the message just after the last one that has been
         // dequeued
         // in the past
-        return lastDequedMessageId_;
-    } else {
-        // No message was received or dequeued by this consumer. Next message would still be the
-        // startMessageId
-        return startMessageId_.get();
+        startMessageId_ = lastDequedMessageId_;
     }
 }
 
@@ -1500,17 +1501,10 @@ void ConsumerImpl::seekAsync(uint64_t timestamp, ResultCallback callback) {
 
 bool ConsumerImpl::isReadCompacted() { return readCompacted_; }
 
-inline bool hasMoreMessages(const MessageId& lastMessageIdInBroker, const MessageId& messageId) {
-    return lastMessageIdInBroker > messageId && lastMessageIdInBroker.entryId() != -1;
-}
-
 void ConsumerImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback) {
-    const auto startMessageId = startMessageId_.get();
     Lock lock(mutexForMessageId_);
-    const auto messageId =
-        (lastDequedMessageId_ == MessageId::earliest()) ? startMessageId.value() : lastDequedMessageId_;
-
-    if (messageId == MessageId::latest()) {
+    if (lastDequedMessageId_ == MessageId::earliest() &&
+        startMessageId_.get().value_or(MessageId::earliest()) == MessageId::latest()) {
         lock.unlock();
         auto self = get_shared_this_ptr();
         getLastMessageIdAsync([self, callback](Result result, const GetLastMessageIdResponse& response) {
@@ -1543,16 +1537,19 @@ void ConsumerImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback
             }
         });
     } else {
-        if (hasMoreMessages(lastMessageIdInBroker_, messageId)) {
+        if (hasMoreMessages()) {
             lock.unlock();
             callback(ResultOk, true);
             return;
         }
         lock.unlock();
 
-        getLastMessageIdAsync([callback, messageId](Result result, const GetLastMessageIdResponse& response) {
-            callback(result, (result == ResultOk) && hasMoreMessages(response.getLastMessageId(), messageId));
-        });
+        auto self = get_shared_this_ptr();
+        getLastMessageIdAsync(
+            [this, self, callback](Result result, const GetLastMessageIdResponse& response) {
+                std::lock_guard<std::mutex> lock{mutexForMessageId_};
+                callback(result, (result == ResultOk) && hasMoreMessages());
+            });
     }
 }
 
@@ -1656,9 +1653,18 @@ void ConsumerImpl::seekAsyncInternal(long requestId, SharedBuffer seek, const Me
         return;
     }
 
+    auto expected = SeekStatus::NOT_STARTED;
+    if (!seekStatus_.compare_exchange_strong(expected, SeekStatus::IN_PROGRESS)) {
+        LOG_ERROR(getName() << " attempted to seek (" << seekId << ", " << timestamp << " when the status is "
+                            << static_cast<int>(expected));
+        callback(ResultNotAllowedError);
+        return;
+    }
+
     const auto originalSeekMessageId = seekMessageId_.get();
     seekMessageId_ = seekId;
-    duringSeek_ = true;
+    seekStatus_ = SeekStatus::IN_PROGRESS;
+    seekCallback_ = std::move(callback);
     if (timestamp > 0) {
         LOG_INFO(getName() << " Seeking subscription to " << timestamp);
     } else {
@@ -1679,15 +1685,22 @@ void ConsumerImpl::seekAsyncInternal(long requestId, SharedBuffer seek, const Me
                 LOG_INFO(getName() << "Seek successfully");
                 ackGroupingTrackerPtr_->flushAndClean();
                 incomingMessages_.clear();
-                Lock lock(mutexForMessageId_);
+                Lock lock{mutexForMessageId_};
                 lastDequedMessageId_ = MessageId::earliest();
                 lock.unlock();
+                if (getCnx().expired()) {
+                    // It's during reconnection, complete the seek future after connection is established
+                    seekStatus_ = SeekStatus::COMPLETED;
+                } else {
+                    startMessageId_ = seekMessageId_.get();
+                    seekCallback_.release()(result);
+                }
             } else {
                 LOG_ERROR(getName() << "Failed to seek: " << result);
                 seekMessageId_ = originalSeekMessageId;
-                duringSeek_ = false;
+                seekStatus_ = SeekStatus::NOT_STARTED;
+                seekCallback_.release()(result);
             }
-            callback(result);
         });
 }
 

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -241,7 +241,6 @@ Future<Result, bool> ConsumerImpl::connectionOpened(const ClientConnectionPtr& c
     }
 
     Lock lockForMessageId(mutexForMessageId_);
-    // Update startMessageId so that we can discard messages after delivery restarts
     clearReceiveQueue();
     const auto subscribeMessageId =
         (subscriptionMode_ == Commands::SubscriptionModeNonDurable) ? startMessageId_.get() : boost::none;
@@ -1047,6 +1046,7 @@ void ConsumerImpl::messageProcessed(Message& msg, bool track) {
  * Clear the internal receiver queue and returns the message id of what was the 1st message in the queue that
  * was
  * not seen by the application
+ * `startMessageId_` is updated so that we can discard messages after delivery restarts.
  */
 void ConsumerImpl::clearReceiveQueue() {
     if (duringSeek()) {

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -75,6 +75,13 @@ const static std::string SYSTEM_PROPERTY_REAL_TOPIC = "REAL_TOPIC";
 const static std::string PROPERTY_ORIGIN_MESSAGE_ID = "ORIGIN_MESSAGE_ID";
 const static std::string DLQ_GROUP_TOPIC_SUFFIX = "-DLQ";
 
+enum class SeekStatus : std::uint8_t
+{
+    NOT_STARTED,
+    IN_PROGRESS,
+    COMPLETED
+};
+
 class ConsumerImpl : public ConsumerImplBase {
    public:
     ConsumerImpl(const ClientImplPtr client, const std::string& topic, const std::string& subscriptionName,
@@ -193,7 +200,7 @@ class ConsumerImpl : public ConsumerImplBase {
                                        const DeadlineTimerPtr& timer,
                                        BrokerGetLastMessageIdCallback callback);
 
-    boost::optional<MessageId> clearReceiveQueue();
+    void clearReceiveQueue();
     void seekAsyncInternal(long requestId, SharedBuffer seek, const MessageId& seekId, long timestamp,
                            ResultCallback callback);
     void processPossibleToDLQ(const MessageId& messageId, ProcessDLQCallBack cb);
@@ -239,9 +246,12 @@ class ConsumerImpl : public ConsumerImplBase {
     MessageId lastDequedMessageId_{MessageId::earliest()};
     MessageId lastMessageIdInBroker_{MessageId::earliest()};
 
-    std::atomic_bool duringSeek_{false};
+    std::atomic<SeekStatus> seekStatus_{SeekStatus::NOT_STARTED};
+    Synchronized<ResultCallback> seekCallback_{[](Result) {}};
     Synchronized<boost::optional<MessageId>> startMessageId_;
     Synchronized<MessageId> seekMessageId_{MessageId::earliest()};
+
+    bool duringSeek() const { return seekStatus_ != SeekStatus::NOT_STARTED; }
 
     class ChunkedMessageCtx {
        public:
@@ -331,6 +341,23 @@ class ConsumerImpl : public ConsumerImplBase {
                                                       const proto::MessageMetadata& metadata,
                                                       const proto::MessageIdData& messageIdData,
                                                       const ClientConnectionPtr& cnx, MessageId& messageId);
+
+    // It must be called when mutexForMessageId_ is held
+    bool hasMoreMessages() {
+        if (lastMessageIdInBroker_.entryId() == -1L) {
+            return false;
+        }
+
+        const auto inclusive = config_.isStartMessageIdInclusive();
+        if (lastDequedMessageId_ == MessageId::earliest()) {
+            // If startMessageId_ is none, use latest so that this method will return false
+            const auto startMessageId = startMessageId_.get().value_or(MessageId::latest());
+            return inclusive ? (lastMessageIdInBroker_ >= startMessageId)
+                             : (lastMessageIdInBroker_ > startMessageId);
+        } else {
+            return lastMessageIdInBroker_ > lastDequedMessageId_;
+        }
+    }
 
     friend class PulsarFriend;
     friend class MultiTopicsConsumerImpl;

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -342,8 +342,8 @@ class ConsumerImpl : public ConsumerImplBase {
                                                       const proto::MessageIdData& messageIdData,
                                                       const ClientConnectionPtr& cnx, MessageId& messageId);
 
-    // It must be called when mutexForMessageId_ is held
     bool hasMoreMessages() const {
+        std::lock_guard<std::mutex> lock{mutexForMessageId_};
         if (lastMessageIdInBroker_.entryId() == -1L) {
             return false;
         }

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -343,7 +343,7 @@ class ConsumerImpl : public ConsumerImplBase {
                                                       const ClientConnectionPtr& cnx, MessageId& messageId);
 
     // It must be called when mutexForMessageId_ is held
-    bool hasMoreMessages() {
+    bool hasMoreMessages() const {
         if (lastMessageIdInBroker_.entryId() == -1L) {
             return false;
         }

--- a/lib/Synchronized.h
+++ b/lib/Synchronized.h
@@ -30,6 +30,11 @@ class Synchronized {
         return value_;
     }
 
+    T&& release() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return std::move(value_);
+    }
+
     Synchronized& operator=(const T& value) {
         std::lock_guard<std::mutex> lock(mutex_);
         value_ = value;

--- a/tests/ReaderTest.cc
+++ b/tests/ReaderTest.cc
@@ -752,6 +752,8 @@ TEST(ReaderSeekTest, testSeekForMessageId) {
     producer.close();
 }
 
+class ReaderSeekTest : public ::testing::TestWithParam<bool> {};
+
 TEST(ReaderSeekTest, testStartAtLatestMessageId) {
     Client client(serviceUrl);
 
@@ -799,7 +801,7 @@ TEST(ReaderTest, testSeekInProgress) {
     client.close();
 }
 
-TEST_P(ReaderTest, testHasMessageAvailableAfterSeekToEnd) {
+TEST_P(ReaderSeekTest, testHasMessageAvailableAfterSeekToEnd) {
     Client client(serviceUrl);
     const auto topic = "test-has-message-available-after-seek-to-end-" + std::to_string(time(nullptr));
     Producer producer;
@@ -813,7 +815,7 @@ TEST_P(ReaderTest, testHasMessageAvailableAfterSeekToEnd) {
     bool hasMessageAvailable;
     if (GetParam()) {
         // Test the case when `ConsumerImpl.lastMessageIdInBroker_` has been initialized
-        reader.hasMessageAvailable(hasMessageAvailable);
+        ASSERT_EQ(ResultOk, reader.hasMessageAvailable(hasMessageAvailable));
     }
 
     ASSERT_EQ(ResultOk, reader.seek(MessageId::latest()));
@@ -837,3 +839,4 @@ TEST_P(ReaderTest, testHasMessageAvailableAfterSeekToEnd) {
 }
 
 INSTANTIATE_TEST_SUITE_P(Pulsar, ReaderTest, ::testing::Values(true, false));
+INSTANTIATE_TEST_SUITE_P(Pulsar, ReaderSeekTest, ::testing::Values(true, false));


### PR DESCRIPTION
### Motivation

See https://github.com/apache/pulsar-client-python/issues/199

There is a race condition when `hasMessageAvailable` is called after `seek` if the start message ID of `Reader` is earliest.

In `ConsumerImpl::hasMessageAvailableAsync`, if the connection is not established at the moment, `lastDequedMessageId_` will be `earliest` because no message is received. Since `lastMessageIdInBroker_` is also `earliest`, `getLastMessageIdAsync` will be called and then it comes at

https://github.com/apache/pulsar-client-cpp/blob/e2cacb7dfb57b6d059b49fead2e1611548ff89b0/lib/ConsumerImpl.cc#L1554

However, before `getLastMessageIdAsync` is called, `messageId` was `earliest` because `lastDequedMessageId_` and `startMessageId_` were both `earliest`. However, when the callback is called, the `startMessageId_` has already been updated to `latest` in `connectionOpened`, so we should compare to `latest`.

### Modifications

In the callback of `getLastMessageIdAsync`, retrieve the latest value of `startMessageId_` to compare rather then reusing the old value.

Refactor the seek flow to reset the seek states and trigger the callback after updating the `startMessageId_`.

`ReaderTest.testHasMessageAvailableAfterSeekToEnd` is added to cover the changes.