### PR TITLE
Fix some compiler warnings in public headers

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,6 +19,7 @@
 
 if (NOT MSVC)
   set(CMAKE_C_FLAGS " -std=c99 ${CMAKE_C_FLAGS}")
+  add_compile_options(-Wextra -Wno-unused-parameter)
 endif()
 
 set(SAMPLE_ASYNC_PRODUCER_SOURCES

--- a/include/pulsar/BrokerConsumerStats.h
+++ b/include/pulsar/BrokerConsumerStats.h
@@ -73,7 +73,7 @@ class PULSAR_PUBLIC BrokerConsumerStats {
     virtual const std::string getConnectedSince() const;
 
     /** Returns Whether this subscription is Exclusive or Shared or Failover */
-    virtual const ConsumerType getType() const;
+    virtual ConsumerType getType() const;
 
     /** Returns the rate of messages expired on this subscription. msg/s */
     virtual double getMsgRateExpired() const;

--- a/include/pulsar/Message.h
+++ b/include/pulsar/Message.h
@@ -176,7 +176,7 @@ class PULSAR_PUBLIC Message {
     /**
      * Get the redelivery count for this message
      */
-    const int getRedeliveryCount() const;
+    int getRedeliveryCount() const;
 
     /**
      * Check if schema version exists

--- a/include/pulsar/c/client_configuration.h
+++ b/include/pulsar/c/client_configuration.h
@@ -195,13 +195,13 @@ PULSAR_PUBLIC const char *pulsar_client_configuration_get_listener_name(pulsar_c
 PULSAR_PUBLIC void pulsar_client_configuration_set_partitions_update_interval(
     pulsar_client_configuration_t *conf, const unsigned int intervalInSeconds);
 
-PULSAR_PUBLIC const unsigned int pulsar_client_configuration_get_partitions_update_interval(
+PULSAR_PUBLIC unsigned int pulsar_client_configuration_get_partitions_update_interval(
     pulsar_client_configuration_t *conf);
 
 /*
  * Get the stats interval set in the client.
  */
-PULSAR_PUBLIC const unsigned int pulsar_client_configuration_get_stats_interval_in_seconds(
+PULSAR_PUBLIC unsigned int pulsar_client_configuration_get_stats_interval_in_seconds(
     pulsar_client_configuration_t *conf);
 
 PULSAR_PUBLIC void pulsar_client_configuration_set_keep_alive_interval_in_seconds(

--- a/lib/BrokerConsumerStats.cc
+++ b/lib/BrokerConsumerStats.cc
@@ -63,7 +63,7 @@ const std::string BrokerConsumerStats::getAddress() const { return impl_->getAdd
 
 const std::string BrokerConsumerStats::getConnectedSince() const { return impl_->getConnectedSince(); }
 
-const ConsumerType BrokerConsumerStats::getType() const { return impl_->getType(); }
+ConsumerType BrokerConsumerStats::getType() const { return impl_->getType(); }
 
 double BrokerConsumerStats::getMsgRateExpired() const { return impl_->getMsgRateExpired(); }
 

--- a/lib/Message.cc
+++ b/lib/Message.cc
@@ -184,7 +184,7 @@ const std::string& Message::getTopicName() const {
     return impl_->getTopicName();
 }
 
-const int Message::getRedeliveryCount() const {
+int Message::getRedeliveryCount() const {
     if (!impl_) {
         return 0;
     }

--- a/lib/c/c_ClientConfiguration.cc
+++ b/lib/c/c_ClientConfiguration.cc
@@ -173,8 +173,7 @@ void pulsar_client_configuration_set_stats_interval_in_seconds(pulsar_client_con
     conf->conf.setStatsIntervalInSeconds(interval);
 }
 
-const unsigned int pulsar_client_configuration_get_stats_interval_in_seconds(
-    pulsar_client_configuration_t *conf) {
+unsigned int pulsar_client_configuration_get_stats_interval_in_seconds(pulsar_client_configuration_t *conf) {
     return conf->conf.getStatsIntervalInSeconds();
 }
 
@@ -204,8 +203,7 @@ void pulsar_client_configuration_set_partitions_update_interval(pulsar_client_co
     conf->conf.setPartititionsUpdateInterval(intervalInSeconds);
 }
 
-const unsigned int pulsar_client_configuration_get_partitions_update_interval(
-    pulsar_client_configuration_t *conf) {
+unsigned int pulsar_client_configuration_get_partitions_update_interval(pulsar_client_configuration_t *conf) {
     return conf->conf.getPartitionsUpdateInterval();
 }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Fix some compiler warnings in public headers when using with -Wextra. These warnings prevent projects using -Wextra -Werror to use pulsar client without modifications.

### Modifications

<!-- Describe the modifications you've done. -->

1. Modified public headers to fix compiler warnings
2. Add compile options "-Wextra -Wno-unused-parameter" to compile examples to help find similar issues

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change can be verified as follows:
- Add compile options "-Wextra -Wno-unused-parameter" to compile examples to help find similar issues

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
Only the compiler warnings have been fixed, and there is no change in functionality.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
