### PR TITLE
[fix][client-cpp] Fix TypedMessageTest to use receiveAsync<T> template overload with decoder

### DIFF
--- a/tests/TypedMessageTest.cc
+++ b/tests/TypedMessageTest.cc
@@ -65,15 +65,16 @@ TEST(TypedMessageTest, testReceive) {
             ASSERT_EQ(ResultOk, consumer.receive(msg, 3000, intDecoder));
         } else {
             Latch latch{1};
-            consumer.receiveAsync(
+            consumer.receiveAsync<int>(
                 [&latch, &msg, &msgMutex](Result result, const TypedMessage<int>& receivedMsg) {
                     ASSERT_EQ(ResultOk, result);
                     {
                         std::lock_guard<std::mutex> lock{msgMutex};
-                        msg = TypedMessage<int>{receivedMsg, intDecoder};
+                        msg = receivedMsg;
                     }
                     latch.countdown();
-                });
+                },
+                intDecoder);
             ASSERT_TRUE(latch.wait(std::chrono::seconds(1)));
         }
 

--- a/tests/TypedMessageTest.cc
+++ b/tests/TypedMessageTest.cc
@@ -65,7 +65,7 @@ TEST(TypedMessageTest, testReceive) {
             ASSERT_EQ(ResultOk, consumer.receive(msg, 3000, intDecoder));
         } else {
             Latch latch{1};
-            consumer.receiveAsync<int>(
+            std::function<void(Result result, const TypedMessage<int>&)> callback =
                 [&latch, &msg, &msgMutex](Result result, const TypedMessage<int>& receivedMsg) {
                     ASSERT_EQ(ResultOk, result);
                     {
@@ -73,8 +73,8 @@ TEST(TypedMessageTest, testReceive) {
                         msg = receivedMsg;
                     }
                     latch.countdown();
-                },
-                intDecoder);
+                };
+            consumer.receiveAsync<int>(callback, intDecoder);
             ASSERT_TRUE(latch.wait(std::chrono::seconds(1)));
         }
 


### PR DESCRIPTION

Fixes https://github.com/apache/pulsar-client-cpp/issues/466

Master Issue: https://github.com/apache/pulsar-client-cpp/pull/149

### Motivation

The `TypedMessageTest.testReceive` test was using `receiveAsync` incorrectly. It called the untyped `receiveAsync(const ReceiveCallback&)` overload (where `ReceiveCallback` is `std::function<void(Result, const Message&)>`), but the lambda's parameter was declared as `const TypedMessage<int>&` — a derived class reference. Since the actual argument passed at runtime is `const Message&`, this relies on an implicit downcast from base to derived, which is not guaranteed to work across compilers.

GCC 11+ happens to be permissive about this implicit conversion when constructing `std::function` from a lambda (it does not strictly enforce contravariance on parameter types during type erasure), so the code compiled successfully. However, GCC 8.x does not accept this conversion, causing a compilation failure (see #466).

The fix is to use the proper typed template overload `consumer.receiveAsync<int>(callback, intDecoder)`, which internally constructs `TypedMessage<int>{msg, decoder}` and passes it to the callback. This is both the intended API usage and portable across all GCC versions.

### Modifications

- Changed `consumer.receiveAsync(...)` to `consumer.receiveAsync<int>(..., intDecoder)` to use the correct typed template overload.
- Simplified the callback by directly assigning `msg = receivedMsg` instead of manually constructing `TypedMessage<int>{receivedMsg, intDecoder}`, since the decoder is now passed to `receiveAsync<T>` and applied internally.

### Verifying this change

This change is already covered by existing tests, such as `TypedMessageTest.testReceive` which validates the typed message receive flow including `receiveAsync<int>`.

### Documentation

- [x] `doc-not-needed` 
(This is a test fix only, no public API changes.)
