### PR TITLE
Fix invalid memory access on the first pending batch receive callback

### DIFF
--- a/lib/ConsumerImplBase.h
+++ b/lib/ConsumerImplBase.h
@@ -112,6 +112,14 @@ class ConsumerImplBase : public HandlerBase {
 
     virtual void setNegativeAcknowledgeEnabledForTesting(bool enabled) = 0;
 
+    // Note: it should be protected by batchPendingReceiveMutex_ and called when `batchPendingReceives_` is
+    // not empty
+    BatchReceiveCallback popBatchReceiveCallback() {
+        auto callback = std::move(batchPendingReceives_.front().batchReceiveCallback_);
+        batchPendingReceives_.pop();
+        return callback;
+    }
+
     friend class MultiTopicsConsumerImpl;
     friend class PulsarFriend;
 };


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar-client-cpp/blob/5940cb518bdf3a13ae7f859fab10d6940eec51b7/lib/ConsumerImplBase.cc#L109-L112

In the code above, `batchReceive` is a reference to the first element in the queue (`batchPendingReceives_`). After `pop()`, the memory would be invalid to access, which might cause unexpected crash.

### Modifications

Add a  `popBatchReceiveCallback` method that moves the callback from the first element in `batchPendingReceives_`. Use this method to replace error-prone `front()` - `pop()` calls.