### PR TITLE
change: Set default routingMode of producer is RoundRobin

### DIFF
--- a/include/pulsar/ProducerConfiguration.h
+++ b/include/pulsar/ProducerConfiguration.h
@@ -236,7 +236,7 @@ class PULSAR_PUBLIC ProducerConfiguration {
     /**
      * Set the message routing modes for partitioned topics.
      *
-     * Default: UseSinglePartition
+     * Default: RoundRobinDistribution
      *
      * @param PartitionsRoutingMode partition routing mode.
      * @return

--- a/lib/ProducerConfigurationImpl.h
+++ b/lib/ProducerConfigurationImpl.h
@@ -34,7 +34,7 @@ struct ProducerConfigurationImpl {
     CompressionType compressionType{CompressionNone};
     int maxPendingMessages{1000};
     int maxPendingMessagesAcrossPartitions{50000};
-    ProducerConfiguration::PartitionsRoutingMode routingMode{ProducerConfiguration::UseSinglePartition};
+    ProducerConfiguration::PartitionsRoutingMode routingMode{ProducerConfiguration::RoundRobinDistribution};
     MessageRoutingPolicyPtr messageRouter;
     ProducerConfiguration::HashingScheme hashingScheme{ProducerConfiguration::BoostHash};
     bool useLazyStartPartitionedProducers{false};


### PR DESCRIPTION
### Motivation

To keep same default routingMode with java client: https://github.com/apache/pulsar/blob/02147454c425b92f0cd1caefa73b9339db6a0269/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java#L357-L359

### Modifications

-  Set default routingMode of producer is RoundRobin

### Verifying this change
- No need

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
