### PR TITLE
Upgrade vcpkg dependencies for the missed boost-format dependency

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -18,11 +18,11 @@
 #
 
 # Note: GCC 4.8 is incompatible with Boost >= 1.84 for the missed std::align
-boost: 1.83.0
+boost: 1.85.0
 cmake: 3.28.3
 protobuf: 3.20.0
 zlib: 1.3.1
-zstd: 1.5.5
+zstd: 1.5.6
 snappy: 1.1.10
 openssl: 1.1.1w
-curl: 8.6.0
+curl: 8.8.0

--- a/lib/HTTPLookupService.cc
+++ b/lib/HTTPLookupService.cc
@@ -415,9 +415,6 @@ void HTTPLookupService::handleGetSchemaHTTPRequest(GetSchemaPromise promise, con
             ptree::write_json(valueStream, kvRoot.get_child("value"), false);
             auto keyData = keyStream.str();
             auto valueData = valueStream.str();
-            // Remove the last line break.
-            keyData.pop_back();
-            valueData.pop_back();
             schemaData = mergeKeyValueSchema(keyData, valueData);
         }
 

--- a/lib/Schema.cc
+++ b/lib/Schema.cc
@@ -172,9 +172,7 @@ SchemaInfo::SchemaInfo(const SchemaInfo &keySchema, const SchemaInfo &valueSchem
         }
         std::ostringstream buf;
         write_json(buf, pt, false);
-        auto s = buf.str();
-        s.pop_back();
-        return s;
+        return buf.str();
     };
 
     StringMap properties;

--- a/pkg/apk/Dockerfile
+++ b/pkg/apk/Dockerfile
@@ -43,12 +43,12 @@ ADD .build/dep-version.py /usr/local/bin
 
 # Download and compile boost
 RUN BOOST_VERSION=$(dep-version.py boost) && \
-    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz && \
-    tar zxf boost-${BOOST_VERSION}.tar.gz && \
+    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-b2-nodocs.tar.gz && \
+    tar zxf boost-${BOOST_VERSION}-b2-nodocs.tar.gz && \
     cd boost-${BOOST_VERSION} && \
     ./bootstrap.sh --with-libraries=regex && \
     ./b2 -d0 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
-    rm -rf /boost-${BOOST_VERSION}.tar.gz /boost-${BOOST_VERSION}
+    rm -rf /boost-${BOOST_VERSION}-b2-nodocs.tar.gz /boost-${BOOST_VERSION}
 
 # Download and compile protobuf
 RUN PROTOBUF_VERSION=$(dep-version.py protobuf) && \

--- a/pkg/deb/Dockerfile
+++ b/pkg/deb/Dockerfile
@@ -41,12 +41,12 @@ ADD .build/dep-version.py /usr/local/bin
 
 # Download and compile boost
 RUN BOOST_VERSION=$(dep-version.py boost) && \
-    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz && \
-    tar zxf boost-${BOOST_VERSION}.tar.gz && \
+    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-b2-nodocs.tar.gz && \
+    tar zxf boost-${BOOST_VERSION}-b2-nodocs.tar.gz && \
     cd boost-${BOOST_VERSION} && \
     ./bootstrap.sh --with-libraries=regex && \
     ./b2 -d0 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
-    rm -rf /boost-${BOOST_VERSION}.tar.gz /boost-${BOOST_VERSION}
+    rm -rf /boost-${BOOST_VERSION}-b2-nodocs.tar.gz /boost-${BOOST_VERSION}
 
 RUN CMAKE_VERSION=$(dep-version.py cmake) && \
     curl -O -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${PLATFORM}.tar.gz && \

--- a/pkg/mac/build-static-library.sh
+++ b/pkg/mac/build-static-library.sh
@@ -47,8 +47,8 @@ CURL_VERSION=$(./dep-version.py curl)
 
 if [ ! -f boost/.done ]; then
     echo "Building Boost $BOOST_VERSION"
-    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz
-    tar zxf boost-${BOOST_VERSION}.tar.gz
+    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-b2-nodocs.tar.gz
+    tar zxf boost-${BOOST_VERSION}-b2-nodocs.tar.gz
     mkdir -p $PREFIX/include
     pushd boost-${BOOST_VERSION}
       ./bootstrap.sh

