### PR TITLE
Use Rocky Linux 8 and vcpkg to build RPM packages

### DIFF
--- a/build-support/merge_archives_vcpkg.sh
+++ b/build-support/merge_archives_vcpkg.sh
@@ -19,29 +19,14 @@
 #
 
 set -e
+cd `dirname $0`
 
-cd /pulsar-client-cpp
-ROOT_DIR=$(pwd)
-cd $ROOT_DIR/pkg/rpm
-
-if [[ $PLATFORM == "aarch64" ]]; then
-    export VCPKG_FORCE_SYSTEM_BINARIES=arm
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <cmake-build-directory>"
+    exit 1
 fi
 
-POM_VERSION=`cat $ROOT_DIR/version.txt | xargs`
-
-# Sanitize VERSION by removing `-incubating` since it's not legal in RPM
-VERSION=`echo $POM_VERSION | awk -F-  '{print $1}'`
-
-mkdir -p BUILD RPMS SOURCES SPECS SRPMS
-
-cp $ROOT_DIR/apache-pulsar-client-cpp-$POM_VERSION.tar.gz SOURCES
-
-rpmbuild -v -bb --clean \
-        --define "version $VERSION" \
-        --define "pom_version $POM_VERSION" \
-        --define "_topdir $PWD" \
-        SPECS/pulsar-client.spec
-
-cd RPMS/${PLATFORM}
-createrepo .
+CMAKE_BUILD_DIRECTORY=$1
+./merge_archives.sh $CMAKE_BUILD_DIRECTORY/libpulsarwithdeps.a \
+    $CMAKE_BUILD_DIRECTORY/lib/libpulsar.a \
+    $(find "$CMAKE_BUILD_DIRECTORY/vcpkg_installed" -name "*.a" | grep -v debug)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -76,6 +76,7 @@ target_include_directories(PULSAR_OBJECT_LIB PUBLIC
     "${CMAKE_SOURCE_DIR}/include"
     "${CMAKE_BINARY_DIR}/include")
 
+include(CheckCXXSymbolExists)
 if (BUILD_DYNAMIC_LIB)
     add_library(pulsarShared SHARED $<TARGET_OBJECTS:PULSAR_OBJECT_LIB>)
     set_property(TARGET pulsarShared PROPERTY OUTPUT_NAME ${LIB_NAME_SHARED})
@@ -89,9 +90,12 @@ if (BUILD_DYNAMIC_LIB)
         target_include_directories(pulsarShared PRIVATE ${dlfcn-win32_INCLUDE_DIRS})
         target_link_options(pulsarShared PRIVATE $<$<CONFIG:DEBUG>:/NODEFAULTLIB:MSVCRT>)
     endif()
+    check_cxx_symbol_exists(__GLIBCXX__ iostream GLIBCXX)
+    if (GLIBCXX)
+        target_link_libraries(pulsarShared PUBLIC -static-libgcc -static-libstdc++)
+    endif ()
 endif()
 
-include(CheckCXXSymbolExists)
 check_cxx_symbol_exists(getauxval sys/auxv.h HAVE_AUXV_GETAUXVAL)
 if(HAVE_AUXV_GETAUXVAL)
     add_definitions(-DPULSAR_AUXV_GETAUXVAL_PRESENT)

--- a/pkg/rpm/Dockerfile
+++ b/pkg/rpm/Dockerfile
@@ -42,7 +42,7 @@ ADD .build/dep-version.py /usr/local/bin
 
 # Vcpkg does not provide pre-built binaries for Arm architectures so we need to build vcpkg from source
 RUN yum install -y cmake
-RUn dnf --enablerepo=devel install -y ninja-build
+RUN dnf --enablerepo=devel install -y ninja-build
 
 # Dependencies when building OpenSSL
 RUN yum install -y perl-IPC-Cmd

--- a/pkg/rpm/Dockerfile
+++ b/pkg/rpm/Dockerfile
@@ -19,7 +19,7 @@
 
 # Build pulsar client library in Centos with tools to build static RPM
 
