### PR TITLE
Fix consumer might not subscribe after a reconnection

### DIFF
--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -404,6 +404,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     const size_t poolIndex_;
 
     friend class PulsarFriend;
+    friend class ConsumerTest;
 
     void checkServerError(ServerError error, const std::string& message);
 

--- a/lib/HandlerBase.h
+++ b/lib/HandlerBase.h
@@ -157,9 +157,11 @@ class HandlerBase : public std::enable_shared_from_this<HandlerBase> {
     ClientConnectionWeakPtr connection_;
     std::string redirectedClusterURI_;
     std::atomic<long> firstRequestIdAfterConnect_{-1L};
+    std::atomic<long> connectionTimeMs_{0};  // only for tests
 
     friend class ClientConnection;
     friend class PulsarFriend;
+    friend class ConsumerTest;
 };
 }  // namespace pulsar
 #endif  //_PULSAR_HANDLER_BASE_HEADER_


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/436

### Motivation

When a consumer starts grabbing the connection, it registers a timer after the operation timeout. When that timer is expired, it will fail the connection and cancel the connection timer. However, it results a race condition that:
  1. The consumer's connection is closed (e.g. the keep alive timer failed)
  2. The connection timer is registered on the executor and will trigger the reconnection after 100ms
  3. The connection timer is cancelled, then the reconnection won't start.

### Modifications

Cancel the `creationTimer_` once `HandlerBase#start` succeeded first time. Add `testReconnectWhenFirstConnectTimedOut` to cover this case.