--- a/pkg/rpm/Dockerfile
+++ b/pkg/rpm/Dockerfile
@@ -42,12 +42,12 @@ ADD .build/dep-version.py /usr/local/bin
 # GCC 4.8.2 implementation of std::regex is buggy, so we install boost::regex here
 RUN BOOST_VERSION=$(dep-version.py boost) && \
     echo "BOOST VERSION: '${BOOST_VERSION}'" && \
-    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz && \
+    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-b2-nodocs.tar.gz && \
     tar zxf boost-${BOOST_VERSION}.tar.gz && \
     cd boost-${BOOST_VERSION} && \
     ./bootstrap.sh --with-libraries=regex && \
     ./b2 address-model=64 cxxflags="-fPIC -std=c++11" link=static threading=multi variant=release install && \
-    rm -rf /boost-${BOOST_VERSION}.tar.gz /boost-${BOOST_VERSION}
+    rm -rf /boost-${BOOST_VERSION}-b2-nodocs.tar.gz /boost-${BOOST_VERSION}
 
 RUN CMAKE_VERSION=$(dep-version.py cmake) && \
     curl -O -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${PLATFORM}.tar.gz && \

--- a/pkg/rpm/Dockerfile
+++ b/pkg/rpm/Dockerfile
@@ -43,7 +43,7 @@ ADD .build/dep-version.py /usr/local/bin
 RUN BOOST_VERSION=$(dep-version.py boost) && \
     echo "BOOST VERSION: '${BOOST_VERSION}'" && \
     curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-b2-nodocs.tar.gz && \
-    tar zxf boost-${BOOST_VERSION}.tar.gz && \
+    tar zxf boost-${BOOST_VERSION}-b2-nodocs.tar.gz && \
     cd boost-${BOOST_VERSION} && \
     ./bootstrap.sh --with-libraries=regex && \
     ./b2 address-model=64 cxxflags="-fPIC -std=c++11" link=static threading=multi variant=release install && \

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,22 +2,26 @@
   "name": "pulsar-cpp",
   "version": "3.5.0",
   "description": "Pulsar C++ SDK",
-  "builtin-baseline": "b051745c68faa6f65c493371d564c4eb8af34dad",
+  "builtin-baseline": "b27651341123a59f7187b42ef2bc476284afb310",
   "dependencies": [
     {
       "name": "asio",
       "features": [
         "openssl"
       ],
-      "version>=": "1.28.2"
+      "version>=": "1.30.2"
     },
     {
       "name": "boost-accumulators",
-      "version>=": "1.83.0"
+      "version>=": "1.85.0"
+    },
+    {
+      "name": "boost-format",
+      "version>=": "1.85.0"
     },
     {
       "name": "boost-property-tree",
-      "version>=": "1.83.0"
+      "version>=": "1.85.0"
     },
     {
       "name": "curl",
@@ -25,7 +29,7 @@
       "features": [
         "openssl"
       ],
-      "version>=": "8.4.0"
+      "version>=": "8.8.0"
     },
     {
       "name": "dlfcn-win32",
@@ -33,11 +37,11 @@
     },
     {
       "name": "openssl",
-      "version>=": "3.1.4#1"
+      "version>=": "3.3.1"
     },
     {
       "name": "protobuf",
-      "version>=": "3.21.12"
+      "version>=": "3.21.12#3"
     },
     {
       "name": "snappy",
@@ -45,11 +49,11 @@
     },
     {
       "name": "zlib",
-      "version>=": "1.3"
+      "version>=": "1.3.1"
     },
     {
       "name": "zstd",
-      "version>=": "1.5.5"
+      "version>=": "1.5.6"
     }
   ],
   "features": {
@@ -58,7 +62,7 @@
       "dependencies": [
         {
           "name": "boost-program-options",
-          "version>=": "1.83.0"
+          "version>=": "1.85.0"
         }
       ]
     },


### PR DESCRIPTION
### Motivation

See https://github.com/microsoft/vcpkg/pull/36510

Currently the commit id of the vcpkg submodule is old. With latest dependencies in vcpkg, it requires a `boost-format` dependency to build.

### Modifications

Upgrade the vcpkg submodule to the latest commit at the moment and add the `boost-format` dependency to fix the build.