### PR TITLE
[fix][client-cpp] Fix Reader segfault when messageListenerThreads=0

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -622,6 +622,11 @@ void ConsumerImpl::messageReceived(const ClientConnectionPtr& cnx, const proto::
     if (state == Closing || state == Closed) {
         return;
     }
+    if (!listenerExecutor_) {
+        LOG_ERROR(getName() << " listenerExecutor_ is null, discarding message to avoid null dereference");
+        increaseAvailablePermits(cnx);
+        return;
+    }
     uint32_t numOfMessageReceived = m.impl_->metadata.num_messages_in_batch();
     if (ackGroupingTrackerPtr_->isDuplicate(m.getMessageId())) {
         LOG_DEBUG(getName() << " Ignoring message as it was ACKed earlier by same consumer.");
@@ -663,8 +668,10 @@ void ConsumerImpl::messageReceived(const ClientConnectionPtr& cnx, const proto::
             return;
         }
         // Trigger message listener callback in a separate thread
-        while (numOfMessageReceived--) {
-            listenerExecutor_->postWork(std::bind(&ConsumerImpl::internalListener, get_shared_this_ptr()));
+        if (listenerExecutor_) {
+            while (numOfMessageReceived--) {
+                listenerExecutor_->postWork(std::bind(&ConsumerImpl::internalListener, get_shared_this_ptr()));
+            }
         }
     }
 }
@@ -713,8 +720,12 @@ void ConsumerImpl::executeNotifyCallback(Message& msg) {
 
     // has pending receive, direct callback.
     if (asyncReceivedWaiting) {
-        listenerExecutor_->postWork(std::bind(&ConsumerImpl::notifyPendingReceivedCallback,
-                                              get_shared_this_ptr(), ResultOk, msg, callback));
+        if (listenerExecutor_) {
+            listenerExecutor_->postWork(std::bind(&ConsumerImpl::notifyPendingReceivedCallback,
+                                                  get_shared_this_ptr(), ResultOk, msg, callback));
+        } else {
+            notifyPendingReceivedCallback(ResultOk, msg, callback);
+        }
         return;
     }
 

--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -670,7 +670,8 @@ void ConsumerImpl::messageReceived(const ClientConnectionPtr& cnx, const proto::
         // Trigger message listener callback in a separate thread
         if (listenerExecutor_) {
             while (numOfMessageReceived--) {
-                listenerExecutor_->postWork(std::bind(&ConsumerImpl::internalListener, get_shared_this_ptr()));
+                listenerExecutor_->postWork(
+                    std::bind(&ConsumerImpl::internalListener, get_shared_this_ptr()));
             }
         }
     }

--- a/lib/ExecutorService.cc
+++ b/lib/ExecutorService.cc
@@ -18,6 +18,8 @@
  */
 #include "ExecutorService.h"
 
+#include <algorithm>
+
 #include "LogUtils.h"
 #include "TimeUtils.h"
 DECLARE_LOG_OBJECT()
@@ -130,9 +132,12 @@ void ExecutorService::postWork(std::function<void(void)> task) { ASIO::post(io_c
 /////////////////////
 
 ExecutorServiceProvider::ExecutorServiceProvider(int nthreads)
-    : executors_(nthreads), executorIdx_(0), mutex_() {}
+    : executors_(std::max(1, nthreads)), executorIdx_(0), mutex_() {}
 
 ExecutorServicePtr ExecutorServiceProvider::get(size_t idx) {
+    if (executors_.empty()) {
+        return nullptr;
+    }
     idx %= executors_.size();
     Lock lock(mutex_);
 

--- a/tests/ReaderTest.cc
+++ b/tests/ReaderTest.cc
@@ -964,8 +964,7 @@ TEST(ReaderTest, testReaderWithZeroMessageListenerThreads) {
     clientConf.setMessageListenerThreads(0);
     Client client(serviceUrl, clientConf);
 
-    const std::string topicName =
-        "testReaderWithZeroMessageListenerThreads-" + std::to_string(time(nullptr));
+    const std::string topicName = "testReaderWithZeroMessageListenerThreads-" + std::to_string(time(nullptr));
 
     Producer producer;
     ASSERT_EQ(ResultOk, client.createProducer(topicName, producer));

--- a/tests/ReaderTest.cc
+++ b/tests/ReaderTest.cc
@@ -18,6 +18,7 @@
  */
 #include <gtest/gtest.h>
 #include <pulsar/Client.h>
+#include <pulsar/ClientConfiguration.h>
 #include <pulsar/Reader.h>
 #include <time.h>
 
@@ -953,6 +954,51 @@ TEST_F(ReaderSeekTest, testSeekInclusiveChunkMessage) {
     };
     assertStartMessageId(true, firstMsgId);
     assertStartMessageId(false, secondMsgId);
+}
+
+// Regression test for segfault when Reader is used with messageListenerThreads=0.
+// Verifies ExecutorServiceProvider(0) does not cause undefined behavior and
+// ConsumerImpl::messageReceived does not dereference null listenerExecutor_.
+TEST(ReaderTest, testReaderWithZeroMessageListenerThreads) {
+    ClientConfiguration clientConf;
+    clientConf.setMessageListenerThreads(0);
+    Client client(serviceUrl, clientConf);
+
+    const std::string topicName =
+        "testReaderWithZeroMessageListenerThreads-" + std::to_string(time(nullptr));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topicName, producer));
+
+    ReaderConfiguration readerConf;
+    Reader reader;
+    ASSERT_EQ(ResultOk, client.createReader(topicName, MessageId::earliest(), readerConf, reader));
+
+    constexpr int numMessages = 5;
+    for (int i = 0; i < numMessages; i++) {
+        Message msg = MessageBuilder().setContent("msg-" + std::to_string(i)).build();
+        ASSERT_EQ(ResultOk, producer.send(msg));
+    }
+
+    int received = 0;
+    for (int i = 0; i < numMessages + 2; i++) {
+        bool hasMessageAvailable = false;
+        ASSERT_EQ(ResultOk, reader.hasMessageAvailable(hasMessageAvailable));
+        if (!hasMessageAvailable) {
+            break;
+        }
+        Message msg;
+        Result res = reader.readNext(msg, 3000);
+        ASSERT_EQ(ResultOk, res) << "readNext failed at iteration " << i;
+        std::string content = msg.getDataAsString();
+        EXPECT_EQ("msg-" + std::to_string(received), content);
+        ++received;
+    }
+    EXPECT_EQ(received, numMessages);
+
+    producer.close();
+    reader.close();
+    client.close();
 }
 
 INSTANTIATE_TEST_SUITE_P(Pulsar, ReaderTest, ::testing::Values(true, false));

--- a/tests/RetryableOperationCacheTest.cc
+++ b/tests/RetryableOperationCacheTest.cc
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <stdexcept>
 
+#include "lib/ExecutorService.h"
 #include "lib/RetryableOperationCache.h"
 
 namespace pulsar {
@@ -81,6 +82,17 @@ class RetryableOperationCacheTest : public ::testing::Test {
 }  // namespace pulsar
 
 using namespace pulsar;
+
+// Regression test: ExecutorServiceProvider(0) must not cause undefined behavior (e.g. idx % 0).
+// After fix, nthreads is clamped to at least 1, so get() returns a valid executor.
+TEST(ExecutorServiceProviderTest, ZeroThreadsReturnsValidExecutor) {
+    ExecutorServiceProviderPtr provider = std::make_shared<ExecutorServiceProvider>(0);
+    for (int i = 0; i < 3; i++) {
+        ExecutorServicePtr executor = provider->get();
+        ASSERT_NE(executor, nullptr) << "get() must not return null when created with 0 threads (clamped to 1)";
+    }
+    provider->close();
+}
 
 TEST_F(RetryableOperationCacheTest, testRetry) {
     auto cache = RetryableOperationCache<int>::create(provider_, std::chrono::seconds(30));

--- a/tests/RetryableOperationCacheTest.cc
+++ b/tests/RetryableOperationCacheTest.cc
@@ -89,7 +89,8 @@ TEST(ExecutorServiceProviderTest, ZeroThreadsReturnsValidExecutor) {
     ExecutorServiceProviderPtr provider = std::make_shared<ExecutorServiceProvider>(0);
     for (int i = 0; i < 3; i++) {
         ExecutorServicePtr executor = provider->get();
-        ASSERT_NE(executor, nullptr) << "get() must not return null when created with 0 threads (clamped to 1)";
+        ASSERT_NE(executor, nullptr)
+            << "get() must not return null when created with 0 threads (clamped to 1)";
     }
     provider->close();
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes #500 

<!-- If there is an existing GitHub issue for "Reader segfault in messageReceived with messageListenerThreads=0", put the issue number above; otherwise remove the Fixes line or leave as Fixes #<xyz> -->

### Motivation

When using a Reader with `ClientConfiguration::setMessageListenerThreads(0)` (or when the listener executor is otherwise null), the application can crash with a segmentation fault in `ConsumerImpl::messageReceived()`. Two root causes were identified:

1. **ExecutorServiceProvider(0)** – When `getMessageListenerThreads()` is 0, the provider is constructed with an empty executor list. In `get()`, the code does `idx %= executors_.size()`, which is **undefined behavior** when `size() == 0` (division by zero). This can lead to wrong or null executor pointers.

2. **Null listenerExecutor_** – The Reader creates its internal consumer with a null `ExecutorServicePtr`. The consumer then falls back to `client->getListenerExecutorProvider()->get()`. If that returns null (e.g. due to the above), `messageReceived` and `executeNotifyCallback` call `listenerExecutor_->postWork(...)` without a null check, causing a null pointer dereference (SIGSEGV at address 0x0).

This was observed in the wild with Reader usage (e.g. periodic `hasMessageAvailable()` and `readNext()`) under moderate to high load or long runtime, with stack traces pointing at `pulsar::ConsumerImpl::messageReceived`.

### Modifications

- **lib/ExecutorService.cc**
  - Construct with `executors_(std::max(1, nthreads))` so the executor list is never empty when `nthreads == 0`, avoiding undefined behavior in `get()`.
  - In `get()`, add an early `if (executors_.empty()) return nullptr;` guard before using `executors_.size()`.
  - Add `#include <algorithm>` for `std::max`.

- **lib/ConsumerImpl.cc**
  - In `messageReceived()`, after the closing-state check, add a check for null `listenerExecutor_`: log an error, call `increaseAvailablePermits(cnx)`, and return to avoid dereferencing null.
  - In the `messageListener_` block, only call `listenerExecutor_->postWork(...)` when `listenerExecutor_` is non-null.
  - In `executeNotifyCallback()`, when notifying a pending async receive: if `listenerExecutor_` is non-null, post the callback as before; otherwise call `notifyPendingReceivedCallback(...)` on the current thread so the callback is still invoked and no null dereference occurs.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- **ExecutorServiceProviderTest.ZeroThreadsReturnsValidExecutor** (unit test, no broker): Creates `ExecutorServiceProvider(0)`, calls `get()` three times, and asserts each return is non-null. Confirms that 0-thread configuration no longer leads to undefined behavior and that a valid executor is always returned.
- **ReaderTest.testReaderWithZeroMessageListenerThreads** (integration test, requires Pulsar broker): Creates a `Client` with `setMessageListenerThreads(0)`, creates a Reader, produces several messages, then in a loop calls `hasMessageAvailable()` and `readNext()` until all messages are consumed. Asserts the correct count and content. Verifies that Reader path with 0 listener threads does not segfault and delivers messages correctly.

Run the unit test (no broker):

```bash
./tests/pulsar-tests --gtest_filter='ExecutorServiceProviderTest.ZeroThreadsReturnsValidExecutor'
```

Run the Reader integration test (with broker at `pulsar://localhost:6650`):

```bash
./tests/pulsar-tests --gtest_filter='ReaderTest.testReaderWithZeroMessageListenerThreads'
```

### Documentation

- [ ] `doc-required`

- [x] `doc-not-needed`  
  (Behavior change is internal and backward-compatible: 0 listener threads is now handled safely; no API or user-facing doc update required.)

- [ ] `doc`

- [ ] `doc-complete`
