### PR TITLE
[CI] Use macos-12 to build macOS libraries

### DIFF
--- a/.github/workflows/ci-build-binary-artifacts.yaml
+++ b/.github/workflows/ci-build-binary-artifacts.yaml
@@ -197,7 +197,7 @@ jobs:
 
   package-macos:
     name: Build macOS libraries
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 500
 
     strategy:


### PR DESCRIPTION
The release workflow is broken because it uses `macos-latest` runner, which is now macOS 14 Arm64, see https://github.com/actions/runner-images

```
+ pip3 install pyyaml
error: externally-managed-environment

× This environment is externally managed
```

