### PR TITLE
Handle the exception from the token supplier

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -528,8 +528,15 @@ void ClientConnection::handleHandshake(const ASIO_ERROR& err) {
 
     bool connectingThroughProxy = logicalAddress_ != physicalAddress_;
     Result result = ResultOk;
-    SharedBuffer buffer = Commands::newConnect(authentication_, logicalAddress_, connectingThroughProxy,
-                                               clientVersion_, result);
+    SharedBuffer buffer;
+    try {
+        buffer = Commands::newConnect(authentication_, logicalAddress_, connectingThroughProxy,
+                                      clientVersion_, result);
+    } catch (const std::exception& e) {
+        LOG_ERROR(cnxString_ << "Failed to create Connect command: " << e.what());
+        close(ResultAuthenticationError);
+        return;
+    }
     if (result != ResultOk) {
         LOG_ERROR(cnxString_ << "Failed to establish connection: " << result);
         close(result);

--- a/tests/AuthTokenTest.cc
+++ b/tests/AuthTokenTest.cc
@@ -200,3 +200,13 @@ TEST(AuthPluginToken, testNoAuthWithHttp) {
     result = client.subscribe(topicName, subName, consumer);
     ASSERT_EQ(ResultConnectError, result);
 }
+
+TEST(AuthPluginToken, testTokenSupplierException) {
+    ClientConfiguration config;
+    config.setAuth(
+        AuthToken::create([]() -> std::string { throw std::runtime_error("failed to generate token"); }));
+    Client client(serviceUrl, config);
+    Producer producer;
+    ASSERT_EQ(ResultAuthenticationError, client.createProducer("topic", producer));
+    ASSERT_EQ(ResultOk, client.close());
+}


### PR DESCRIPTION
### Motivation

When a token supplier is passed to the `AuthToken`, if exceptions are thrown from it, the application will crash immediately. A typical case is the Python wrapper might raise an exception when trying to get token.

### Modifications

Catch the exception in `Commands::newConnect` because the token supplier is called in it. Then convert it to `ResultAuthenticationError`. Add `testTokenSupplierException` to verify it.