### PR TITLE
Bump macos runner image to 14

### DIFF
--- a/.github/workflows/ci-build-binary-artifacts.yaml
+++ b/.github/workflows/ci-build-binary-artifacts.yaml
@@ -197,7 +197,7 @@ jobs:
 
   package-macos:
     name: Build macOS libraries
-    runs-on: macos-12
+    runs-on: macos-14
     timeout-minutes: 500
 
     strategy:

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        # TODO: support build on macos-12
+        # TODO: support build on macos-14
         os: [ubuntu-20.04]
 
     steps:
@@ -314,7 +314,7 @@ jobs:
     timeout-minutes: 120
     name: Build CPP Client on macOS
     needs: formatting-check
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -340,7 +340,7 @@ jobs:
   cpp-build-macos-static:
     timeout-minutes: 120
     name: Build CPP Client on macOS with static dependencies
-    runs-on: macos-12
+    runs-on: macos-14
     needs: unit-tests
     steps:
       - name: checkout

--- a/pkg/mac/build-static-library.sh
+++ b/pkg/mac/build-static-library.sh
@@ -21,7 +21,9 @@
 set -ex
 cd `dirname $0`
 
-pip3 install pyyaml
+python3 -m venv venv
+source venv/bin/activate
+python3 -m pip install pyyaml
 
 MACOSX_DEPLOYMENT_TARGET=10.15
 if [[ -z ${ARCH} ]]; then


### PR DESCRIPTION
macOS 12 is deprecated, see https://github.com/actions/runner-images?tab=readme-ov-file#available-images