### PR TITLE
Fix ack failure on message listener in multi topics consumer

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -292,11 +292,7 @@ void ConsumerImpl::sendFlowPermitsToBroker(const ClientConnectionPtr& cnx, int n
 Result ConsumerImpl::handleCreateConsumer(const ClientConnectionPtr& cnx, Result result) {
     Result handleResult = ResultOk;
 
-    static bool firstTime = true;
     if (result == ResultOk) {
-        if (firstTime) {
-            firstTime = false;
-        }
         LOG_INFO(getName() << "Created consumer on broker " << cnx->cnxString());
         {
             Lock lock(mutex_);
@@ -313,12 +309,10 @@ Result ConsumerImpl::handleCreateConsumer(const ClientConnectionPtr& cnx, Result
         }
 
         LOG_DEBUG(getName() << "Send initial flow permits: " << config_.getReceiverQueueSize());
-        if (consumerTopicType_ == NonPartitioned || !firstTime) {
-            if (config_.getReceiverQueueSize() != 0) {
-                sendFlowPermitsToBroker(cnx, config_.getReceiverQueueSize());
-            } else if (messageListener_) {
-                sendFlowPermitsToBroker(cnx, 1);
-            }
+        if (config_.getReceiverQueueSize() != 0) {
+            sendFlowPermitsToBroker(cnx, config_.getReceiverQueueSize());
+        } else if (messageListener_) {
+            sendFlowPermitsToBroker(cnx, 1);
         }
         consumerCreatedPromise_.setValue(get_shared_this_ptr());
     } else {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #446 

<!-- or this PR is one task of an issue -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

We found an ack failure issue: #446 

MessageListeners can start to process messages before subscribing all child topics are completed in "multi topics" (e.g. partitioned, list, regex) cases.
If `acknowledge()` is called in messageListeners (it is very typical usage) before subscribing completion, it will fail with `AlreadyClosed` error since the state of the parent consumer is not `Ready` yet:
https://github.com/apache/pulsar-client-cpp/blob/8b2753a56579ea6cf11e26a0c5a160797518df63/lib/MultiTopicsConsumerImpl.cc#L643-L648
That results in ack holes, and finally full backlog.

### Modifications

<!-- Describe the modifications you've done. -->

* `MultiTopicsConsumerImpl`: Pause messageListeners at first by setting `startPaused` to true and resume them after subscribing all child topics are completed.
* `ConsumerImpl`: Delete unused code.
  * It tries to skip `sendFlowPermitsToBroker()` at the first connection.
    * The motivation seems same as this PR, i.e. to prevent messageListeners from starting before subscribing completion.
  * However, actually it does not work so far, the variable `firstTime` looks always false at https://github.com/apache/pulsar-client-cpp/blob/8b2753a56579ea6cf11e26a0c5a160797518df63/lib/ConsumerImpl.cc#L316 because it becomes false at https://github.com/apache/pulsar-client-cpp/blob/8b2753a56579ea6cf11e26a0c5a160797518df63/lib/ConsumerImpl.cc#L297-L299
    * Also it is static variable in a method that is shared by all `ConsumerImpl` instances, whereas it has no chance of returning to true once it becomes false.
  * It seems better that child consumers don't have to care about their parents and are completely independent of them.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Specific tests for this issue is difficult to implement because it does not occur every time.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
