### PR TITLE
fix: ignore ping command in connection keepalive logic

### DIFF
--- a/lib/ClientConnection.cc
+++ b/lib/ClientConnection.cc
@@ -924,7 +924,9 @@ void ClientConnection::handleIncomingCommand(BaseCommand& incomingCmd) {
         case Ready: {
             // Since we are receiving data from the connection, we are assuming that for now the
             // connection is still working well.
-            havePendingPingRequest_ = false;
+            if (incomingCmd.type() != BaseCommand::PING) {
+                havePendingPingRequest_ = false;
+            }
 
             // Handle normal commands
             switch (incomingCmd.type()) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #479 

### Motivation

The current keepalive logic is too lenient – merely receiving ping commands can keep the connection alive.

### Modifications

Ignore ping command in connection keepalive logic.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework without any test coverage. It is not easy to write a test for ClientConnection but the change is simple.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
Bug fix only.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
