### PR TITLE
[fix] Fix an issue where zero queue consumers are unable to receive messages after topic unloading

### DIFF
--- a/tests/ZeroQueueSizeTest.cc
+++ b/tests/ZeroQueueSizeTest.cc
@@ -27,6 +27,7 @@
 #include <mutex>
 
 #include "ConsumerTest.h"
+#include "HttpHelper.h"
 #include "lib/Latch.h"
 #include "lib/LogUtils.h"
 
@@ -37,6 +38,7 @@ using namespace pulsar;
 static int totalMessages = 10;
 static int globalCount = 0;
 static std::string lookupUrl = "pulsar://localhost:6650";
+static std::string adminUrl = "http://localhost:8080";
 static std::string contentBase = "msg-";
 
 static void messageListenerFunction(Consumer consumer, const Message& msg, Latch& latch) {
@@ -287,3 +289,101 @@ TEST(ZeroQueueSizeTest, testPauseResumeNoReconnection) {
 
     client.close();
 }
+
+class ZeroQueueSizeTest : public ::testing::TestWithParam<bool> {};
+
+TEST_P(ZeroQueueSizeTest, testReceptionAfterUnloading) {
+    Client client(lookupUrl);
+    auto isAsync = GetParam();
+    std::string topicName = "zero-queue-size-reception-after-unloading";
+    if (isAsync) {
+        topicName += "-async";
+    }
+    std::string subName = "my-sub";
+
+    Producer producer;
+    Result result = client.createProducer(topicName, producer);
+    ASSERT_EQ(ResultOk, result);
+
+    Consumer consumer;
+    ConsumerConfiguration consConfig;
+    consConfig.setReceiverQueueSize(0);
+    result = client.subscribe(topicName, subName, consConfig, consumer);
+    ASSERT_EQ(ResultOk, result);
+
+    for (int i = 0; i < totalMessages / 2; i++) {
+        std::ostringstream ss;
+        ss << contentBase << i;
+        Message msg = MessageBuilder().setContent(ss.str()).build();
+        result = producer.send(msg);
+        ASSERT_EQ(ResultOk, result);
+    }
+
+    for (int i = 0; i < totalMessages / 2; i++) {
+        ASSERT_EQ(0, ConsumerTest::getNumOfMessagesInQueue(consumer));
+        std::ostringstream ss;
+        ss << contentBase << i;
+        if (isAsync) {
+            Latch latch(1);
+            consumer.receiveAsync([&consumer, &ss, &latch](Result res, const Message& receivedMsg) {
+                ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
+                ASSERT_EQ(ss.str(), receivedMsg.getDataAsString());
+                ASSERT_EQ(0, ConsumerTest::getNumOfMessagesInQueue(consumer));
+                latch.countdown();
+            });
+            ASSERT_TRUE(latch.wait(std::chrono::seconds(10)));
+        } else {
+            Message receivedMsg;
+            consumer.receive(receivedMsg);
+            ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
+            ASSERT_EQ(ss.str(), receivedMsg.getDataAsString());
+            ASSERT_EQ(0, ConsumerTest::getNumOfMessagesInQueue(consumer));
+        }
+    }
+
+    // Wait for messages to be delivered while performing `receive` or `receiveAsync` in a separate thread.
+    // At this time, the value of availablePermits should be 1.
+    std::thread consumeThread([&consumer, &isAsync] {
+        for (int i = totalMessages / 2; i < totalMessages; i++) {
+            ASSERT_EQ(0, ConsumerTest::getNumOfMessagesInQueue(consumer));
+            std::ostringstream ss;
+            ss << contentBase << i;
+            if (isAsync) {
+                Latch latch(1);
+                consumer.receiveAsync([&consumer, &ss, &latch](Result res, const Message& receivedMsg) {
+                    ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
+                    ASSERT_EQ(ss.str(), receivedMsg.getDataAsString());
+                    ASSERT_EQ(0, ConsumerTest::getNumOfMessagesInQueue(consumer));
+                    latch.countdown();
+                });
+                ASSERT_TRUE(latch.wait(std::chrono::seconds(10)));
+            } else {
+                Message receivedMsg;
+                consumer.receive(receivedMsg);
+                ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
+                ASSERT_EQ(ss.str(), receivedMsg.getDataAsString());
+                ASSERT_EQ(0, ConsumerTest::getNumOfMessagesInQueue(consumer));
+            }
+        }
+    });
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    int res = makePutRequest(adminUrl + "/admin/v2/persistent/public/default/" + topicName + "/unload", "");
+    ASSERT_TRUE(res / 100 == 2) << "res: " << res;
+
+    for (int i = totalMessages / 2; i < totalMessages; i++) {
+        std::ostringstream ss;
+        ss << contentBase << i;
+        Message msg = MessageBuilder().setContent(ss.str()).build();
+        result = producer.send(msg);
+        ASSERT_EQ(ResultOk, result);
+    }
+
+    consumeThread.join();
+    consumer.unsubscribe();
+    consumer.close();
+    producer.close();
+    client.close();
+}
+
+INSTANTIATE_TEST_CASE_P(Pulsar, ZeroQueueSizeTest, ::testing::Values(false, true));


### PR DESCRIPTION
### Motivation

If a consumer with a receiver queue size of 0 is waiting for messages using `receive` or `receiveAsync`, and the topic is unloaded or the broker is restarted, the consumer will no longer be able to receive messages. This is because `receive` and `receiveAsync` have different bugs. Both bugs are highly reproducible.

#### receive

When the `receive` method of a zero queue consumer is executed, `fetchSingleMessageFromBroker` is called internally. In `fetchSingleMessageFromBroker`, the connection of the received message is compared with the connection when the flow permit was sent, and if they do not match, the message is discarded.
https://github.com/apache/pulsar-client-cpp/blob/115d64af81ae26ae73aaba7aaba36d4a9e47324c/lib/ConsumerImpl.cc#L918-L942

If the topic is unloaded or the broker is restarted between sending the flow permit and receiving the message, the connections at the two times will no longer match, so the message will be discarded and no further flow permits will be sent, causing message delivery to stop.

#### receiveAsync

If the consumer is reopened by unloading the topic or restarting the broker, flow permits that were sent before the reopening must be sent again. However, if a consumer with a receiver queue size of 0 is waiting for messages with `receiveAsync`, it does not seem to send flow permits even if the consumer is reopened.
https://github.com/apache/pulsar-client-cpp/blob/115d64af81ae26ae73aaba7aaba36d4a9e47324c/lib/ConsumerImpl.cc#L311-L332

### Modifications

#### receive

In `fetchSingleMessageFromBroker`, I think the connection of the received message should be compared with the current connection, not the connection at the time the flow permit was sent. In fact, the Java client makes such a comparison.
https://github.com/apache/pulsar/blob/8a40b30cf47a91ec02d931e6371d02409ba5951e/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java#L121

In addition, if the `handleCreateConsumer` method, which is executed when the consumer is reopened, is executed "after setting `waitingForZeroQueueSizeMessage` to true" and "before sending a flow permit", there is a possibility that the flow permit will be sent twice, so we lock `mutex_` to perform exclusive control.

#### receiveAsync

We can find the number of flow permits sent before the reconnection and the number of callbacks waiting for `receiveAsync` to complete by checking the number of elements in `pendingReceives_`.
https://github.com/apache/pulsar-client-cpp/blob/115d64af81ae26ae73aaba7aaba36d4a9e47324c/lib/ConsumerImpl.cc#L976-L981

Therefore, when a zero queue consumer is reopened, it should send the same number of flow permits as the elements of `pendingReceives_`.

In this case too, if `handleCreateConsumer` is executed "after adding an element to `pendingReceives_`" and "before sending a flow permit", it is possible that more flow permits will be sent than expected. So we need to lock `mutex_` in `receiveAsync` too.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-not-needed`