### PR TITLE
feat: expose partitions update interval configuration to C client

### DIFF
--- a/include/pulsar/c/client_configuration.h
+++ b/include/pulsar/c/client_configuration.h
@@ -192,6 +192,12 @@ PULSAR_PUBLIC void pulsar_client_configuration_set_listener_name(pulsar_client_c
 
 PULSAR_PUBLIC const char *pulsar_client_configuration_get_listener_name(pulsar_client_configuration_t *conf);
 
+PULSAR_PUBLIC void pulsar_client_configuration_set_partitions_update_interval(
+    pulsar_client_configuration_t *conf, const unsigned int intervalInSeconds);
+
+PULSAR_PUBLIC const unsigned int pulsar_client_configuration_get_partitions_update_interval(
+    pulsar_client_configuration_t *conf);
+
 /*
  * Get the stats interval set in the client.
  */

--- a/lib/c/c_ClientConfiguration.cc
+++ b/lib/c/c_ClientConfiguration.cc
@@ -198,3 +198,13 @@ void pulsar_client_configuration_set_listener_name(pulsar_client_configuration_t
 const char *pulsar_client_configuration_get_listener_name(pulsar_client_configuration_t *conf) {
     return conf->conf.getListenerName().c_str();
 }
+
+void pulsar_client_configuration_set_partitions_update_interval(pulsar_client_configuration_t *conf,
+                                                               const unsigned int intervalInSeconds) {
+    conf->conf.setPartititionsUpdateInterval(intervalInSeconds);
+}
+
+const unsigned int pulsar_client_configuration_get_partitions_update_interval(
+    pulsar_client_configuration_t *conf) {
+    return conf->conf.getPartitionsUpdateInterval();
+}

--- a/lib/c/c_ClientConfiguration.cc
+++ b/lib/c/c_ClientConfiguration.cc
@@ -200,7 +200,7 @@ const char *pulsar_client_configuration_get_listener_name(pulsar_client_configur
 }
 
 void pulsar_client_configuration_set_partitions_update_interval(pulsar_client_configuration_t *conf,
-                                                               const unsigned int intervalInSeconds) {
+                                                                const unsigned int intervalInSeconds) {
     conf->conf.setPartititionsUpdateInterval(intervalInSeconds);
 }
 

--- a/tests/c/c_ClientConfigurationTest.cc
+++ b/tests/c/c_ClientConfigurationTest.cc
@@ -31,4 +31,7 @@ TEST(C_ClientConfigurationTest, testCApiConfig) {
 
     pulsar_client_configuration_set_listener_name(conf, "listenerName");
     ASSERT_STREQ(pulsar_client_configuration_get_listener_name(conf), "listenerName");
+
+    pulsar_client_configuration_set_partitions_update_interval(conf, 10);
+    ASSERT_EQ(pulsar_client_configuration_get_partitions_update_interval(conf), 10);
 }


### PR DESCRIPTION
### Motivation
expose partitions update interval configuration to C client

### Modifications
expose partitions update interval configuration to C client


### Verifying this change
- Add test to cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
