### PR TITLE
[fix] Change return code of MultiTopicsConsumerImpl::closeAsync after unsubscribe or close

### DIFF
--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -475,7 +475,7 @@ void MultiTopicsConsumerImpl::closeAsync(ResultCallback originalCallback) {
     };
     const auto state = state_.load();
     if (state == Closing || state == Closed) {
-        callback(ResultAlreadyClosed);
+        callback(ResultOk);
         return;
     }
 
@@ -488,7 +488,7 @@ void MultiTopicsConsumerImpl::closeAsync(ResultCallback originalCallback) {
     if (consumers.empty()) {
         LOG_DEBUG("TopicsConsumer have no consumers to close "
                   << " topic" << topic() << " subscription - " << subscriptionName_);
-        callback(ResultAlreadyClosed);
+        callback(ResultOk);
         return;
     }
 

--- a/tests/BasicEndToEndTest.cc
+++ b/tests/BasicEndToEndTest.cc
@@ -1694,7 +1694,7 @@ TEST(BasicEndToEndTest, testSeekOnPartitionedTopic) {
     ASSERT_EQ(expected.str(), msgReceived.getDataAsString());
     ASSERT_EQ(ResultOk, consumer.acknowledge(msgReceived));
     ASSERT_EQ(ResultOk, consumer.unsubscribe());
-    ASSERT_EQ(ResultAlreadyClosed, consumer.close());
+    ASSERT_EQ(ResultOk, consumer.close());
     ASSERT_EQ(ResultOk, producer.close());
     ASSERT_EQ(ResultOk, client.close());
 }


### PR DESCRIPTION
Fixes #88

### Motivation

https://github.com/apache/pulsar-client-cpp/pull/338 fixed `ConsumerImpl::closeAsync` so that closing after it was already closed or unsubscribed returns `ResultOk` instead of `ResultAlreadyClosed`. However, `MultiTopicsConsumerImpl::closeAsync` still returns `ResultAlreadyClosed`. This seems to be a change omission.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed`