### PR TITLE
Log the default location of trusted CA certificates when tlsTrustCertsFilePath is not specified

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -18,6 +18,7 @@
  */
 #include "ClientConnection.h"
 
+#include <openssl/x509.h>
 #include <pulsar/MessageIdBuilder.h>
 
 #include <boost/optional.hpp>
@@ -227,6 +228,7 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
                 }
             } else {
                 ctx.set_default_verify_paths();
+                LOG_INFO("Use " << X509_get_default_cert_file() << " as default CA path");
             }
         }
 


### PR DESCRIPTION
### Motivation

Currently when `tlsTrustCertsFilePath` is not specified, default locations of CA certificates will be used. However, these paths are determined by the compile option when building OpenSSL and they are invisible to users. If the OS uses a different path, the TLS connection will fail with no helpful error message.

References:
- https://www.openssl.org/docs/man3.3/man3/X509_get_default_cert_file.html
- https://www.openssl.org/docs/man3.3/man3/SSL_CTX_set_default_verify_paths.html
- https://www.boost.org/doc/libs/1_83_0/doc/html/boost_asio/reference/ssl__context/set_default_verify_paths/overload2.html