### PR TITLE
Fix default operation timeout

### DIFF
--- a/lib/ClientConfigurationImpl.h
+++ b/lib/ClientConfigurationImpl.h
@@ -30,7 +30,7 @@ struct ClientConfigurationImpl {
     uint64_t memoryLimit{0ull};
     int ioThreads{1};
     int connectionsPerBroker{1};
-    std::chrono::nanoseconds operationTimeout{30L * 1000 * 1000 * 1000};
+    std::chrono::nanoseconds operationTimeout{30LL * 1000 * 1000 * 1000};
     int messageListenerThreads{1};
     int concurrentLookupRequest{50000};
     int maxLookupRedirects{20};


### PR DESCRIPTION
Fixes: Default operation timeout has the wrong value (no issue entered)

### Motivation
The driver will timeout on all operations because the operation timeout is initialized with a literal of a too small size and when cast to `std::chrono::seconds` we end up with 0. `long long` should be used because according to https://en.cppreference.com/w/cpp/chrono/duration `std::chrono::nanoseconds` takes a type of at least 64 bits. 

Example of the problem here:
https://godbolt.org/z/o51G6xbqo

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 


- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
