### PR TITLE
[fix][client-cpp] Fail producers immediately when topic is terminated

### DIFF
--- a/lib/HandlerBase.cc
+++ b/lib/HandlerBase.cc
@@ -171,6 +171,7 @@ void HandlerBase::handleDisconnection(Result result, const ClientConnectionPtr& 
         case Closing:
         case Closed:
         case Producer_Fenced:
+        case Terminated:
         case Failed:
             LOG_DEBUG(getName() << "Ignoring connection closed event since the handler is not used anymore");
             break;

--- a/lib/HandlerBase.h
+++ b/lib/HandlerBase.h
@@ -138,6 +138,8 @@ class HandlerBase : public std::enable_shared_from_this<HandlerBase> {
         Failed,           // Handler is failed, in Java client: HandlerState.State.Failed
         Producer_Fenced,  // The producer has been fenced by the broker
                           // in Java client: HandlerState.State.ProducerFenced
+        Terminated,       // The topic has been terminatedproducer has been fenced by the broker
+                          // in Java client: HandlerState.State.Terminated
     };
 
     std::atomic<State> state_;

--- a/lib/ProducerImpl.cc
+++ b/lib/ProducerImpl.cc
@@ -273,8 +273,8 @@ Result ProducerImpl::handleCreateProducer(const ClientConnectionPtr& cnx, Result
             }
         }
 
