### PR TITLE
[improve] add physicalAddress as part of connection pool key

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -1321,7 +1321,7 @@ void ClientConnection::close(Result result, bool detach) {
     }
     // Remove the connection from the pool before completing any promise
     if (detach) {
-        pool_.remove(logicalAddress_ + "-" + std::to_string(poolIndex_), this);
+        pool_.remove(logicalAddress_, physicalAddress_, poolIndex_, this);
     }
 
     auto self = shared_from_this();

--- a/lib/ConnectionPool.h
+++ b/lib/ConnectionPool.h
@@ -51,7 +51,8 @@ class PULSAR_PUBLIC ConnectionPool {
      */
     bool close();
 
-    void remove(const std::string& key, ClientConnection* value);
+    void remove(const std::string& logicalAddress, const std::string& physicalAddress, size_t keySuffix,
+                ClientConnection* value);
 
     /**
      * Get a connection from the pool.


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Context: https://github.com/apache/pulsar/pull/22085/files#r1497008116

Currently, the connection pool key does not include physicalAddress (currently logicalAddress + keySuffix). This can be a problem when the same logicalAddresses are in the migrated(green) cluster. (the connection pool will return the connection to the old(blue) cluster)

### Modifications

Add physicalAddress as part of the connection pool key

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
