### PR TITLE
Adapt to latest Asio APIs (Asio 1.32 or Boost.Asio 1.88)

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -142,6 +142,11 @@ jobs:
       - name: Run unit tests
         run: RETRY_FAILED=3 CMAKE_BUILD_DIRECTORY=./build ./run-unit-tests.sh
 
+      - name: Build with Boost.Asio
+        run: |
+          cmake -B build-boost-asio -DINTEGRATE_VCPKG=ON -DBUILD_TESTS=ON
+          cmake --build build-boost-asio -j8
+
       - name: Build perf tools
         run: |
           cmake -B build -DINTEGRATE_VCPKG=ON -DBUILD_TESTS=ON -DBUILD_PERF_TOOLS=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,15 +19,19 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-option(USE_ASIO "Use Asio instead of Boost.Asio" OFF)
-
 option(INTEGRATE_VCPKG "Integrate with Vcpkg" OFF)
 if (INTEGRATE_VCPKG)
-    set(USE_ASIO ON)
+    option(USE_ASIO "Use Asio instead of Boost.Asio" ON)
     if (NOT CMAKE_TOOLCHAIN_FILE)
         set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
     endif ()
+    if (NOT USE_ASIO)
+        list(APPEND VCPKG_MANIFEST_FEATURES "boost-asio")
+    endif ()
+else ()
+    option(USE_ASIO "Use Asio instead of Boost.Asio" OFF)
 endif ()
+message(STATUS "USE_ASIO: ${USE_ASIO}")
 
 option(BUILD_TESTS "Build tests" ON)
 message(STATUS "BUILD_TESTS:  " ${BUILD_TESTS})

--- a/lib/AckGroupingTrackerEnabled.cc
+++ b/lib/AckGroupingTrackerEnabled.cc
@@ -121,8 +121,7 @@ AckGroupingTrackerEnabled::~AckGroupingTrackerEnabled() {
     this->flush();
     std::lock_guard<std::mutex> lock(this->mutexTimer_);
     if (this->timer_) {
-        ASIO_ERROR ec;
-        this->timer_->cancel(ec);
+        cancelTimer(*this->timer_);
     }
 }
 
@@ -172,7 +171,7 @@ void AckGroupingTrackerEnabled::scheduleTimer() {
 
     std::lock_guard<std::mutex> lock(this->mutexTimer_);
     this->timer_ = this->executor_->createDeadlineTimer();
-    this->timer_->expires_from_now(std::chrono::milliseconds(std::max(1L, this->ackGroupingTimeMs_)));
+    this->timer_->expires_after(std::chrono::milliseconds(std::max(1L, this->ackGroupingTimeMs_)));
     std::weak_ptr<AckGroupingTracker> weakSelf = shared_from_this();
     this->timer_->async_wait([this, weakSelf](const ASIO_ERROR& ec) -> void {
         auto self = weakSelf.lock();

--- a/lib/AsioTimer.h
+++ b/lib/AsioTimer.h
@@ -29,3 +29,12 @@
 #include "AsioDefines.h"
 
 using DeadlineTimerPtr = std::shared_ptr<ASIO::steady_timer>;
+
+inline void cancelTimer(ASIO::steady_timer& timer) {
+    try {
+        timer.cancel();
+    } catch (const ASIO_SYSTEM_ERROR& ignored) {
+        // Most of the time the exception can be ignored unless the following logic depends on the fact that
+        // the timer is cancelled.
+    }
+}

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -489,7 +489,11 @@ void ClientConnection::handleTcpConnected(const ASIO_ERROR& err, const tcp::endp
         }
     } else {
         LOG_ERROR(cnxString_ << "Failed to establish connection: " << err.message());
-        close(ResultRetryable);
+        if (err == ASIO::error::operation_aborted) {
+            close();
+        } else {
+            close(ResultRetryable);
+        }
     }
 }
 
@@ -620,7 +624,7 @@ void ClientConnection::handleResolve(ASIO_ERROR err, const tcp::resolver::result
         }
         ptr->connectTimeoutTask_->stop();
     });
