### PR TITLE
Bump curl, openssl, zlib to address CVEs

### DIFF
--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         # TODO: support build on macos-14
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     steps:
       - name: checkout

--- a/lib/HTTPLookupService.cc
+++ b/lib/HTTPLookupService.cc
@@ -26,6 +26,7 @@
 #include "CurlWrapper.h"
 #include "ExecutorService.h"
 #include "Int64SerDes.h"
+#include "JsonUtils.h"
 #include "LogUtils.h"
 #include "NamespaceName.h"
 #include "SchemaUtils.h"
@@ -409,15 +410,8 @@ void HTTPLookupService::handleGetSchemaHTTPRequest(GetSchemaPromise promise, con
                 promise.setFailed(ResultInvalidMessage);
                 return;
             }
-            std::stringstream keyStream;
-            ptree::write_json(keyStream, kvRoot.get_child("key"), false);
-            std::stringstream valueStream;
-            ptree::write_json(valueStream, kvRoot.get_child("value"), false);
-            auto keyData = keyStream.str();
-            auto valueData = valueStream.str();
-            // Remove the last line break.
-            keyData.pop_back();
-            valueData.pop_back();
+            const auto keyData = toJson(kvRoot.get_child("key"));
+            const auto valueData = toJson(kvRoot.get_child("value"));
             schemaData = mergeKeyValueSchema(keyData, valueData);
         }
 

--- a/lib/JsonUtils.h
+++ b/lib/JsonUtils.h
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include <boost/property_tree/json_parser.hpp>
+#include <sstream>
+#include <string>
+
+namespace pulsar {
+
+template <typename Ptree>
+inline std::string toJson(const Ptree& pt) {
+    std::ostringstream oss;
+    boost::property_tree::write_json(oss, pt, false);
+    // For Boost < 1.86, boost::property_tree will write a endline at the end
+#if BOOST_VERSION < 108600
+    auto s = oss.str();
+    s.pop_back();
+    return s;
+#else
+    return oss.str();
+#endif
+}
+
+}  // namespace pulsar

--- a/lib/Schema.cc
+++ b/lib/Schema.cc
@@ -25,11 +25,10 @@
 #include <map>
 #include <memory>
 
+#include "JsonUtils.h"
 #include "SchemaUtils.h"
 
 using boost::property_tree::ptree;
