### PR TITLE
fix: remove unnecessary copies

### DIFF
--- a/lib/NegativeAcksTracker.cc
+++ b/lib/NegativeAcksTracker.cc
@@ -88,9 +88,9 @@ void NegativeAcksTracker::handleTimer(const ASIO_ERROR &ec) {
             break;
         }
 
-        auto ledgerMap = it->second;
+        auto &ledgerMap = it->second;
         for (auto ledgerIt = ledgerMap.begin(); ledgerIt != ledgerMap.end(); ++ledgerIt) {
-            auto entrySet = ledgerIt->second;
+            auto &entrySet = ledgerIt->second;
             for (auto setIt = entrySet.begin(); setIt != entrySet.end(); ++setIt) {
                 messagesToRedeliver.insert(
                     MessageIdBuilder().ledgerId(ledgerIt->first).entryId(*setIt).build());


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Remove unnecessary copies from PR https://github.com/apache/pulsar-client-cpp/pull/497

[lib/NegativeAcksTracker.cc](https://github.com/apache/pulsar-client-cpp/pull/497/files/fe435c918874b0c1447c59ab8a5511b5ea36c604#diff-eaa00d87a3e2e87777561ceb10d136ad1d227957e72c763fdabc1a7ec1572e15)

        auto ledgerMap = it->second;
        for (auto ledgerIt = ledgerMap.begin(); ledgerIt != ledgerMap.end(); ++ledgerIt) {
            auto entrySet = ledgerIt->second;

>This makes a copy. Is this intended to be a reference instead - `auto& entrySet = ledgerIt->second;`?
This line also makes a copy `auto ledgerMap = it->second;
_Originally posted by @arhoads in https://github.com/apache/pulsar-client-cpp/pull/497#discussion_r2274220029_

<!-- or this PR is one task of an issue -->


### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
