### PR TITLE
Fix hasMessageAvailable incorrectly returns true when read to latest after seeking by timestamp

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -1588,7 +1588,7 @@ void ConsumerImpl::hasMessageAvailableAsync(const HasMessageAvailableCallback& c
             // If the start message id is latest, we should seek to the actual last message first.
             (startMessageId_.get().value_or(MessageId::earliest()) == MessageId::latest() ||
              // If there is a previous seek operation by timestamp, the start message id will be incorrect, so
-             // we cannot compare the start positin with the last position.
+             // we cannot compare the start position with the last position.
              hasSoughtByTimestamp());
     }
     if (compareMarkDeletePosition) {

--- a/lib/ConsumerImpl.h
+++ b/lib/ConsumerImpl.h
@@ -266,6 +266,7 @@ class ConsumerImpl : public ConsumerImplBase {
     Synchronized<MessageId> seekMessageId_{MessageId::earliest()};
     std::atomic<bool> hasSoughtByTimestamp_{false};
 
+    bool hasSoughtByTimestamp() const { return hasSoughtByTimestamp_.load(std::memory_order_acquire); }
     bool duringSeek() const { return seekStatus_ != SeekStatus::NOT_STARTED; }
 
     class ChunkedMessageCtx {

--- a/tests/ReaderTest.cc
+++ b/tests/ReaderTest.cc
@@ -885,6 +885,16 @@ TEST_F(ReaderSeekTest, testHasMessageAvailableAfterSeekTimestamp) {
         createReader(reader, msgId);
         ASSERT_EQ(ResultOk, reader.seek(timestampBeforeSend));
         EXPECT_HAS_MESSAGE_AVAILABLE(reader, true);
+
+        bool hasMessageAvailable;
+        while (true) {
+            ASSERT_EQ(ResultOk, reader.hasMessageAvailable(hasMessageAvailable));
+            if (!hasMessageAvailable) {
+                break;
+            }
+            Message msg;
+            ASSERT_EQ(ResultOk, reader.readNext(msg, 3000));
+        }
     }
 
     // Test `hasMessageAvailableAsync` will complete immediately if the incoming message queue is non-empty


### PR DESCRIPTION
The computation for `compareMarkDeletePosition` is wrong that `hasSoughtByTimestamp_` should only be checked when `lastDequedMessageId_` is `earliest`, which means no messages have been received.

Additionally, reset `startMessageId_` when seeking by timestamp, otherwise, if the initial `startMessageId` of a reader is a valid message id, that message could be filtered in https://github.com/apache/pulsar-client-cpp/blob/9b86f9e2b037015cc437abc2f5f8b9475846bf95/lib/ConsumerImpl.cc#L619-L625 or https://github.com/apache/pulsar-client-cpp/blob/9b86f9e2b037015cc437abc2f5f8b9475846bf95/lib/ConsumerImpl.cc#L774-L780

Improve `testHasMessageAvailableAfterSeekTimestamp` to cover the cases above.