### PR TITLE
[fix] add physicalAddress as part of connection pool key

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -101,6 +101,22 @@ jobs:
           cmake . -DINTEGRATE_VCPKG=ON -DBUILD_TESTS=ON -DBUILD_PERF_TOOLS=ON
           cmake --build . -j8
 
+  loadbalancer-integ-tests:
+    name: Run load balancer integ tests
+    needs: unit-tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Run unit tests
+        run: RETRY_FAILED=3 ./run-loadbalancer-integ-tests.sh
+
   cpp20-build:
     name: Build with the C++20 standard
     runs-on: ubuntu-22.04
@@ -337,7 +353,7 @@ jobs:
   check-completion:
     name: Check Completion
     runs-on: ubuntu-latest
-    needs: [wireshark-dissector-build, unit-tests, cpp20-build, cpp-build-windows, package, cpp-build-macos]
+    needs: [wireshark-dissector-build, unit-tests, loadbalancer-integ-tests, cpp20-build, cpp-build-windows, package, cpp-build-macos]
 
     steps:
       - run: true

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -1321,7 +1321,7 @@ void ClientConnection::close(Result result, bool detach) {
     }
     // Remove the connection from the pool before completing any promise
     if (detach) {
-        pool_.remove(logicalAddress_ + "-" + std::to_string(poolIndex_), this);
+        pool_.remove(logicalAddress_, physicalAddress_, poolIndex_, this);
     }
 
     auto self = shared_from_this();

--- a/lib/ConnectionPool.cc
+++ b/lib/ConnectionPool.cc
@@ -66,6 +66,13 @@ bool ConnectionPool::close() {
     return true;
 }
 
+static const std::string getKey(const std::string& logicalAddress, const std::string& physicalAddress,
+                                size_t keySuffix) {
+    std::stringstream ss;
+    ss << logicalAddress << '-' << physicalAddress << '-' << keySuffix;
+    return ss.str();
+}
+
 Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(const std::string& logicalAddress,
                                                                            const std::string& physicalAddress,
                                                                            size_t keySuffix) {
@@ -77,9 +84,7 @@ Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(const
 
     std::unique_lock<std::recursive_mutex> lock(mutex_);
 
-    std::stringstream ss;
-    ss << logicalAddress << '-' << keySuffix;
-    const std::string key = ss.str();
+    auto key = getKey(logicalAddress, physicalAddress, keySuffix);
 
     PoolMap::iterator cnxIt = pool_.find(key);
     if (cnxIt != pool_.end()) {
@@ -127,7 +132,9 @@ Future<Result, ClientConnectionWeakPtr> ConnectionPool::getConnectionAsync(const
     return future;
 }
 
-void ConnectionPool::remove(const std::string& key, ClientConnection* value) {
+void ConnectionPool::remove(const std::string& logicalAddress, const std::string& physicalAddress,
+                            size_t keySuffix, ClientConnection* value) {
+    auto key = getKey(logicalAddress, physicalAddress, keySuffix);
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     auto it = pool_.find(key);
     if (it != pool_.end() && it->second.get() == value) {
@@ -135,5 +142,4 @@ void ConnectionPool::remove(const std::string& key, ClientConnection* value) {
         pool_.erase(it);
     }
 }
-
 }  // namespace pulsar

--- a/lib/ConnectionPool.h
+++ b/lib/ConnectionPool.h
@@ -51,7 +51,8 @@ class PULSAR_PUBLIC ConnectionPool {
      */
     bool close();
 
-    void remove(const std::string& key, ClientConnection* value);
+    void remove(const std::string& logicalAddress, const std::string& physicalAddress, size_t keySuffix,
+                ClientConnection* value);
 
     /**
      * Get a connection from the pool.

--- a/run-loadbalancer-integ-tests.sh
+++ b/run-loadbalancer-integ-tests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+cd $ROOT_DIR
+
+if [[ ! $CMAKE_BUILD_DIRECTORY ]]; then
+    CMAKE_BUILD_DIRECTORY=.
+fi
+
+# Run ExtensibleLoadManager tests
+docker compose -f tests/extensibleLM/docker-compose.yml up -d
+docker compose -f tests/blue-green/docker-compose.yml up -d
+until curl http://localhost:8080/metrics > /dev/null 2>&1 ; do sleep 1; done
+until curl http://localhost:8081/metrics > /dev/null 2>&1 ; do sleep 1; done
+sleep 5
+$CMAKE_BUILD_DIRECTORY/tests/ExtensibleLoadManagerTest
+docker compose -f tests/blue-green/docker-compose.yml down
+docker compose -f tests/extensibleLM/docker-compose.yml down
+exit(1)


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Context: https://github.com/apache/pulsar/pull/22085/files#r1497008116

Currently, the connection pool key does not include physicalAddress (currently logicalAddress + keySuffix). This can be a problem when the same logicalAddresses are in the migrated(green) cluster. (the connection pool will return the connection to the old(blue) cluster)

### Modifications

Add physicalAddress as part of the connection pool key

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
