### PR TITLE
fix: Keep compatible with old boost versions

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -172,7 +172,13 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
       executor_(executor),
       resolver_(executor_->createTcpResolver()),
       socket_(executor_->createSocket()),
+#if defined(USE_ASIO) || BOOST_VERSION >= 107000
       strand_(ASIO::make_strand(executor_->getIOService().get_executor())),
+#elif BOOST_VERSION >= 106600
+      strand_(executor_->getIOService().get_executor()),
+#else
+      strand_(executor_->getIOService()),
+#endif
       logicalAddress_(logicalAddress),
       physicalAddress_(physicalAddress),
       cnxString_("[<none> -> " + physicalAddress + "] "),


### PR DESCRIPTION
### Motivation

Keep compatible with old boost versions.

### Modifications

Port boost compatible code from branch-3.4 and make minor changes for USE_ASIO.

Code from branch-3.4:
https://github.com/apache/pulsar-client-cpp/blob/1cb1bf8ba1ca1033b4a36d35514f22fcf150973a/lib/ClientConnection.cc#L171-L177

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
No functionality changed. Just keep the old compatible behavior.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
