### PR TITLE
[fix][ProtobufNativeSchema] Fix build by converting abseil string_view to std::string

### DIFF
--- a/lib/ProtobufNativeSchema.cc
+++ b/lib/ProtobufNativeSchema.cc
@@ -39,8 +39,8 @@ SchemaInfo createProtobufNativeSchema(const google::protobuf::Descriptor* descri
     }
 
     const auto fileDescriptor = descriptor->file();
-    const std::string& rootMessageTypeName = descriptor->full_name();
-    const std::string& rootFileDescriptorName = fileDescriptor->name();
+    const std::string& rootMessageTypeName = std::string(descriptor->full_name());
+    const std::string& rootFileDescriptorName = std::string(fileDescriptor->name());
 
     FileDescriptorSet fileDescriptorSet;
     internalCollectFileDescriptors(fileDescriptor, fileDescriptorSet);


### PR DESCRIPTION
Fixes #478 

### Motivation

Our `libpulsar` builds started failing with latest upstream dependencies (abseil-cpp/protobuf). After creating this patch, I noticed @cho-m had already reported an issue and suggested a couple fixes, which are likely better than this. But that was months ago, so I figured I'd open a PR to push the conversation forward.

### Modifications

Explicitly convert absl string_view to std::string for use in the schemaJson.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
No user-visible changes.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
