### PR TITLE
Support seek operation on a multi-topics consumer

### DIFF
--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -897,11 +897,6 @@ void MultiTopicsConsumerImpl::afterSeek() {
     });
 }
 
-void MultiTopicsConsumerImpl::handleNoConsumersWhenSeek(const ResultCallback& callback) const {
-    LOG_ERROR(getName() << "There are no consumers when seek");
-    callback(ResultOperationNotSupported);
-}
-
 void MultiTopicsConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
     if (msgId == MessageId::earliest() || msgId == MessageId::latest()) {
         return seekAllAsync(msgId, callback);

--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -828,6 +828,7 @@ void MultiTopicsConsumerImpl::getBrokerConsumerStatsAsync(BrokerConsumerStatsCal
         std::make_shared<MultiTopicsBrokerConsumerStatsImpl>(numberTopicPartitions_->load());
     LatchPtr latchPtr = std::make_shared<Latch>(numberTopicPartitions_->load());
     lock.unlock();
+
     size_t i = 0;
     consumers_.forEachValue([this, &latchPtr, &statsPtr, &i, callback](const ConsumerImplPtr& consumer) {
         size_t index = i++;

--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -897,6 +897,11 @@ void MultiTopicsConsumerImpl::afterSeek() {
     });
 }
 
+void MultiTopicsConsumerImpl::handleNoConsumersWhenSeek(const ResultCallback& callback) const {
+    LOG_ERROR(getName() << "There are no consumers when seek");
+    callback(ResultOperationNotSupported);
+}
+
 void MultiTopicsConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
     if (msgId == MessageId::earliest() || msgId == MessageId::latest()) {
         return seekAllAsync(msgId, callback);

--- a/lib/MultiTopicsConsumerImpl.h
+++ b/lib/MultiTopicsConsumerImpl.h
@@ -98,7 +98,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
     uint64_t getNumberOfConnectedConsumer() override;
     void hasMessageAvailableAsync(HasMessageAvailableCallback callback) override;
 
-    void handleGetConsumerStats(Result, BrokerConsumerStats, SharedFuture, MultiTopicsBrokerConsumerStatsPtr,
+    void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, MultiTopicsBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);
     // return first topic name when all topics name valid, or return null pointer
     static std::shared_ptr<TopicName> topicNamesValid(const std::vector<std::string>& topics);

--- a/lib/MultiTopicsConsumerImpl.h
+++ b/lib/MultiTopicsConsumerImpl.h
@@ -185,6 +185,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
 
     void beforeSeek();
     void afterSeek();
+    void handleNoConsumersWhenSeek(const ResultCallback& callback) const;
 
     FRIEND_TEST(ConsumerTest, testMultiTopicsConsumerUnAckedMessageRedelivery);
     FRIEND_TEST(ConsumerTest, testPartitionedConsumerUnAckedMessageRedelivery);
@@ -228,7 +229,7 @@ template <typename SeekArg>
                 }
             });
         },
-        [callback] { callback(ResultOk); });
+        [this, callback] { handleNoConsumersWhenSeek(callback); });
 }
 
 }  // namespace pulsar

--- a/lib/MultiTopicsConsumerImpl.h
+++ b/lib/MultiTopicsConsumerImpl.h
@@ -185,7 +185,6 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
 
     void beforeSeek();
     void afterSeek();
-    void handleNoConsumersWhenSeek(const ResultCallback& callback) const;
 
     FRIEND_TEST(ConsumerTest, testMultiTopicsConsumerUnAckedMessageRedelivery);
     FRIEND_TEST(ConsumerTest, testPartitionedConsumerUnAckedMessageRedelivery);
@@ -229,7 +228,7 @@ template <typename SeekArg>
                 }
             });
         },
-        [this, callback] { handleNoConsumersWhenSeek(callback); });
+        [callback] { callback(ResultOk); });
 }
 
 }  // namespace pulsar

--- a/lib/MultiTopicsConsumerImpl.h
+++ b/lib/MultiTopicsConsumerImpl.h
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include "Commands.h"
-#include "ConsumerImplBase.h"
+#include "ConsumerImpl.h"
 #include "ConsumerInterceptors.h"
 #include "Future.h"
 #include "Latch.h"