-using boost::property_tree::read_json;
-using boost::property_tree::write_json;
 
 PULSAR_PUBLIC std::ostream &operator<<(std::ostream &s, pulsar::SchemaType schemaType) {
     return s << strSchemaType(schemaType);
@@ -170,11 +169,7 @@ SchemaInfo::SchemaInfo(const SchemaInfo &keySchema, const SchemaInfo &valueSchem
         for (auto &entry : properties) {
             pt.put(entry.first, entry.second);
         }
-        std::ostringstream buf;
-        write_json(buf, pt, false);
-        auto s = buf.str();
-        s.pop_back();
-        return s;
+        return toJson(pt);
     };
 
     StringMap properties;

--- a/perf/PerfConsumer.cc
+++ b/perf/PerfConsumer.cc
@@ -19,6 +19,8 @@
 #include <lib/LogUtils.h>
 DECLARE_LOG_OBJECT()
 
+// Don't remove this line because p_square_quantile.hpp requires including <algorithm> on some platforms
+#include <algorithm>
 #include <chrono>
 #include <fstream>
 #include <functional>

--- a/perf/PerfProducer.cc
+++ b/perf/PerfProducer.cc
@@ -19,6 +19,8 @@
 #include <lib/LogUtils.h>
 DECLARE_LOG_OBJECT()
 
+// Don't remove this line because p_square_quantile.hpp requires including <algorithm> on some platforms
+#include <algorithm>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
 #include <boost/accumulators/statistics/p_square_quantile.hpp>

--- a/pkg/mac/build-static-library.sh
+++ b/pkg/mac/build-static-library.sh
@@ -48,7 +48,7 @@ git commit -m "Update version"
 COMMIT_ID=$(git log --pretty=oneline | head -n 1 | awk '{print $1}')
 cd ..
 sed -i.bak "s/.*builtin-baseline.*/  \"builtin-baseline\": \"$COMMIT_ID\",/" vcpkg.json
-sed -i.bak "s/\"version>=\": \"8\.4\.0\"/\"version>=\": \"8.4.0#1\"/" vcpkg.json
+sed -i.bak "s/\"version>=\": \"8\.13\.0#1\"/\"version>=\": \"8.13.0#2\"/" vcpkg.json
 
 INSTALL_DIR=$PWD/pkg/mac/.install
 set -x

--- a/pkg/mac/vcpkg-curl-patch.diff
+++ b/pkg/mac/vcpkg-curl-patch.diff
@@ -1,8 +1,8 @@
 diff --git a/ports/curl/portfile.cmake b/ports/curl/portfile.cmake
-index bdc544e9e..340d93865 100644
+index 427bccb217..ddfd75d30f 100644
 --- a/ports/curl/portfile.cmake
 +++ b/ports/curl/portfile.cmake
-@@ -64,6 +64,10 @@ if(VCPKG_TARGET_IS_WINDOWS)
+@@ -62,6 +62,10 @@ if(VCPKG_TARGET_IS_WINDOWS)
      list(APPEND OPTIONS -DENABLE_UNICODE=ON)
  endif()
  
@@ -10,18 +10,19 @@ index bdc544e9e..340d93865 100644
 +    list(APPEND OPTIONS -DENABLE_IPV6=OFF)
 +endif()
 +
+ vcpkg_find_acquire_program(PKGCONFIG)
+
  vcpkg_cmake_configure(
-     SOURCE_PATH "${SOURCE_PATH}"
-     OPTIONS 
 diff --git a/ports/curl/vcpkg.json b/ports/curl/vcpkg.json
-index e028d3897..a63858e34 100644
+index 31955859d0..50e619b846 100644
 --- a/ports/curl/vcpkg.json
 +++ b/ports/curl/vcpkg.json
-@@ -1,6 +1,7 @@
+@@ -1,7 +1,7 @@
  {
    "name": "curl",
-   "version": "8.4.0",
-+  "port-version": 1,
+   "version": "8.13.0",
+-  "port-version": 1,
++  "port-version": 2,
    "description": "A library for transferring data with URLs",
    "homepage": "https://curl.se/",
    "license": "curl AND ISC AND BSD-3-Clause",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -29,7 +29,7 @@
       "features": [
         "openssl"
       ],
-      "version>=": "8.13.0"
+      "version>=": "8.13.0#1"
     },
     {
       "name": "dlfcn-win32",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "pulsar-cpp",
-  "version": "3.5.0",
+  "version": "3.8.0",
   "description": "Pulsar C++ SDK",
-  "builtin-baseline": "b051745c68faa6f65c493371d564c4eb8af34dad",
+  "builtin-baseline": "d6995a0cf3cafda5e9e52749fad075dd62bfd90c",
   "dependencies": [
     {
       "name": "asio",
@@ -16,6 +16,10 @@
       "version>=": "1.83.0"
     },
     {
+      "name": "boost-format",
+      "version>=": "1.83.0"
+    },
+    {
       "name": "boost-property-tree",
       "version>=": "1.83.0"
     },
@@ -25,7 +29,7 @@
       "features": [
         "openssl"
       ],
-      "version>=": "8.4.0"
+      "version>=": "8.13.0"
     },
     {
       "name": "dlfcn-win32",
@@ -33,7 +37,7 @@
     },
     {
       "name": "openssl",
-      "version>=": "3.1.4#1"
+      "version>=": "3.5.0"
     },
     {
       "name": "protobuf",
@@ -45,7 +49,7 @@
     },
     {
       "name": "zlib",
-      "version>=": "1.3"
+      "version>=": "1.3.1"
     },
     {
       "name": "zstd",
@@ -71,5 +75,15 @@
         }
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "asio",
+      "version": "1.28.2"
+    },
+    {
+      "name": "protobuf",
+      "version": "3.21.12"
+    }
+  ]
 }


### PR DESCRIPTION
- openssl 3.1.4 -> 3.5.0
- zlib 1.3 -> 1.3.1
- curl 8.4.0 -> 8.13.0

Keep the `protobuf` to an old version (3.21.12) because it's the last release that supports C++11, see https://protobuf.dev/news/2022-08-03/

Keep the `asio` version not changed (1.28.2) because there are some APIs removed.