### PR TITLE
Fix broken wireshark build workflow on macOS 

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -64,6 +64,11 @@ jobs:
         run: |
           # See https://github.com/Homebrew/homebrew-core/issues/157142
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          cd /usr/local/bin
+          rm -f 2to3* idle3* pydoc* python3*
+          rm -f /usr/local/share/man/man1/python3.1 /usr/local/lib/pkgconfig/python3*
+          cd /usr/local/Frameworks/Python.framework
+          rm -rf Headers Python Resources Versions/Current
           brew update
           brew install pkg-config wireshark protobuf
       - name: Build wireshark plugin


### PR DESCRIPTION
### Motivation

See https://github.com/apache/pulsar-client-cpp/actions/runs/8276076995/job/22644077705

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
```

`brew install` failed because the wireshark dependency depends on
python@3.12 and it failed at `brew link`.

### Modifications

Remove the existing binaries that might conflict.