### PR TITLE
Fix the YAML format error in latest image

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -47,7 +47,8 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        # TODO: support build on macos-12
+        os: [ubuntu-20.04]
 
     steps:
       - name: checkout

--- a/tests/blue-green/docker-compose.yml
+++ b/tests/blue-green/docker-compose.yml
@@ -33,12 +33,12 @@ services:
     environment:
       - PULSAR_MEM=-Xms128m -Xmx128m -XX:MaxDirectMemorySize=56m
     command: >
-      bin/pulsar initialize-cluster-metadata \
-               --cluster cluster-a \
-               --zookeeper zookeeper:2181 \
-               --configuration-store zookeeper:2181 \
-               --web-service-url http://broker-1:8080 \
-               --broker-service-url pulsar://broker-1:6650
+      bin/pulsar initialize-cluster-metadata
+        --cluster cluster-a
+        --zookeeper zookeeper:2181
+        --configuration-store zookeeper:2181
+        --web-service-url http://broker-1:8080
+        --broker-service-url pulsar://broker-1:6650
     depends_on:
       zookeeper:
         condition: service_healthy

--- a/tests/extensibleLM/docker-compose.yml
+++ b/tests/extensibleLM/docker-compose.yml
@@ -33,12 +33,11 @@ services:
     environment:
       - PULSAR_MEM=-Xms128m -Xmx128m -XX:MaxDirectMemorySize=56m
     command: >
-      bin/pulsar initialize-cluster-metadata \
-               --cluster cluster-a \
-               --zookeeper zookeeper:2181 \
-               --configuration-store zookeeper:2181 \
-               --web-service-url http://broker-1:8080 \
-               --broker-service-url pulsar://broker-1:6650
+      bin/pulsar initialize-cluster-metadata --cluster cluster-a
+        --zookeeper zookeeper:2181
+        --configuration-store zookeeper:2181
+        --web-service-url http://broker-1:8080
+        --broker-service-url pulsar://broker-1:6650
     depends_on:
       zookeeper:
         condition: service_healthy


### PR DESCRIPTION
With the latest image, the `pulsar-init` service will fail with command line parsing.

```
picocli.CommandLine$UnmatchedArgumentException: Unmatched arguments from index 0: '
', '
', '
', '
', '
'
Exception in thread "main" picocli.CommandLine$UnmatchedArgumentException: Unmatched arguments from index 0: '
', '
', '
', '
', '
'
	at picocli.CommandLine$Interpreter.validateConstraints(CommandLine.java:13662)
	at picocli.CommandLine$Interpreter.parse(CommandLine.java:13614)
	at picocli.CommandLine$Interpreter.parse(CommandLine.java:13559)
	at picocli.CommandLine$Interpreter.parse(CommandLine.java:13454)
	at picocli.CommandLine.parseArgs(CommandLine.java:1552)
	at org.apache.pulsar.PulsarClusterMetadataSetup.main(PulsarClusterMetadataSetup.java:227)
```