-FROM centos:7
+FROM rockylinux:8
 
 ARG PLATFORM
 
@@ -30,87 +30,19 @@ RUN yum update -y && \
         rpm-build \
         which \
         createrepo \
-        libstdc++-static \
-        python3
+        git \
+        python3 \
+        python3-pip
+RUN dnf --enablerepo=powertools install -y libstdc++-static
 
 RUN pip3 install pyyaml
 
 ADD .build/dependencies.yaml /
 ADD .build/dep-version.py /usr/local/bin
 
-# Download and compile boost
-# GCC 4.8.2 implementation of std::regex is buggy, so we install boost::regex here
-RUN BOOST_VERSION=$(dep-version.py boost) && \
-    echo "BOOST VERSION: '${BOOST_VERSION}'" && \
-    curl -O -L https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}.tar.gz && \
-    tar zxf boost-${BOOST_VERSION}.tar.gz && \
-    cd boost-${BOOST_VERSION} && \
-    ./bootstrap.sh --with-libraries=regex && \
-    ./b2 address-model=64 cxxflags="-fPIC -std=c++11" link=static threading=multi variant=release install && \
-    rm -rf /boost-${BOOST_VERSION}.tar.gz /boost-${BOOST_VERSION}
+# Vcpkg does not provide pre-built binaries for Arm architectures so we need to build vcpkg from source
+RUN yum install -y cmake
+RUn dnf --enablerepo=devel install -y ninja-build
 