-        if (result == ResultProducerFenced) {
-            state_ = Producer_Fenced;
+        if (result == ResultProducerFenced || result == ResultTopicTerminated) {
+            state_ = result == ResultProducerFenced ? Producer_Fenced : Terminated;
             failPendingMessages(result, false);
             auto client = client_.lock();
             if (client) {
@@ -449,6 +449,9 @@ bool ProducerImpl::isValidProducerState(const SendCallback& callback) const {
             return false;
         case HandlerBase::Producer_Fenced:
             callback(ResultProducerFenced, {});
+            return false;
+        case HandlerBase::Terminated:
+            callback(ResultTopicTerminated, {});
             return false;
         case HandlerBase::NotStarted:
         case HandlerBase::Failed:

--- a/lib/ResultUtils.h
+++ b/lib/ResultUtils.h
@@ -39,6 +39,7 @@ inline bool isResultRetryable(Result result) {
                                                       ResultInvalidConfiguration,
                                                       ResultIncompatibleSchema,
                                                       ResultTopicNotFound,
+                                                      ResultTopicTerminated,
                                                       ResultOperationNotSupported,
                                                       ResultNotAllowedError,
                                                       ResultChecksumError,

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -215,6 +215,53 @@ TEST(ProducerTest, testBacklogQuotasExceeded) {
     client.close();
 }
 
+TEST(ProducerTest, testCreateProducerAfterTopicTermination) {
+    const auto topicName =
+        "testCreateProducerAfterTopicTermination-" + std::to_string(time(nullptr));
+    const auto topic = "persistent://public/default/" + topicName;
+
+    Client client(serviceUrl, ClientConfiguration().setOperationTimeoutSeconds(1));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic, producer));
+    ASSERT_EQ(ResultOk, producer.send(MessageBuilder().setContent("content").build()));
+    ASSERT_EQ(ResultOk, producer.close());
+
+    const auto httpCode =
+        makePostRequest(adminUrl + "admin/v2/persistent/public/default/" + topicName + "/terminate", "");
+    ASSERT_EQ(200, httpCode) << "httpCode: " << httpCode;
+
+    Producer terminatedProducer;
+    ASSERT_EQ(ResultTopicTerminated, client.createProducer(topic, terminatedProducer));
+
+    client.close();
+}
+
+TEST(ProducerTest, testSendAfterTopicTerminationReconnect) {
+    const auto topicName =
+        "testSendAfterTopicTerminationReconnect-" + std::to_string(time(nullptr));
+    const auto topic = "persistent://public/default/" + topicName;
+
+    Client client(serviceUrl, ClientConfiguration().setOperationTimeoutSeconds(1));
+
+    Producer producer;
+    ASSERT_EQ(ResultOk, client.createProducer(topic, producer));
+    ASSERT_EQ(ResultOk, producer.send(MessageBuilder().setContent("before-terminate").build()));
+
+    const auto httpCode =
+        makePostRequest(adminUrl + "admin/v2/persistent/public/default/" + topicName + "/terminate", "");
+    ASSERT_EQ(200, httpCode) << "httpCode: " << httpCode;
+
+    PulsarFriend::getProducerImpl(producer).disconnectProducer();
+    ASSERT_TRUE(waitUntil(std::chrono::seconds(3),
+                          [&producer] { return PulsarFriend::isTerminated(producer); }));
+
+    ASSERT_EQ(ResultTopicTerminated,
+              producer.send(MessageBuilder().setContent("after-terminate").build()));
+
+    client.close();
+}
+
 class ProducerTest : public ::testing::TestWithParam<bool> {};
 
 TEST_P(ProducerTest, testMaxMessageSize) {

--- a/tests/ProducerTest.cc
+++ b/tests/ProducerTest.cc
@@ -216,8 +216,7 @@ TEST(ProducerTest, testBacklogQuotasExceeded) {
 }
 
 TEST(ProducerTest, testCreateProducerAfterTopicTermination) {
-    const auto topicName =
-        "testCreateProducerAfterTopicTermination-" + std::to_string(time(nullptr));
+    const auto topicName = "testCreateProducerAfterTopicTermination-" + std::to_string(time(nullptr));
     const auto topic = "persistent://public/default/" + topicName;
 
     Client client(serviceUrl, ClientConfiguration().setOperationTimeoutSeconds(1));
@@ -238,8 +237,7 @@ TEST(ProducerTest, testCreateProducerAfterTopicTermination) {
 }
 
 TEST(ProducerTest, testSendAfterTopicTerminationReconnect) {
-    const auto topicName =
-        "testSendAfterTopicTerminationReconnect-" + std::to_string(time(nullptr));
+    const auto topicName = "testSendAfterTopicTerminationReconnect-" + std::to_string(time(nullptr));
     const auto topic = "persistent://public/default/" + topicName;
 
     Client client(serviceUrl, ClientConfiguration().setOperationTimeoutSeconds(1));
@@ -253,11 +251,10 @@ TEST(ProducerTest, testSendAfterTopicTerminationReconnect) {
     ASSERT_EQ(200, httpCode) << "httpCode: " << httpCode;
 
     PulsarFriend::getProducerImpl(producer).disconnectProducer();
-    ASSERT_TRUE(waitUntil(std::chrono::seconds(3),
-                          [&producer] { return PulsarFriend::isTerminated(producer); }));
+    ASSERT_TRUE(
+        waitUntil(std::chrono::seconds(3), [&producer] { return PulsarFriend::isTerminated(producer); }));
 
-    ASSERT_EQ(ResultTopicTerminated,
-              producer.send(MessageBuilder().setContent("after-terminate").build()));
+    ASSERT_EQ(ResultTopicTerminated, producer.send(MessageBuilder().setContent("after-terminate").build()));
 
     client.close();
 }

--- a/tests/PulsarFriend.h
+++ b/tests/PulsarFriend.h
@@ -257,6 +257,11 @@ class PulsarFriend {
         return waitUntil(std::chrono::seconds(3),
                          [producerImpl] { return !producerImpl->getCnx().expired(); });
     }
+
+    static bool isTerminated(Producer producer) {
+        auto producerImpl = std::dynamic_pointer_cast<ProducerImpl>(producer.impl_);
+        return producerImpl && producerImpl->state_ == HandlerBase::Terminated;
+    }
 };
 }  // namespace pulsar
 


### PR DESCRIPTION
Fixes #566

### Motivation

When a topic is terminated, producer operations should fail immediately with `ResultTopicTerminated`. Before this change, the C++ client could treat `ResultTopicTerminated` as retryable during producer creation and reconnection flows, which caused retries until the operation timed out instead of surfacing the terminal condition immediately.

### Modifications

- Treat `ResultTopicTerminated` as a non-retryable producer error.
- Return the terminal result during producer creation and disconnection/reconnection handling.
- Reject later sends from a terminated producer with `ResultTopicTerminated`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added `ProducerTest.testCreateProducerAfterTopicTermination`
- Added `ProducerTest.testSendAfterTopicTerminationReconnect`
- These tests are included in the standard CI `unit-tests` job.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [X] `doc-not-needed` 
This change only adjusts producer error handling for terminated topics and does not require user-facing documentation changes.

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