@@ -38,7 +38,6 @@
 namespace pulsar {
 typedef std::shared_ptr<Promise<Result, Consumer>> ConsumerSubResultPromisePtr;
 
-class ConsumerImpl;
 using ConsumerImplPtr = std::shared_ptr<ConsumerImpl>;
 class ClientImpl;
 using ClientImplPtr = std::shared_ptr<ClientImpl>;
@@ -99,7 +98,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
     uint64_t getNumberOfConnectedConsumer() override;
     void hasMessageAvailableAsync(HasMessageAvailableCallback callback) override;
 
-    void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, MultiTopicsBrokerConsumerStatsPtr,
+    void handleGetConsumerStats(Result, BrokerConsumerStats, SharedFuture, MultiTopicsBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);
     // return first topic name when all topics name valid, or return null pointer
     static std::shared_ptr<TopicName> topicNamesValid(const std::vector<std::string>& topics);
@@ -152,8 +151,6 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
     void handleSingleConsumerCreated(Result result, ConsumerImplBaseWeakPtr consumerImplBaseWeakPtr,
                                      std::shared_ptr<std::atomic<int>> partitionsNeedCreate,
                                      ConsumerSubResultPromisePtr topicSubResultPromise);
-    void handleUnsubscribedAsync(Result result, std::shared_ptr<std::atomic<int>> consumerUnsubed,
-                                 ResultCallback callback);
     void handleOneTopicUnsubscribedAsync(Result result, std::shared_ptr<std::atomic<int>> consumerUnsubed,
                                          int numberPartitions, TopicNamePtr topicNamePtr,
                                          std::string& topicPartitionName, ResultCallback callback);
@@ -179,6 +176,16 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
         return std::static_pointer_cast<MultiTopicsConsumerImpl>(shared_from_this());
     }
 
+    template <typename SeekArg>
+#if __cplusplus >= 202002L
+        requires std::convertible_to<SeekArg, uint64_t> ||
+        std::same_as<std::remove_cv_t<std::remove_reference_t<SeekArg>>, MessageId>
+#endif
+        void seekAllAsync(const SeekArg& seekArg, ResultCallback callback);
+
+    void beforeSeek();
+    void afterSeek();
+
     FRIEND_TEST(ConsumerTest, testMultiTopicsConsumerUnAckedMessageRedelivery);
     FRIEND_TEST(ConsumerTest, testPartitionedConsumerUnAckedMessageRedelivery);
     FRIEND_TEST(ConsumerTest, testAcknowledgeCumulativeWithPartition);
@@ -187,5 +194,42 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase {
 };
 
 typedef std::shared_ptr<MultiTopicsConsumerImpl> MultiTopicsConsumerImplPtr;
+
+template <typename SeekArg>
+#if __cplusplus >= 202002L
+    requires std::convertible_to<SeekArg, uint64_t> ||
+    std::same_as<std::remove_cv_t<std::remove_reference_t<SeekArg>>, MessageId>
+#endif
+    inline void MultiTopicsConsumerImpl::seekAllAsync(const SeekArg& seekArg, ResultCallback callback) {
+    if (state_ != Ready) {
+        callback(ResultAlreadyClosed);
+        return;
+    }
+    beforeSeek();
+    auto weakSelf = weak_from_this();
+    auto failed = std::make_shared<std::atomic_bool>(false);
+    consumers_.forEachValue(
+        [this, weakSelf, &seekArg, callback, failed](const ConsumerImplPtr& consumer, SharedFuture future) {
+            consumer->seekAsync(seekArg, [this, weakSelf, callback, failed, future](Result result) {
+                auto self = weakSelf.lock();
+                if (!self || failed->load(std::memory_order_acquire)) {
+                    callback(result);
+                    return;
+                }
+                if (result != ResultOk) {
+                    failed->store(true, std::memory_order_release);  // skip the following callbacks
+                    afterSeek();
+                    callback(result);
+                    return;
+                }
+                if (future.tryComplete()) {
+                    afterSeek();
+                    callback(ResultOk);
+                }
+            });
+        },
+        [callback] { callback(ResultOk); });
+}
+
 }  // namespace pulsar
 #endif  // PULSAR_MULTI_TOPICS_CONSUMER_HEADER

--- a/tests/ConsumerSeekTest.cc
+++ b/tests/ConsumerSeekTest.cc
@@ -197,7 +197,7 @@ TEST_P(ConsumerSeekTest, testMultiTopicsSeekSingle) {
 TEST_F(ConsumerSeekTest, testNoInternalConsumer) {
     Consumer consumer;
     ASSERT_EQ(ResultOk, client_.subscribeWithRegex("testNoInternalConsumer.*", "sub", consumer));
-    ASSERT_EQ(ResultOperationNotSupported, consumer.seek(MessageId::earliest()));
+    ASSERT_EQ(ResultOk, consumer.seek(MessageId::earliest()));
 }
 
 INSTANTIATE_TEST_SUITE_P(Pulsar, ConsumerSeekTest, ::testing::Values(true, false));

--- a/tests/ConsumerSeekTest.cc
+++ b/tests/ConsumerSeekTest.cc
@@ -194,6 +194,12 @@ TEST_P(ConsumerSeekTest, testMultiTopicsSeekSingle) {
     }
 }
 