-RUN CMAKE_VERSION=$(dep-version.py cmake) && \
-    curl -O -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${PLATFORM}.tar.gz && \
-    tar xfz cmake-${CMAKE_VERSION}-linux-${PLATFORM}.tar.gz && \
-    cp cmake-${CMAKE_VERSION}-linux-${PLATFORM}/bin/* /usr/bin/ && \
-    cp -r cmake-${CMAKE_VERSION}-linux-${PLATFORM}/share/cmake-* /usr/share/ && \
-    rm -rf cmake-${CMAKE_VERSION}-linux-${PLATFORM} cmake-${CMAKE_VERSION}-linux-${PLATFORM}.tar.gz
-
-# Download and compile protobuf
-RUN PROTOBUF_VERSION=$(dep-version.py protobuf) && \
-    curl -O -L  https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-cpp-${PROTOBUF_VERSION}.tar.gz && \
-    tar xfz protobuf-cpp-${PROTOBUF_VERSION}.tar.gz && \
-    cd protobuf-${PROTOBUF_VERSION}/ && \
-    CXXFLAGS=-fPIC ./configure && \
-    make -j8 && make install && ldconfig && \
-    rm -rf /protobuf-cpp-${PROTOBUF_VERSION}.tar.gz /protobuf-${PROTOBUF_VERSION}
-
-# ZLib
-RUN ZLIB_VERSION=$(dep-version.py zlib) && \
-    curl -O -L https://github.com/madler/zlib/archive/v${ZLIB_VERSION}.tar.gz && \
-    tar xfz v${ZLIB_VERSION}.tar.gz && \
-    cd zlib-${ZLIB_VERSION} && \
-    CFLAGS="-fPIC -O3" ./configure && \
-    make -j8 && make install && \
-    rm -rf /v${ZLIB_VERSION}.tar.gz /zlib-${ZLIB_VERSION}
-
-# Zstandard
-RUN ZSTD_VERSION=$(dep-version.py zstd) && \
-    curl -O -L https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz && \
-    tar xfz zstd-${ZSTD_VERSION}.tar.gz && \
-    cd zstd-${ZSTD_VERSION} && \
-    CFLAGS="-fPIC -O3" make -j8 && \
-    make install && \
-    rm -rf /zstd-${ZSTD_VERSION} /zstd-${ZSTD_VERSION}.tar.gz
-
-# Snappy
-RUN SNAPPY_VERSION=$(dep-version.py snappy) && \
-    curl -O -L https://github.com/google/snappy/archive/refs/tags/${SNAPPY_VERSION}.tar.gz && \
-    tar xfz ${SNAPPY_VERSION}.tar.gz && \
-    cd snappy-${SNAPPY_VERSION} && \
-    CXXFLAGS="-fPIC -O3" cmake . -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF && \
-    make -j8 && make install && \
-    rm -rf /snappy-${SNAPPY_VERSION} /${SNAPPY_VERSION}.tar.gz
-
-RUN OPENSSL_VERSION=$(dep-version.py openssl) && \
-    OPENSSL_VERSION_UNDERSCORE=$(echo $OPENSSL_VERSION | sed 's/\./_/g') && \
-    curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz && \
-    tar xfz OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz && \
-    cd openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}/ && \
-    ./Configure -fPIC --prefix=/usr/local/ssl/ linux-${PLATFORM} && \
-    make -j8 && make install && \
-    rm -rf /OpenSSL_${OPENSSL_VERSION_UNDERSCORE}.tar.gz /openssl-OpenSSL_${OPENSSL_VERSION_UNDERSCORE}
-
-ENV LD_LIBRARY_PATH /usr/local/ssl/lib/:
-ENV OPENSSL_ROOT_DIR /usr/local/ssl/
-
-# LibCurl
-RUN CURL_VERSION=$(dep-version.py curl) && \
-    CURL_VERSION_UNDERSCORE=$(echo $CURL_VERSION | sed 's/\./_/g') && \
-    curl -O -L  https://github.com/curl/curl/releases/download/curl-${CURL_VERSION_UNDERSCORE}/curl-${CURL_VERSION}.tar.gz && \
-    tar xfz curl-${CURL_VERSION}.tar.gz && \
-    cd curl-${CURL_VERSION} && \
-    CFLAGS=-fPIC ./configure --with-ssl=/usr/local/ssl/ --without-zstd --without-libpsl && \
-    make -j8 && make install && \
-    rm -rf /curl-${CURL_VERSION}.tar.gz /curl-${CURL_VERSION}
-
+# Dependencies when building OpenSSL
+RUN yum install -y perl-IPC-Cmd

--- a/pkg/rpm/SPECS/pulsar-client.spec
+++ b/pkg/rpm/SPECS/pulsar-client.spec
@@ -20,6 +20,7 @@
 %define name        apache-pulsar-client
 %define release     1
 %define buildroot   %{_topdir}/%{name}-%{version}-root
+%define debug_package %{nil}
 
 BuildRoot:      %{buildroot}
 Summary:        Apache Pulsar client library
@@ -52,8 +53,15 @@ static library.
 %setup -q -n apache-pulsar-client-cpp-%{pom_version}
 
 %build
-cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON
-make -j 3
+git clone https://github.com/microsoft/vcpkg.git
+cmake -B build -DINTEGRATE_VCPKG=ON -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTS=OFF -DBUILD_DYNAMIC_LIB=ON -DBUILD_STATIC_LIB=ON
+cmake --build build -j8
+./build-support/merge_archives_vcpkg.sh $PWD/build
+
+cp build/lib/libpulsar.a lib/libpulsar.a
+cp build/lib/libpulsar.so lib/libpulsar.so
+cp build/libpulsarwithdeps.a lib/libpulsarwithdeps.a
 
 %install
 INCLUDE_DIR=$RPM_BUILD_ROOT/usr/include


### PR DESCRIPTION
### Motivation

See https://lists.apache.org/thread/7o8hpv1gtoffvzx053wm0ss2s9xt0795, we will discard the support for CentOS 7 and old `std::string` ABI.

### Modifications

- Switch from `centos:7` image and GCC 4.8 to `rockylinux:8` image and GCC 8 to build RPM packages.
- Use vcpkg to install dependencies according to `vcpkg.json` (`dependencies.json` will be deprecated in future)
- Add a new script to build `libpulsarwithdeps.a` for dependencies installed by vcpkg
- Link to `libstdc++` and `libgcc_s` libraries statically

Additional, with vcpkg, OpenSSL will search `/etc/ssl/certs.pem` for the default CA certificate rather than `/usr/local/ssl/ssl/certs.pem`.