### PR TITLE
[fix][cpp] Clear stale consumer connection after reconnect subscribe failure

### DIFF
--- a/lib/ConsumerImpl.cc
+++ b/lib/ConsumerImpl.cc
@@ -371,8 +371,9 @@ Result ConsumerImpl::handleCreateConsumer(const ClientConnectionPtr& cnx, Result
         }
 
         if (consumerCreatedPromise_.isComplete()) {
-            // Consumer had already been initially created, we need to retry connecting in any case
+            // Clear the connection set before SUBSCRIBE so the next reconnect is not skipped.
             LOG_WARN(getName() << "Failed to reconnect consumer: " << strResult(result));
+            resetCnx();
             handleResult = ResultRetryable;
         } else {
             // Consumer was not yet created, retry to connect to broker if it's possible

--- a/tests/ConsumerTest.cc
+++ b/tests/ConsumerTest.cc
@@ -1596,4 +1596,40 @@ TEST(ConsumerTest, testCloseAfterSeek) {
     anotherClient.close();
 }
 
+TEST(ConsumerTest, testIsConnectedFalsePositiveAfterSubscribeRejectedOnReconnect) {
+    // A reconnect SUBSCRIBE failure happens after the initial subscribe has already completed.
+    const std::string topic =
+        "persistent://public/default/test-false-positive-" + std::to_string(time(nullptr));
+    Client client(lookupUrl);
+    Consumer consumer;
+    ASSERT_EQ(ResultOk, client.subscribe(topic, "sub", consumer));
+    ASSERT_TRUE(consumer.isConnected()) << "Precondition: consumer should be connected";
+
+    auto& consumerImpl = PulsarFriend::getConsumerImpl(consumer);
+
+    // Capture the current live connection.
+    auto cnx = consumerImpl.getCnx().lock();
+    ASSERT_TRUE(cnx != nullptr) << "Precondition: cnx should be non-null";
+    LOG_INFO("Step 1 passed: consumer subscribed, cnx=" << cnx);
+
+    // Simulate the broker rejecting the SUBSCRIBE command during reconnect.
+    Result handleResult = PulsarFriend::consumerHandleCreateConsumer(consumer, cnx, ResultAuthorizationError);
+    LOG_INFO("Step 2: handleCreateConsumer returned " << handleResult);
+    EXPECT_EQ(ResultRetryable, handleResult)
+        << "handleCreateConsumer should return ResultRetryable for an already-created consumer";
+
+    // The failed SUBSCRIBE must clear the connection set before SUBSCRIBE.
+    auto cnxAfter = consumerImpl.getCnx().lock();
+    LOG_INFO("Step 3: cnx after handleCreateConsumer failure = " << cnxAfter);
+    LOG_INFO("Step 3: isConnected() = " << consumer.isConnected());
+
+    EXPECT_EQ(nullptr, cnxAfter)
+        << "After fix: connection_ must be cleared by resetCnx() so grabCnx() can retry";
+    EXPECT_FALSE(consumer.isConnected())
+        << "After fix: isConnected() must return false after SUBSCRIBE rejection";
+
+    consumer.close();
+    client.close();
+}
+
 }  // namespace pulsar

--- a/tests/PulsarFriend.h
+++ b/tests/PulsarFriend.h
@@ -102,6 +102,11 @@ class PulsarFriend {
         return *consumerImpl;
     }
 
+    static Result consumerHandleCreateConsumer(Consumer consumer, const ClientConnectionPtr& cnx,
+                                               Result result) {
+        return getConsumerImpl(consumer).handleCreateConsumer(cnx, result);
+    }
+
     static std::shared_ptr<ConsumerImpl> getConsumerImplPtr(Consumer consumer) {
         return std::static_pointer_cast<ConsumerImpl>(consumer.impl_);
     }


### PR DESCRIPTION
### Motivation

A consumer can be created successfully and consume messages for some time. Later, after a broker restart, namespace bundle unload, or topic ownership change, the client reconnects and sends a new broker-side `SUBSCRIBE` command for the existing consumer.

Before this fix, if that reconnect `SUBSCRIBE` failed, the local consumer could get stuck with `isConnected() == true` even though the broker no longer had an active consumer for the subscription.

### Failure path

```text
Initial subscribe succeeds; consumer is running
             |
             v
Broker restart / topic unload / ownership change
             |
             v
Old connection is closed or broker sends CLOSE_CONSUMER
             |
             v
HandlerBase::handleDisconnection() or ConsumerImpl::disconnectConsumer()
    -> resetCnx()
    -> scheduleReconnection()
             |
             v
lookup + TCP connect succeeds
             |
             v
ConsumerImpl::connectionOpened(cnx)
    -> setCnx(cnx)                 <-- connection_ is set before SUBSCRIBE
    -> cnx->registerConsumer()
    -> sendRequestWithId(SUBSCRIBE)
             |
             v
broker rejects SUBSCRIBE, for example:
    "Client is not authorized to subscribe"
    ResultUnknownError or ResultAuthorizationError
             |
             v
ConsumerImpl::handleCreateConsumer(cnx, result)
    consumerCreatedPromise_.isComplete() == true
    -> handleResult = ResultRetryable
    -> previously: connection_ was not cleared
             |
             v
HandlerBase connectionOpened listener
    isResultRetryable(ResultRetryable) == true
    -> scheduleReconnection()      <-- appears to retry
             |
             v
timer fires; HandlerBase::grabCnx()
    getCnx().lock() != nullptr     <-- stale connection_ is still set
    -> "Ignoring reconnection request since we're already connected"
    -> reconnectionPending_ = false
    -> no further reconnect attempt
             |
             v
ConsumerImpl::isConnected()
    = !getCnx().expired() && state_ == Ready
    = true && true
    = true                         <-- false positive
```

The key issue is that `connectionOpened()` sets `connection_` before the broker confirms the `SUBSCRIBE`. If the `SUBSCRIBE` fails for an already-created consumer, the reconnect path returns `ResultRetryable`, but the stale `connection_` must also be cleared. Otherwise the next reconnect attempt is skipped by `grabCnx()` because it sees a non-null connection.

### Changes

- Clear the stale consumer connection when an already-created consumer fails to re-subscribe during reconnect.
- Add a regression test that simulates a reconnect `SUBSCRIBE` rejection and verifies the stale connection is cleared and `isConnected()` returns false.
- Expose the internal `handleCreateConsumer()` path through `PulsarFriend` for the regression test.

### Validation

- `./build-support/docker-format.sh`
- Attempted `./build/tests/pulsar-tests --gtest_filter=ConsumerTest.testIsConnectedFalsePositiveAfterSubscribeRejectedOnReconnect`, but the local Pulsar service was not running on `localhost:6650`, so the test timed out during initial subscribe before reaching the regression path.