-
+    connectTimeoutTask_->start();
     ASIO::async_connect(*socket_, results, [weakSelf](const ASIO_ERROR& err, const tcp::endpoint& endpoint) {
         auto self = weakSelf.lock();
         if (self) {

--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -178,13 +178,7 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
       executor_(executor),
       resolver_(executor_->createTcpResolver()),
       socket_(executor_->createSocket()),
-#if defined(USE_ASIO) || BOOST_VERSION >= 107000
       strand_(ASIO::make_strand(executor_->getIOService().get_executor())),
-#elif BOOST_VERSION >= 106600
-      strand_(executor_->getIOService().get_executor()),
-#else
-      strand_(executor_->getIOService()),
-#endif
       logicalAddress_(logicalAddress),
       physicalAddress_(physicalAddress),
       cnxString_("[<none> -> " + physicalAddress + "] "),

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -238,7 +238,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
      * although not usable at this point, since this is just tcp connection
      * Pulsar - Connect/Connected has yet to happen
      */
-    void handleTcpConnected(const ASIO_ERROR& err, ASIO::ip::tcp::resolver::iterator endpointIterator);
+    void handleTcpConnected(const ASIO_ERROR& err, const ASIO::ip::tcp::endpoint& endpoint);
 
     void handleHandshake(const ASIO_ERROR& err);
 
@@ -261,7 +261,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
 
     void handlePulsarConnected(const proto::CommandConnected& cmdConnected);
 
-    void handleResolve(const ASIO_ERROR& err, const ASIO::ip::tcp::resolver::iterator& endpointIterator);
+    void handleResolve(ASIO_ERROR err, const ASIO::ip::tcp::resolver::results_type& results);
 
     void handleSend(const ASIO_ERROR& err, const SharedBuffer& cmd);
     void handleSendPair(const ASIO_ERROR& err);

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -26,13 +26,13 @@
 #include <cstdint>
 #ifdef USE_ASIO
 #include <asio/bind_executor.hpp>
-#include <asio/io_service.hpp>
+#include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
 #include <asio/ssl/stream.hpp>
 #include <asio/strand.hpp>
 #else
 #include <boost/asio/bind_executor.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/strand.hpp>
@@ -325,7 +325,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
      */
     SocketPtr socket_;
     TlsSocketPtr tlsSocket_;
-    ASIO::strand<ASIO::io_service::executor_type> strand_;
+    ASIO::strand<ASIO::io_context::executor_type> strand_;
 
     const std::string logicalAddress_;
     /*

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -423,7 +423,7 @@ void ConsumerImpl::discardChunkMessages(const std::string& uuid, const MessageId
 }
 
 void ConsumerImpl::triggerCheckExpiredChunkedTimer() {
-    checkExpiredChunkedTimer_->expires_from_now(milliseconds(expireTimeOfIncompleteChunkedMessageMs_));
+    checkExpiredChunkedTimer_->expires_after(milliseconds(expireTimeOfIncompleteChunkedMessageMs_));
     std::weak_ptr<ConsumerImplBase> weakSelf{shared_from_this()};
     checkExpiredChunkedTimer_->async_wait([this, weakSelf](const ASIO_ERROR& ec) -> void {
         auto self = weakSelf.lock();
@@ -1690,7 +1690,7 @@ void ConsumerImpl::internalGetLastMessageIdAsync(const BackoffPtr& backoff, Time
         }
         remainTime -= next;
 
-        timer->expires_from_now(next);
+        timer->expires_after(next);
 
         auto self = shared_from_this();
         timer->async_wait([this, backoff, remainTime, timer, next, callback,
@@ -1814,9 +1814,8 @@ std::shared_ptr<ConsumerImpl> ConsumerImpl::get_shared_this_ptr() {
 }
 
 void ConsumerImpl::cancelTimers() noexcept {
-    ASIO_ERROR ec;
-    batchReceiveTimer_->cancel(ec);
-    checkExpiredChunkedTimer_->cancel(ec);
+    cancelTimer(*batchReceiveTimer_);
+    cancelTimer(*checkExpiredChunkedTimer_);
     unAckedMessageTrackerPtr_->stop();
     consumerStatsBasePtr_->stop();
 }

--- a/lib/ConsumerImplBase.cc
+++ b/lib/ConsumerImplBase.cc
@@ -49,7 +49,7 @@ ConsumerImplBase::ConsumerImplBase(const ClientImplPtr& client, const std::strin
 
 void ConsumerImplBase::triggerBatchReceiveTimerTask(long timeoutMs) {
     if (timeoutMs > 0) {
-        batchReceiveTimer_->expires_from_now(std::chrono::milliseconds(timeoutMs));
+        batchReceiveTimer_->expires_after(std::chrono::milliseconds(timeoutMs));
         std::weak_ptr<ConsumerImplBase> weakSelf{shared_from_this()};
         batchReceiveTimer_->async_wait([weakSelf](const ASIO_ERROR& ec) {
             auto self = weakSelf.lock();

--- a/lib/ExecutorService.cc
+++ b/lib/ExecutorService.cc
@@ -38,8 +38,8 @@ void ExecutorService::start() {
             try {
                 io_context_.run();
                 LOG_DEBUG("Event loop of ExecutorService exits successfully");
-            } catch (const ASIO_ERROR &e) {
-                LOG_ERROR("Failed to run io_context: " << e.message());
+            } catch (const ASIO_SYSTEM_ERROR &e) {
+                LOG_ERROR("Failed to run io_context: " << e.what());
             }
         }
         {

--- a/lib/ExecutorService.cc
+++ b/lib/ExecutorService.cc
@@ -31,17 +31,16 @@ ExecutorService::~ExecutorService() { close(0); }
 void ExecutorService::start() {
     auto self = shared_from_this();
     std::thread t{[this, self] {
-        LOG_DEBUG("Run io_service in a single thread");
-        ASIO_ERROR ec;
+        LOG_DEBUG("Run io_context in a single thread");
         while (!closed_) {
-            io_service_.restart();
-            IOService::work work{getIOService()};
-            io_service_.run(ec);
-        }
-        if (ec) {
-            LOG_ERROR("Failed to run io_service: " << ec.message());
-        } else {
-            LOG_DEBUG("Event loop of ExecutorService exits successfully");
+            io_context_.restart();
+            auto work_guard = ASIO::make_work_guard(io_context_);
+            try {
+                io_context_.run();
+                LOG_DEBUG("Event loop of ExecutorService exits successfully");
+            } catch (const ASIO_ERROR &e) {
+                LOG_ERROR("Failed to run io_context: " << e.message());
+            }
         }
         {
             std::lock_guard<std::mutex> lock{mutex_};
@@ -63,12 +62,12 @@ ExecutorServicePtr ExecutorService::create() {
 }
 
 /*
- *  factory method of ASIO::ip::tcp::socket associated with io_service_ instance
+ *  factory method of ASIO::ip::tcp::socket associated with io_context_ instance
  *  @ returns shared_ptr to this socket
  */
 SocketPtr ExecutorService::createSocket() {
     try {
-        return SocketPtr(new ASIO::ip::tcp::socket(io_service_));
+        return SocketPtr(new ASIO::ip::tcp::socket(io_context_));
     } catch (const ASIO_SYSTEM_ERROR &e) {
         restart();
         auto error = std::string("Failed to create socket: ") + e.what();
@@ -82,12 +81,12 @@ TlsSocketPtr ExecutorService::createTlsSocket(SocketPtr &socket, ASIO::ssl::cont
 }
 
 /*
- *  factory method of Resolver object associated with io_service_ instance
+ *  factory method of Resolver object associated with io_context_ instance
  *  @returns shraed_ptr to resolver object
  */
 TcpResolverPtr ExecutorService::createTcpResolver() {
     try {
-        return TcpResolverPtr(new ASIO::ip::tcp::resolver(io_service_));
+        return TcpResolverPtr(new ASIO::ip::tcp::resolver(io_context_));
     } catch (const ASIO_SYSTEM_ERROR &e) {
         restart();
         auto error = std::string("Failed to create resolver: ") + e.what();
@@ -97,7 +96,7 @@ TcpResolverPtr ExecutorService::createTcpResolver() {
 
 DeadlineTimerPtr ExecutorService::createDeadlineTimer() {
     try {
-        return DeadlineTimerPtr(new ASIO::steady_timer(io_service_));
+        return DeadlineTimerPtr(new ASIO::steady_timer(io_context_));
     } catch (const ASIO_SYSTEM_ERROR &e) {
         restart();
         auto error = std::string("Failed to create steady_timer: ") + e.what();
@@ -105,7 +104,7 @@ DeadlineTimerPtr ExecutorService::createDeadlineTimer() {
     }
 }
 
-void ExecutorService::restart() { io_service_.stop(); }
+void ExecutorService::restart() { io_context_.stop(); }
 
 void ExecutorService::close(long timeoutMs) {
     bool expectedState = false;
@@ -113,12 +112,12 @@ void ExecutorService::close(long timeoutMs) {
         return;
     }
     if (timeoutMs == 0) {  // non-blocking
-        io_service_.stop();
+        io_context_.stop();
         return;
     }
 
     std::unique_lock<std::mutex> lock{mutex_};
-    io_service_.stop();
+    io_context_.stop();
     if (timeoutMs > 0) {
         cond_.wait_for(lock, std::chrono::milliseconds(timeoutMs), [this] { return ioServiceDone_; });
     } else {  // < 0
@@ -126,7 +125,7 @@ void ExecutorService::close(long timeoutMs) {
     }
 }
 
-void ExecutorService::postWork(std::function<void(void)> task) { io_service_.post(task); }
+void ExecutorService::postWork(std::function<void(void)> task) { ASIO::post(io_context_, std::move(task)); }
 
 /////////////////////
 

--- a/lib/ExecutorService.h
+++ b/lib/ExecutorService.h
@@ -23,11 +23,11 @@
 
 #include <atomic>
 #ifdef USE_ASIO
-#include <asio/io_service.hpp>
+#include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
 #include <asio/ssl.hpp>
 #else
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
 #endif
@@ -46,7 +46,7 @@ typedef std::shared_ptr<ASIO::ssl::stream<ASIO::ip::tcp::socket &> > TlsSocketPt
 typedef std::shared_ptr<ASIO::ip::tcp::resolver> TcpResolverPtr;
 class PULSAR_PUBLIC ExecutorService : public std::enable_shared_from_this<ExecutorService> {
    public:
-    using IOService = ASIO::io_service;
+    using IOService = ASIO::io_context;
     using SharedPtr = std::shared_ptr<ExecutorService>;
 
     static SharedPtr create();
@@ -67,14 +67,14 @@ class PULSAR_PUBLIC ExecutorService : public std::enable_shared_from_this<Execut
     // See TimeoutProcessor for the semantics of the parameter.
     void close(long timeoutMs = 3000);
 
-    IOService &getIOService() { return io_service_; }
+    IOService &getIOService() { return io_context_; }
     bool isClosed() const noexcept { return closed_; }
 
    private:
     /*
-     * io_service is our interface to os, io object schedule async ops on this object
+     * io_context is our interface to os, io object schedule async ops on this object
      */
-    IOService io_service_;
+    IOService io_context_;
 
     std::atomic_bool closed_{false};
     std::mutex mutex_;

--- a/lib/JsonUtils.h
+++ b/lib/JsonUtils.h
@@ -28,14 +28,7 @@ template <typename Ptree>
 inline std::string toJson(const Ptree& pt) {
     std::ostringstream oss;
     boost::property_tree::write_json(oss, pt, false);
-    // For Boost < 1.86, boost::property_tree will write a endline at the end
-#if BOOST_VERSION < 108600
-    auto s = oss.str();
-    s.pop_back();
-    return s;
-#else
     return oss.str();
-#endif
 }
 
 }  // namespace pulsar

--- a/lib/MultiTopicsConsumerImpl.cc
+++ b/lib/MultiTopicsConsumerImpl.cc
@@ -507,7 +507,7 @@ void MultiTopicsConsumerImpl::closeAsync(const ResultCallback& originalCallback)
     failPendingBatchReceiveCallback();
 
     // cancel timer
-    batchReceiveTimer_->cancel();
+    cancelTimer(*batchReceiveTimer_);
 }
 
 void MultiTopicsConsumerImpl::messageReceived(const Consumer& consumer, const Message& msg) {
@@ -973,7 +973,7 @@ uint64_t MultiTopicsConsumerImpl::getNumberOfConnectedConsumer() {
     return numberOfConnectedConsumer;
 }
 void MultiTopicsConsumerImpl::runPartitionUpdateTask() {
-    partitionsUpdateTimer_->expires_from_now(partitionsUpdateInterval_);
+    partitionsUpdateTimer_->expires_after(partitionsUpdateInterval_);
     auto weakSelf = weak_from_this();
     partitionsUpdateTimer_->async_wait([weakSelf](const ASIO_ERROR& ec) {
         // If two requests call runPartitionUpdateTask at the same time, the timer will fail, and it
@@ -1126,8 +1126,7 @@ void MultiTopicsConsumerImpl::beforeConnectionChange(ClientConnection& cnx) {
 
 void MultiTopicsConsumerImpl::cancelTimers() noexcept {
     if (partitionsUpdateTimer_) {
-        ASIO_ERROR ec;
-        partitionsUpdateTimer_->cancel(ec);
+        cancelTimer(*partitionsUpdateTimer_);
     }
 }
 

--- a/lib/Murmur3_32Hash.cc
+++ b/lib/Murmur3_32Hash.cc
@@ -23,8 +23,8 @@
 // the orignal MurmurHash3 source code.
 #include "Murmur3_32Hash.h"
 
-#include <boost/version.hpp>
 #include <boost/predef.h>
+
 #include <limits>
 
 #if BOOST_COMP_MSVC

--- a/lib/Murmur3_32Hash.cc
+++ b/lib/Murmur3_32Hash.cc
@@ -24,11 +24,7 @@
 #include "Murmur3_32Hash.h"
 
 #include <boost/version.hpp>
-#if BOOST_VERSION >= 105500
 #include <boost/predef.h>
-#else
-#include <boost/detail/endian.hpp>
-#endif
 #include <limits>
 
 #if BOOST_COMP_MSVC

--- a/lib/NegativeAcksTracker.cc
+++ b/lib/NegativeAcksTracker.cc
@@ -56,7 +56,7 @@ void NegativeAcksTracker::scheduleTimer() {
         return;
     }
     std::weak_ptr<NegativeAcksTracker> weakSelf{shared_from_this()};
-    timer_->expires_from_now(timerInterval_);
+    timer_->expires_after(timerInterval_);
     timer_->async_wait([weakSelf](const ASIO_ERROR &ec) {
         if (auto self = weakSelf.lock()) {
             self->handleTimer(ec);
@@ -135,8 +135,7 @@ void NegativeAcksTracker::add(const MessageId &m) {
 
 void NegativeAcksTracker::close() {
     closed_ = true;
-    ASIO_ERROR ec;
-    timer_->cancel(ec);
+    cancelTimer(*timer_);
     std::lock_guard<std::mutex> lock(mutex_);
     nackedMessages_.clear();
 }

--- a/lib/PartitionedProducerImpl.cc
+++ b/lib/PartitionedProducerImpl.cc
@@ -421,7 +421,7 @@ void PartitionedProducerImpl::flushAsync(FlushCallback callback) {
 
 void PartitionedProducerImpl::runPartitionUpdateTask() {
     auto weakSelf = weak_from_this();
-    partitionsUpdateTimer_->expires_from_now(partitionsUpdateInterval_);
+    partitionsUpdateTimer_->expires_after(partitionsUpdateInterval_);
     partitionsUpdateTimer_->async_wait([weakSelf](const ASIO_ERROR& ec) {
         auto self = weakSelf.lock();
         if (self) {
@@ -524,8 +524,7 @@ uint64_t PartitionedProducerImpl::getNumberOfConnectedProducer() {
 
 void PartitionedProducerImpl::cancelTimers() noexcept {
     if (partitionsUpdateTimer_) {
-        ASIO_ERROR ec;
-        partitionsUpdateTimer_->cancel(ec);
+        cancelTimer(*partitionsUpdateTimer_);
     }
 }
 

--- a/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/lib/PatternMultiTopicsConsumerImpl.cc
@@ -48,7 +48,7 @@ const PULSAR_REGEX_NAMESPACE::regex PatternMultiTopicsConsumerImpl::getPattern()
 
 void PatternMultiTopicsConsumerImpl::resetAutoDiscoveryTimer() {
     autoDiscoveryRunning_ = false;
-    autoDiscoveryTimer_->expires_from_now(seconds(conf_.getPatternAutoDiscoveryPeriod()));
+    autoDiscoveryTimer_->expires_after(seconds(conf_.getPatternAutoDiscoveryPeriod()));
 
     auto weakSelf = weak_from_this();
     autoDiscoveryTimer_->async_wait([weakSelf](const ASIO_ERROR& err) {
@@ -232,7 +232,7 @@ void PatternMultiTopicsConsumerImpl::start() {
     LOG_DEBUG("PatternMultiTopicsConsumerImpl start autoDiscoveryTimer_.");
 
     if (conf_.getPatternAutoDiscoveryPeriod() > 0) {
-        autoDiscoveryTimer_->expires_from_now(seconds(conf_.getPatternAutoDiscoveryPeriod()));
+        autoDiscoveryTimer_->expires_after(seconds(conf_.getPatternAutoDiscoveryPeriod()));
         auto weakSelf = weak_from_this();
         autoDiscoveryTimer_->async_wait([weakSelf](const ASIO_ERROR& err) {
             if (auto self = weakSelf.lock()) {
@@ -252,7 +252,4 @@ void PatternMultiTopicsConsumerImpl::closeAsync(const ResultCallback& callback) 
     MultiTopicsConsumerImpl::closeAsync(callback);
 }
 
-void PatternMultiTopicsConsumerImpl::cancelTimers() noexcept {
-    ASIO_ERROR ec;
-    autoDiscoveryTimer_->cancel(ec);
-}
+void PatternMultiTopicsConsumerImpl::cancelTimers() noexcept { cancelTimer(*autoDiscoveryTimer_); }

--- a/lib/RetryableOperation.h
+++ b/lib/RetryableOperation.h
@@ -68,8 +68,7 @@ class RetryableOperation : public std::enable_shared_from_this<RetryableOperatio
 
     void cancel() {
         promise_.setFailed(ResultDisconnected);
-        ASIO_ERROR ec;
-        timer_->cancel(ec);
+        cancelTimer(*timer_);
     }
 
    private:
@@ -107,7 +106,7 @@ class RetryableOperation : public std::enable_shared_from_this<RetryableOperatio
             }
 
             auto delay = std::min(backoff_.next(), remainingTime);
-            timer_->expires_from_now(delay);
+            timer_->expires_after(delay);
 
             auto nextRemainingTime = remainingTime - delay;
             LOG_INFO("Reschedule " << name_ << " for " << toMillis(delay)

--- a/lib/SharedBuffer.h
+++ b/lib/SharedBuffer.h
@@ -151,11 +151,11 @@ class SharedBuffer {
 
     inline bool writable() const { return writableBytes() > 0; }
 
-    ASIO::const_buffers_1 const_asio_buffer() const {
-        return ASIO::const_buffers_1(ptr_ + readIdx_, readableBytes());
+    ASIO::const_buffer const_asio_buffer() const {
+        return ASIO::const_buffer(ptr_ + readIdx_, readableBytes());
     }
 
-    ASIO::mutable_buffers_1 asio_buffer() {
+    ASIO::mutable_buffer asio_buffer() {
         assert(data_);
         return ASIO::buffer(ptr_ + writeIdx_, writableBytes());
     }

--- a/lib/UnAckedMessageTrackerEnabled.cc
+++ b/lib/UnAckedMessageTrackerEnabled.cc
@@ -38,7 +38,7 @@ void UnAckedMessageTrackerEnabled::timeoutHandler() {
     }
     ExecutorServicePtr executorService = client->getIOExecutorProvider()->get();
     timer_ = executorService->createDeadlineTimer();
-    timer_->expires_from_now(std::chrono::milliseconds(tickDurationInMs_));
+    timer_->expires_after(std::chrono::milliseconds(tickDurationInMs_));
     std::weak_ptr<UnAckedMessageTrackerEnabled> weakSelf{shared_from_this()};
     timer_->async_wait([weakSelf](const ASIO_ERROR& ec) {
         auto self = weakSelf.lock();
@@ -177,9 +177,8 @@ void UnAckedMessageTrackerEnabled::clear() {
 }
 
 void UnAckedMessageTrackerEnabled::stop() {
-    ASIO_ERROR ec;
     if (timer_) {
-        timer_->cancel(ec);
+        cancelTimer(*timer_);
     }
 }
 } /* namespace pulsar */

--- a/lib/checksum/crc32c_sse42.cc
+++ b/lib/checksum/crc32c_sse42.cc
@@ -15,18 +15,8 @@
  ******************************************************************************/
 #include "crc32c_sse42.h"
 
-#include <boost/version.hpp>
-#if BOOST_VERSION >= 105500
-#include <boost/predef.h>
-#else
-#if _MSC_VER
-#pragma message("Boost version is < 1.55, disable CRC32C")
-#else
-#warning "Boost version is < 1.55, disable CRC32C"
-#endif
-#endif
-
 #include <assert.h>
+#include <boost/predef.h>
 #include <stdlib.h>
 
 #include "gf2.hpp"

--- a/lib/stats/ConsumerStatsImpl.cc
+++ b/lib/stats/ConsumerStatsImpl.cc
@@ -59,7 +59,7 @@ void ConsumerStatsImpl::flushAndReset(const ASIO_ERROR& ec) {
     LOG_INFO(oss.str());
 }
 
-ConsumerStatsImpl::~ConsumerStatsImpl() { timer_->cancel(); }
+ConsumerStatsImpl::~ConsumerStatsImpl() { cancelTimer(*timer_); }
 
 void ConsumerStatsImpl::start() { scheduleTimer(); }
 
@@ -80,7 +80,7 @@ void ConsumerStatsImpl::messageAcknowledged(Result res, CommandAck_AckType ackTy
 }
 
 void ConsumerStatsImpl::scheduleTimer() {
-    timer_->expires_from_now(std::chrono::seconds(statsIntervalInSeconds_));
+    timer_->expires_after(std::chrono::seconds(statsIntervalInSeconds_));
     std::weak_ptr<ConsumerStatsImpl> weakSelf{shared_from_this()};
     timer_->async_wait([this, weakSelf](const ASIO_ERROR& ec) {
         auto self = weakSelf.lock();

--- a/lib/stats/ConsumerStatsImpl.h
+++ b/lib/stats/ConsumerStatsImpl.h
@@ -55,10 +55,7 @@ class ConsumerStatsImpl : public std::enable_shared_from_this<ConsumerStatsImpl>
     ConsumerStatsImpl(const ConsumerStatsImpl& stats);
     void flushAndReset(const ASIO_ERROR&);
     void start() override;
-    void stop() override {
-        ASIO_ERROR error;
-        timer_->cancel(error);
-    }
+    void stop() override { cancelTimer(*timer_); }
     void receivedMessage(Message&, Result) override;
     void messageAcknowledged(Result, CommandAck_AckType, uint32_t ackNums) override;
     virtual ~ConsumerStatsImpl();

--- a/lib/stats/ProducerStatsImpl.cc
+++ b/lib/stats/ProducerStatsImpl.cc
@@ -106,10 +106,10 @@ void ProducerStatsImpl::messageReceived(Result res, const ptime& publishTime) {
     totalSendMap_[res] += 1;  // Value will automatically be initialized to 0 in the constructor
 }
 
-ProducerStatsImpl::~ProducerStatsImpl() { timer_->cancel(); }
+ProducerStatsImpl::~ProducerStatsImpl() { cancelTimer(*timer_); }
 
 void ProducerStatsImpl::scheduleTimer() {
-    timer_->expires_from_now(std::chrono::seconds(statsIntervalInSeconds_));
+    timer_->expires_after(std::chrono::seconds(statsIntervalInSeconds_));
     std::weak_ptr<ProducerStatsImpl> weakSelf{shared_from_this()};
     timer_->async_wait([this, weakSelf](const ASIO_ERROR& ec) {
         auto self = weakSelf.lock();

--- a/lib/stats/ProducerStatsImpl.h
+++ b/lib/stats/ProducerStatsImpl.h
@@ -20,15 +20,14 @@
 #ifndef PULSAR_PRODUCER_STATS_IMPL_HEADER
 #define PULSAR_PRODUCER_STATS_IMPL_HEADER
 
-#include <map>
-
-#include <boost/serialization/array_wrapper.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/framework/accumulator_set.hpp>
 #include <boost/accumulators/framework/features.hpp>
 #include <boost/accumulators/statistics.hpp>
 #include <boost/accumulators/statistics/extended_p_square.hpp>
+#include <boost/serialization/array_wrapper.hpp>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <vector>

--- a/lib/stats/ProducerStatsImpl.h
+++ b/lib/stats/ProducerStatsImpl.h
@@ -22,9 +22,7 @@
 
 #include <map>
 
-#if BOOST_VERSION >= 106400
 #include <boost/serialization/array_wrapper.hpp>
-#endif
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/framework/accumulator_set.hpp>
 #include <boost/accumulators/framework/features.hpp>

--- a/tests/AuthPluginTest.cc
+++ b/tests/AuthPluginTest.cc
@@ -370,7 +370,7 @@ class SocketStream {
 
 void mockZTS(Latch& latch, int port) {
     LOG_INFO("-- MockZTS started");
-    ASIO::io_service io;
+    ASIO::io_context io;
     ASIO::ip::tcp::acceptor acceptor(io, ASIO::ip::tcp::endpoint(ASIO::ip::tcp::v4(), port));
 
     LOG_INFO("-- MockZTS waiting for connnection");

--- a/tests/ConsumerTest.h
+++ b/tests/ConsumerTest.h
@@ -46,8 +46,8 @@ class ConsumerTest {
             return nullptr;
         }
         auto timer = cnx->executor_->createDeadlineTimer();
-        timer->expires_from_now(delaySinceStartGrabCnx -
-                                std::chrono::milliseconds(impl->connectionTimeMs_ + 50));
+        timer->expires_after(delaySinceStartGrabCnx -
+                             std::chrono::milliseconds(impl->connectionTimeMs_ + 50));
         timer->async_wait([cnx](const ASIO_ERROR&) { cnx->close(); });
         return timer;
     }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,19 +9,19 @@
       "features": [
         "openssl"
       ],
-      "version>=": "1.28.2"
+      "version>=": "1.32.0"
     },
     {
       "name": "boost-accumulators",
-      "version>=": "1.83.0"
+      "version>=": "1.88.0"
     },
     {
       "name": "boost-format",
-      "version>=": "1.83.0"
+      "version>=": "1.88.0"
     },
     {
       "name": "boost-property-tree",
-      "version>=": "1.83.0"
+      "version>=": "1.88.0"
     },
     {
       "name": "curl",
@@ -61,12 +61,21 @@
     }
   ],
   "features": {
+    "boost-asio": {
+      "description": "Use Boost.Asio instead of standalone Asio",
+      "dependencies": [
+        {
+          "name": "boost-asio",
+          "version>=": "1.88.0"
+        }
+      ]
+    },
     "perf": {
       "description": "Build Performance Tool",
       "dependencies": [
         {
           "name": "boost-program-options",
-          "version>=": "1.83.0"
+          "version>=": "1.88.0"
         }
       ]
     },
@@ -81,10 +90,6 @@
     }
   },
   "overrides": [
-    {
-      "name": "asio",
-      "version": "1.28.2"
-    },
     {
       "name": "protobuf",
       "version": "3.21.12"


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-cpp/issues/475

### Motivation

There were some breaking changes with Boost.Asio APIs so that the code base is incompatible with the latest Boost.Asio.

### Modifications

- Upgrade the Asio and Boost.Asio dependencies
- Support verifying build with Boost.Asio (non-default) in CI, whose version (1.88) has deprecated some APIs
- Replace deprecated (removed) APIs with the recommended new Asio APIs, including
  - Replace iterator based `async_connect` method with the `async_connect` function that accepts the list of endpoints from the latest `async_resolve` method. This also simplifies the code that it no longer needs to manually retry each endpoint, which might fix the issue like https://github.com/apache/pulsar-client-cpp/issues/502
  - Replace `io_service` with `io_context`
  - Replace `io_service::work` with `make_work_guard`
  - Replace `expires_from_now` with `expires_after` for `steady_timer`, a wrapped `cancelTimer` function is used to simplify the `try-catch` clause
  - Replace `rfc2818_verification` with `host_name_verification`
- Remove `BOOST_VERSION` conditional compilation, which makes code hard to maintain due to the Asio API compatibility changes.