### PR TITLE
[fix][client-cpp] Restore pulsar/Version.h for the dev package

### DIFF
--- a/pkg/deb/build-deb.sh
+++ b/pkg/deb/build-deb.sh
@@ -63,6 +63,7 @@ cmake --build build -j8
 cp build/lib/libpulsar.a lib/libpulsar.a
 cp build/lib/libpulsar.so lib/libpulsar.so
 cp build/libpulsarwithdeps.a lib/libpulsarwithdeps.a
+cp build/include/pulsar/Version.h include/pulsar/Version.h
 popd
 
 DEST_DIR=apache-pulsar-client
@@ -95,6 +96,7 @@ mkdir -p $DEVEL_DEST_DIR/usr/share/doc/pulsar-client-dev-$VERSION
 ls $CPP_DIR/lib/libpulsar*
 
 cp -ar $CPP_DIR/include/pulsar $DEVEL_DEST_DIR/usr/include/
+cp $CPP_DIR/include/pulsar/Version.h $DEVEL_DEST_DIR/usr/include/
 cp $CPP_DIR/lib/libpulsar.a $DEVEL_DEST_DIR/usr/lib
 cp $CPP_DIR/lib/libpulsarwithdeps.a $DEVEL_DEST_DIR/usr/lib
 cp $CPP_DIR/lib/libpulsar.so $DEST_DIR/usr/lib


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #570 

### Motivation

My application using pulsar-client-cpp reads the version number to generate some diagnostic logs. This worked fine when I was building pulsar-client-cpp from source, but I've switched to building against the debian packages and the build failed when pulsar/Version.h was missing.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

The debian packaging scripts grab the headers from the source archive but the Version.h is generated from a template (Version.h.in) and so it is not present in the source archive. I've added a couple of file copy commands to make sure the file makes it into the final package.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

# Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 

- [x] `doc-not-needed` 
The documentation already states this header will be present

- [ ] `doc` 

- [ ] `doc-complete`
