### PR TITLE
Fix flaky testHasMessageAvailableWhenCreated

### DIFF
--- a/tests/ReaderTest.cc
+++ b/tests/ReaderTest.cc
@@ -645,6 +645,7 @@ TEST_P(ReaderTest, testHasMessageAvailableWhenCreated) {
 
     ProducerConfiguration producerConf;
     producerConf.setBatchingMaxMessages(3);
+    producerConf.setPartitionsRoutingMode(ProducerConfiguration::UseSinglePartition);
     Producer producer;
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producerConf, producer));
 


### PR DESCRIPTION
`testHasMessageAvailableWhenCreated` could only succeed when all messages are sent to the same partition, but after #507 the default routing mode changes to a round robin approach with switch latency. Then there is only a little chance that it will succeed. 