### PR TITLE
Fix multi-topics-consumer new topic listeners stuck in paused state

### DIFF
--- a/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/lib/PatternMultiTopicsConsumerImpl.cc
@@ -118,6 +118,9 @@ void PatternMultiTopicsConsumerImpl::timerGetTopicsOfNamespace(const Result resu
     // callback method when added topics all subscribed.
     ResultCallback topicsAddedCallback = [this, topicsRemoved, topicsRemovedCallback](Result result) {
         if (result == ResultOk) {
+            if(messageListener_) {
+                resumeMessageListener();
+            }
             // call to unsubscribe all removed topics.
             onTopicsRemoved(topicsRemoved, topicsRemovedCallback);
         } else {

--- a/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/lib/PatternMultiTopicsConsumerImpl.cc
@@ -118,7 +118,7 @@ void PatternMultiTopicsConsumerImpl::timerGetTopicsOfNamespace(const Result resu
     // callback method when added topics all subscribed.
     ResultCallback topicsAddedCallback = [this, topicsRemoved, topicsRemovedCallback](Result result) {
         if (result == ResultOk) {
-            if(messageListener_) {
+            if (messageListener_) {
                 resumeMessageListener();
             }
             // call to unsubscribe all removed topics.


### PR DESCRIPTION
This was introduced in v3.7.0 via #447, which contained a change that attempted to fix an issue where a pre-mature ack of a message before a multi-topic subscriber was ready could have caused a crash.  To fix the original bug, all multi-topic subscriptions are started with their message listener paused. They later get un-paused once all topics are successfully subscribed and connected.  However, on a regex subscription when new topics are discovered, they also start in a paused state, and there's no mechanism to resume them.  Hence, they get stuck, and no messages for new topics will be processed.

This change adds a call to resume any new listeners after new topics are added.  The fix has been deployed to production in my company's infrastructure and has been confirmed working for a few weeks.

### Verifying this change

I could not get the tests to pass with a bare checkout of master no matter what I did.  The first few tests were extremely flaky, so I commented them out.  The OAuth tests require sudo and wanted to modify my root certificates, which I'm not about to allow, so I commented that out.  And the broker tests always segfault in the `BasicEndToEndTest.testUnAckedMessageTrackerEnabledIndividualAck` test.  I gave up trying to mess with the tests - I've confirmed the fix works in my environment and our tests pass, so I was satisfied.  Just trying to upstream this bugfix... 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
Simple regression bug fix

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
