### PR TITLE
bugfix: check callback to avoid std::bad_function_call exception

### DIFF
--- a/lib/AckGroupingTracker.h
+++ b/lib/AckGroupingTracker.h
@@ -71,7 +71,10 @@ class AckGroupingTracker : public std::enable_shared_from_this<AckGroupingTracke
      * @param[in] msgId ID of the message to be ACKed.
      * @param[in] callback the callback that is triggered when the message is acknowledged
      */
-    virtual void addAcknowledge(const MessageId& msgId, ResultCallback callback) { callback(ResultOk); }
+    virtual void addAcknowledge(const MessageId& msgId, ResultCallback callback) {
+        if (callback)
+            callback(ResultOk);
+    }
 
     /**
      * Adding message ID list into ACK group for individual ACK.
@@ -79,7 +82,8 @@ class AckGroupingTracker : public std::enable_shared_from_this<AckGroupingTracke
      * @param[in] callback the callback that is triggered when the messages are acknowledged
      */
     virtual void addAcknowledgeList(const MessageIdList& msgIds, ResultCallback callback) {
-        callback(ResultOk);
+        if (callback)
+            callback(ResultOk);
     }
 
     /**
@@ -88,7 +92,8 @@ class AckGroupingTracker : public std::enable_shared_from_this<AckGroupingTracke
      * @param[in] callback the callback that is triggered when the message is acknowledged
      */
     virtual void addAcknowledgeCumulative(const MessageId& msgId, ResultCallback callback) {
-        callback(ResultOk);
+        if (callback)
+            callback(ResultOk);
     }
 
     /**


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #455 

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Fixed the bug that when reading messages from a non-persistent topic with `Reader`, it throw `std::bad_function_call` exception.

### Modifications

<!-- Describe the modifications you've done. -->

Check `checkback` before calling it in `AckGroupingTracker`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

A simple bug fix.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
