### PR TITLE
Expose keep alive interval for c and c++ client

### DIFF
--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -365,7 +365,7 @@ class PULSAR_PUBLIC ClientConfiguration {
     ClientConfiguration& setKeepAliveIntervalInSeconds(unsigned int keepAliveIntervalInSeconds);
 
     /**
-     * The getter associated with setConnectionTimeout().
+     * The getter associated with setKeepAliveIntervalInSeconds().
      */
     unsigned int getKeepAliveIntervalInSeconds() const;
 

--- a/include/pulsar/ClientConfiguration.h
+++ b/include/pulsar/ClientConfiguration.h
@@ -356,6 +356,19 @@ class PULSAR_PUBLIC ClientConfiguration {
      */
     int getConnectionTimeout() const;
 
+    /**
+     * Set keep alive interval for each client-broker-connection. <i>(default: 30 seconds)</i>.
+     *
+     * @param keepAliveIntervalInSeconds
+     * @return
+     */
+    ClientConfiguration& setKeepAliveIntervalInSeconds(unsigned int keepAliveIntervalInSeconds);
+
+    /**
+     * The getter associated with setConnectionTimeout().
+     */
+    unsigned int getKeepAliveIntervalInSeconds() const;
+
     friend class ClientImpl;
     friend class PulsarWrapper;
 

--- a/include/pulsar/c/client_configuration.h
+++ b/include/pulsar/c/client_configuration.h
@@ -204,6 +204,12 @@ PULSAR_PUBLIC const unsigned int pulsar_client_configuration_get_partitions_upda
 PULSAR_PUBLIC const unsigned int pulsar_client_configuration_get_stats_interval_in_seconds(
     pulsar_client_configuration_t *conf);
 
+PULSAR_PUBLIC void pulsar_client_configuration_set_keep_alive_interval_in_seconds(
+    pulsar_client_configuration_t *conf, unsigned int keepAliveIntervalInSeconds);
+
+PULSAR_PUBLIC unsigned int pulsar_client_configuration_get_keep_alive_interval_in_seconds(
+    pulsar_client_configuration_t *conf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/ClientConfiguration.cc
+++ b/lib/ClientConfiguration.cc
@@ -214,6 +214,16 @@ ClientConfiguration& ClientConfiguration::setConnectionTimeout(int timeoutMs) {
 
 int ClientConfiguration::getConnectionTimeout() const { return impl_->connectionTimeoutMs; }
 
+ClientConfiguration& ClientConfiguration::setKeepAliveIntervalInSeconds(
+    unsigned int keepAliveIntervalInSeconds) {
+    impl_->keepAliveIntervalInSeconds = keepAliveIntervalInSeconds;
+    return *this;
+}
+
+unsigned int ClientConfiguration::getKeepAliveIntervalInSeconds() const {
+    return impl_->keepAliveIntervalInSeconds;
+}
+
 ClientConfiguration& ClientConfiguration::setDescription(const std::string& description) {
     if (description.length() > 64) {
         throw std::invalid_argument("The description length exceeds 64");

--- a/lib/ClientConfigurationImpl.h
+++ b/lib/ClientConfigurationImpl.h
@@ -47,6 +47,7 @@ struct ClientConfigurationImpl {
     unsigned int partitionsUpdateInterval{60};  // 1 minute
     std::string listenerName;
     int connectionTimeoutMs{10000};  // 10 seconds
+    unsigned int keepAliveIntervalInSeconds{30};
     std::string description;
     std::string proxyServiceUrl;
     ClientConfiguration::ProxyProtocol proxyProtocol;

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -388,6 +388,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     // Signals whether we're waiting for a response from broker
     bool havePendingPingRequest_ = false;
     bool isSniProxy_ = false;
+    unsigned int keepAliveIntervalInSeconds_;
     DeadlineTimerPtr keepAliveTimer_;
     DeadlineTimerPtr consumerStatsRequestTimer_;
 

--- a/lib/c/c_ClientConfiguration.cc
+++ b/lib/c/c_ClientConfiguration.cc
@@ -208,3 +208,13 @@ const unsigned int pulsar_client_configuration_get_partitions_update_interval(
     pulsar_client_configuration_t *conf) {
     return conf->conf.getPartitionsUpdateInterval();
 }
+
+void pulsar_client_configuration_set_keep_alive_interval_in_seconds(pulsar_client_configuration_t *conf,
+                                                                    unsigned int keepAliveIntervalInSeconds) {
+    conf->conf.setKeepAliveIntervalInSeconds(keepAliveIntervalInSeconds);
+}
+
+unsigned int pulsar_client_configuration_get_keep_alive_interval_in_seconds(
+    pulsar_client_configuration_t *conf) {
+    return conf->conf.getKeepAliveIntervalInSeconds();
+}

--- a/tests/c/c_ClientConfigurationTest.cc
+++ b/tests/c/c_ClientConfigurationTest.cc
@@ -34,4 +34,7 @@ TEST(C_ClientConfigurationTest, testCApiConfig) {
 
     pulsar_client_configuration_set_partitions_update_interval(conf, 10);
     ASSERT_EQ(pulsar_client_configuration_get_partitions_update_interval(conf), 10);
+
+    pulsar_client_configuration_set_keep_alive_interval_in_seconds(conf, 60);
+    ASSERT_EQ(pulsar_client_configuration_get_keep_alive_interval_in_seconds(conf), 60);
 }


### PR DESCRIPTION
### Motivation
Expose keep alive interval for c and c++ client

### Modifications
Expose keep alive interval for c and c++ client


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