+TEST_F(ConsumerSeekTest, testNoInternalConsumer) {
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client_.subscribeWithRegex("testNoInternalConsumer.*", "sub", consumer));
+    ASSERT_EQ(ResultOperationNotSupported, consumer.seek(MessageId::earliest()));
+}
+
 INSTANTIATE_TEST_SUITE_P(Pulsar, ConsumerSeekTest, ::testing::Values(true, false));
 
 }  // namespace pulsar

--- a/tests/ConsumerSeekTest.cc
+++ b/tests/ConsumerSeekTest.cc
@@ -1,0 +1,199 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <pulsar/Client.h>
+
+#include <set>
+#include <stdexcept>
+#include <string>
+
+#include "HttpHelper.h"
+#include "lib/LogUtils.h"
+
+DECLARE_LOG_OBJECT()
+
+static const std::string lookupUrl = "pulsar://localhost:6650";
+static const std::string adminUrl = "http://localhost:8080/";
+
+extern std::string unique_str();
+
+namespace pulsar {
+
+class ConsumerSeekTest : public ::testing::TestWithParam<bool> {
+   public:
+    void SetUp() override { client_ = Client{lookupUrl}; }
+
+    void TearDown() override { client_.close(); }
+
+   protected:
+    Client client_{lookupUrl};
+    ProducerConfiguration producerConf_;
+
+    std::vector<Producer> initProducersForPartitionedTopic(const std::string& topic) {
+        constexpr int numPartitions = 3;
+        int res = makePutRequest(adminUrl + "admin/v2/persistent/public/default/" + topic + "/partitions",
+                                 std::to_string(numPartitions));
+        if (res != 204 && res != 409) {
+            throw std::runtime_error("Failed to create partitioned topic: " + std::to_string(res));
+        }
+
+        std::vector<Producer> producers(numPartitions);
+        for (int i = 0; i < numPartitions; i++) {
+            auto result = client_.createProducer(topic + "-partition-" + std::to_string(i), producers[i]);
+            if (result != ResultOk) {
+                throw std::runtime_error(std::string{"Failed to create producer: "} + strResult(result));
+            }
+        }
+        return producers;
+    }
+
+    Consumer createConsumer(const std::string& topic) {
+        Consumer consumer;
+        ConsumerConfiguration conf;
+        conf.setStartMessageIdInclusive(GetParam());
+        auto result = client_.subscribe(topic, "sub", conf, consumer);
+        if (result != ResultOk) {
+            throw std::runtime_error(std::string{"Failed to subscribe: "} + strResult(result));
+        }
+        return consumer;
+    }
+};
+
+TEST_P(ConsumerSeekTest, testSeekForMessageId) {
+    Client client(lookupUrl);
+
+    const std::string topic = "test-seek-for-message-id-" + std::string((GetParam() ? "batch-" : "")) +
+                              std::to_string(time(nullptr));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic, producerConf_, producer));
+
+    Consumer consumerExclusive;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, "sub-0", consumerExclusive));
+
+    Consumer consumerInclusive;
+    ASSERT_EQ(ResultOk,
+              client.subscribe(topic, "sub-1", ConsumerConfiguration().setStartMessageIdInclusive(true),
+                               consumerInclusive));
+
+    const auto numMessages = 100;
+    MessageId seekMessageId;
+
+    int r = (rand() % (numMessages - 1));
+    for (int i = 0; i < numMessages; i++) {
+        MessageId id;
+        ASSERT_EQ(ResultOk,
+                  producer.send(MessageBuilder().setContent("msg-" + std::to_string(i)).build(), id));
+
+        if (i == r) {
+            seekMessageId = id;
+        }
+    }
+
+    LOG_INFO("The seekMessageId is: " << seekMessageId << ", r : " << r);
+
+    consumerExclusive.seek(seekMessageId);
+    Message msg0;
+    ASSERT_EQ(ResultOk, consumerExclusive.receive(msg0, 3000));
+
+    consumerInclusive.seek(seekMessageId);
+    Message msg1;
+    ASSERT_EQ(ResultOk, consumerInclusive.receive(msg1, 3000));
+
+    LOG_INFO("consumerExclusive received " << msg0.getDataAsString() << " from " << msg0.getMessageId());
+    LOG_INFO("consumerInclusive received " << msg1.getDataAsString() << " from " << msg1.getMessageId());
+
+    ASSERT_EQ(msg0.getDataAsString(), "msg-" + std::to_string(r + 1));
+    ASSERT_EQ(msg1.getDataAsString(), "msg-" + std::to_string(r));
+
+    consumerInclusive.close();
+    consumerExclusive.close();
+    producer.close();
+}
+
+TEST_P(ConsumerSeekTest, testMultiTopicsSeekAll) {
+    std::string topic = "consumer-seek-test-multi-topics-seek-all-" + unique_str();
+    auto producers = initProducersForPartitionedTopic(topic);
+    auto consumer = createConsumer(topic);
+    const auto numPartitions = producers.size();
+
+    auto receive = [&consumer, numPartitions] {
+        std::set<std::string> values;
+        for (int i = 0; i < numPartitions; i++) {
+            Message msg;
+            auto result = consumer.receive(msg, 3000);
+            if (result != ResultOk) {
+                throw std::runtime_error(std::string{"Receive failed: "} + strResult(result));
+            }
+            values.emplace(msg.getDataAsString());
+        }
+        return values;
+    };
+
+    for (int i = 0; i < numPartitions; i++) {
+        producers[i].send(MessageBuilder().setContent("msg-" + std::to_string(i) + "-0").build());
+    }
+    ASSERT_EQ(receive(), (std::set<std::string>{"msg-0-0", "msg-1-0", "msg-2-0"}));
+
+    // Seek to earliest
+    ASSERT_EQ(ResultOk, consumer.seek(MessageId::earliest()));
+    ASSERT_EQ(receive(), (std::set<std::string>{"msg-0-0", "msg-1-0", "msg-2-0"}));
+
+    // Seek to latest
+    for (int i = 0; i < numPartitions; i++) {
+        producers[i].send(MessageBuilder().setContent("msg-" + std::to_string(i) + "-1").build());
+    }
+    ASSERT_EQ(ResultOk, consumer.seek(MessageId::latest()));
+
+    for (int i = 0; i < numPartitions; i++) {
+        producers[i].send(MessageBuilder().setContent("msg-" + std::to_string(i) + "-2").build());
+    }
+    ASSERT_EQ(receive(), (std::set<std::string>{"msg-0-2", "msg-1-2", "msg-2-2"}));
+}
+
+TEST_P(ConsumerSeekTest, testMultiTopicsSeekSingle) {
+    std::string topic = "consumer-seek-test-multi-topics-seek-single-" + unique_str();
+    auto producers = initProducersForPartitionedTopic(topic);
+    auto consumer = createConsumer(topic);
+
+    MessageId msgId;
+    producers[0].send(MessageBuilder().setContent("msg-0").build(), msgId);
+    ASSERT_EQ(ResultOperationNotSupported, consumer.seek(msgId));
+    producers[0].send(MessageBuilder().setContent("msg-1").build(), msgId);
+    ASSERT_EQ(ResultOperationNotSupported, consumer.seek(msgId));
+
+    std::vector<MessageId> msgIds;
+    Message msg;
+    for (int i = 0; i < 2; i++) {
+        ASSERT_EQ(ResultOk, consumer.receive(msg, 3000));
+        msgIds.emplace_back(msg.getMessageId());
+    }
+
+    ASSERT_EQ(ResultOk, consumer.seek(msgIds[0]));
+    ASSERT_EQ(ResultOk, consumer.receive(msg, 3000));
+    if (GetParam()) {
+        ASSERT_EQ(msg.getMessageId(), msgIds[0]);
+    } else {
+        ASSERT_EQ(msg.getMessageId(), msgIds[1]);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(Pulsar, ConsumerSeekTest, ::testing::Values(true, false));
+
+}  // namespace pulsar

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -1136,69 +1136,6 @@ TEST(ConsumerTest, testPatternSubscribeTopic) {
     client.close();
 }
 
-class ConsumerSeekTest : public ::testing::TestWithParam<bool> {
-   public:
-    void SetUp() override { producerConf_ = ProducerConfiguration().setBatchingEnabled(GetParam()); }
-
-    void TearDown() override { client_.close(); }
-
-   protected:
-    Client client_{lookupUrl};
-    ProducerConfiguration producerConf_;
-};
-
-TEST_P(ConsumerSeekTest, testSeekForMessageId) {
-    Client client(lookupUrl);
-
-    const std::string topic = "test-seek-for-message-id-" + std::string((GetParam() ? "batch-" : "")) +
-                              std::to_string(time(nullptr));
-
-    Producer producer;
-    ASSERT_EQ(ResultOk, client.createProducer(topic, producerConf_, producer));
-
-    Consumer consumerExclusive;
-    ASSERT_EQ(ResultOk, client.subscribe(topic, "sub-0", consumerExclusive));
-
-    Consumer consumerInclusive;
-    ASSERT_EQ(ResultOk,
-              client.subscribe(topic, "sub-1", ConsumerConfiguration().setStartMessageIdInclusive(true),
-                               consumerInclusive));
-
-    const auto numMessages = 100;
-    MessageId seekMessageId;
-
-    int r = (rand() % (numMessages - 1));
-    for (int i = 0; i < numMessages; i++) {
-        MessageId id;
-        ASSERT_EQ(ResultOk,
-                  producer.send(MessageBuilder().setContent("msg-" + std::to_string(i)).build(), id));
-
-        if (i == r) {
-            seekMessageId = id;
-        }
-    }
-
-    LOG_INFO("The seekMessageId is: " << seekMessageId << ", r : " << r);
-
-    consumerExclusive.seek(seekMessageId);
-    Message msg0;
-    ASSERT_EQ(ResultOk, consumerExclusive.receive(msg0, 3000));
-
-    consumerInclusive.seek(seekMessageId);
-    Message msg1;
-    ASSERT_EQ(ResultOk, consumerInclusive.receive(msg1, 3000));
-
-    LOG_INFO("consumerExclusive received " << msg0.getDataAsString() << " from " << msg0.getMessageId());
-    LOG_INFO("consumerInclusive received " << msg1.getDataAsString() << " from " << msg1.getMessageId());
-
-    ASSERT_EQ(msg0.getDataAsString(), "msg-" + std::to_string(r + 1));
-    ASSERT_EQ(msg1.getDataAsString(), "msg-" + std::to_string(r));
-
-    consumerInclusive.close();
-    consumerExclusive.close();
-    producer.close();
-}
-
 TEST(ConsumerTest, testNegativeAcksTrackerClose) {
     Client client(lookupUrl);
     auto topicName = "testNegativeAcksTrackerClose";
@@ -1251,8 +1188,6 @@ TEST(ConsumerTest, testAckNotPersistentTopic) {
 
     client.close();
 }
-
-INSTANTIATE_TEST_CASE_P(Pulsar, ConsumerSeekTest, ::testing::Values(true, false));
 
 class InterceptorForNegAckDeadlock : public ConsumerInterceptor {
    public:

--- a/tests/SynchronizedHashMapTest.cc
+++ b/tests/SynchronizedHashMapTest.cc
@@ -91,6 +91,28 @@ TEST(SynchronizedHashMapTest, testForEach) {
     m.forEach([&pairs](const int& key, const int& value) { pairs.emplace_back(key, value); });
     PairVector expectedPairs({{1, 100}, {2, 200}, {3, 300}});
     ASSERT_EQ(sort(pairs), expectedPairs);
+
+    m.clear();
+    int result = 0;
+    values.clear();
+    m.forEachValue([&values](int value, SharedFuture) { values.emplace_back(value); },
+                   [&result] { result = 1; });
+    ASSERT_TRUE(values.empty());
+    ASSERT_EQ(result, 1);
+
+    m.emplace(1, 100);
+    m.forEachValue([&values](int value, SharedFuture) { values.emplace_back(value); },
+                   [&result] { result = 2; });
+    ASSERT_EQ(values, (std::vector<int>({100})));
+    ASSERT_EQ(result, 1);
+
+    values.clear();
+    m.emplace(2, 200);
+    m.forEachValue([&values](int value, SharedFuture) { values.emplace_back(value); },
+                   [&result] { result = 2; });
+    std::sort(values.begin(), values.end());
+    ASSERT_EQ(values, (std::vector<int>({100, 200})));
+    ASSERT_EQ(result, 1);
 }
 
 TEST(SynchronizedHashMap, testRecursiveMutex) {


### PR DESCRIPTION
### Motivation

See https://github.com/apache/pulsar-client-python/issues/213

### Modifications

Add a new `forEachValue` overload that allows users to count the number of rest running tasks through `SharedFuture` to `SynchronizedHashMap`. Leverage this overload in seek operations when the argument is a timestamp, or a MessageId that represents earliest or latest. When the argument is a MessageId whose `getTopicName()` method returns a correct topic name, seek on the internal consumer of that topic.

Add `testMultiTopicsSeekAll` and `testMultiTopicsSeekSingle` to `ConsumerSeekTest` to cover these cases.