### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/ci-build-binary-artifacts.yaml
+++ b/.github/workflows/ci-build-binary-artifacts.yaml
@@ -31,7 +31,7 @@ jobs:
 
   package-linux:
     name: Build ${{matrix.pkg.name}} ${{matrix.cpu.platform}}
-    runs-on: ubuntu-22.04
+    runs-on: ${{matrix.cpu.runner}}
     timeout-minutes: 500
 
     strategy:
@@ -42,15 +42,20 @@ jobs:
           - { name: 'Deb', type: 'deb', path: 'pkg/deb/BUILD/DEB' }
           - { name: 'Alpine', type: 'apk', path: 'pkg/apk/build' }
         cpu:
-          - { arch: 'x86_64', platform: 'x86_64' }
-          - { arch: 'aarch64', platform: 'arm64' }
+          - { arch: 'x86_64', platform: 'x86_64', runner: 'ubuntu-22.04' }
+          - { arch: 'aarch64', platform: 'arm64', runner: 'ubuntu-22.04-arm' }
 
     steps:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/vcpkg/archives
+          key: vcpkg-linux-${{matrix.pkg.type}}-${{matrix.cpu.platform}}-${{hashFiles('vcpkg.json')}}
+          restore-keys: |
+            vcpkg-linux-${{matrix.pkg.type}}-${{matrix.cpu.platform}}-
 
       - name: Package Pulsar source
         run: build-support/generate-source-archive.sh
@@ -65,8 +70,8 @@ jobs:
           tags: build:latest
           platforms: linux/${{matrix.cpu.platform}}
           build-args: PLATFORM=${{matrix.cpu.arch}}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{matrix.pkg.type}}-${{matrix.cpu.platform}}
+          cache-to: type=gha,mode=max,scope=${{matrix.pkg.type}}-${{matrix.cpu.platform}}
 
       - name: Build packages
         run: pkg/${{matrix.pkg.type}}/docker-build-${{matrix.pkg.type}}-${{matrix.cpu.platform}}.sh build:latest
@@ -210,6 +215,14 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/vcpkg/archives
+          key: vcpkg-macos-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-macos-${{ matrix.arch }}-
 
       - name: Install dependencies
         run: |

--- a/build-support/download-release-artifacts.py
+++ b/build-support/download-release-artifacts.py
@@ -47,7 +47,7 @@ with requests.get(workflow_run_url, headers=headers) as response:
     for artifact in data['artifacts']:
         name = artifact['name']
         # Skip debug artifact
-        if name.endswith("-Debug"):
+        if name.endswith("-Debug") or name.find("dockerbuild") >= 0:
             continue
         dest_dir = os.path.join(dest_path, name)
         if name.find("windows") >= 0 and os.path.exists(dest_dir + ".tar.gz"):

--- a/pkg/apk/docker-build-apk-arm64.sh
+++ b/pkg/apk/docker-build-apk-arm64.sh
@@ -24,7 +24,9 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 IMAGE_NAME=${1:-apachepulsar/pulsar-build:alpine-3.16-arm64}
 
+mkdir -p $HOME/.cache/vcpkg/archives
 docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        -v $HOME/.cache/vcpkg/archives:/root/.cache/vcpkg/archives \
         --env PLATFORM=aarch64 \
         $IMAGE_NAME \
         /pulsar-client-cpp/pkg/apk/build-apk.sh

--- a/pkg/apk/docker-build-apk-x86_64.sh
+++ b/pkg/apk/docker-build-apk-x86_64.sh
@@ -24,7 +24,9 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 IMAGE_NAME=${1:-apachepulsar/pulsar-build:alpine-3.16-x86_64}
 
+mkdir -p $HOME/.cache/vcpkg/archives
 docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        -v $HOME/.cache/vcpkg/archives:/root/.cache/vcpkg/archives \
         --env PLATFORM=x86_64 \
         $IMAGE_NAME \
         /pulsar-client-cpp/pkg/apk/build-apk.sh

--- a/pkg/deb/docker-build-deb-arm64.sh
+++ b/pkg/deb/docker-build-deb-arm64.sh
@@ -24,7 +24,9 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 IMAGE_NAME=${1:-apachepulsar/pulsar-build:debian-9-2.11-arm64}
 
+mkdir -p $HOME/.cache/vcpkg/archives
 docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        -v $HOME/.cache/vcpkg/archives:/root/.cache/vcpkg/archives \
         --env PLATFORM=arm64 \
         $IMAGE_NAME \
         /pulsar-client-cpp/pkg/deb/build-deb.sh \

--- a/pkg/deb/docker-build-deb-x86_64.sh
+++ b/pkg/deb/docker-build-deb-x86_64.sh
@@ -24,7 +24,9 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 IMAGE_NAME=${1:-apachepulsar/pulsar-build:debian-9-2.11-x86_64}
 
+mkdir -p $HOME/.cache/vcpkg/archives
 docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        -v $HOME/.cache/vcpkg/archives:/root/.cache/vcpkg/archives \
         --env PLATFORM=amd64 \
         $IMAGE_NAME \
         /pulsar-client-cpp/pkg/deb/build-deb.sh \

--- a/pkg/rpm/docker-build-rpm-arm64.sh
+++ b/pkg/rpm/docker-build-rpm-arm64.sh
@@ -24,7 +24,9 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 IMAGE_NAME=${1:-apachepulsar/pulsar-build:centos-7-2.11-arm64}
 
+mkdir -p $HOME/.cache/vcpkg/archives
 docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        -v $HOME/.cache/vcpkg/archives:/root/.cache/vcpkg/archives \
         --env PLATFORM=aarch64 \
         $IMAGE_NAME \
         /pulsar-client-cpp/pkg/rpm/build-rpm.sh

--- a/pkg/rpm/docker-build-rpm-x86_64.sh
+++ b/pkg/rpm/docker-build-rpm-x86_64.sh
@@ -24,7 +24,9 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 IMAGE_NAME=${1:-apachepulsar/pulsar-build:centos-7-2.11-x86_64}
 
+mkdir -p $HOME/.cache/vcpkg/archives
 docker run -v $ROOT_DIR:/pulsar-client-cpp \
+        -v $HOME/.cache/vcpkg/archives:/root/.cache/vcpkg/archives \
         --env PLATFORM=x86_64 \
         $IMAGE_NAME \
         /pulsar-client-cpp/pkg/rpm/build-rpm.sh


### PR DESCRIPTION
fixes #585 
fixes #559

All changes are in place. Here's a summary of what was done:

---

## Changes Made

### 1. `ci-build-binary-artifacts.yaml`

**Fix 1 — Native arm64 runners:**
- Added `runner` field to the CPU matrix: `x86_64` → `ubuntu-22.04`, `arm64` → `ubuntu-22.04-arm`
- Changed `runs-on: ubuntu-22.04` → `runs-on: ${{matrix.cpu.runner}}`
- Removed `Set up QEMU` step entirely (not needed when each architecture runs on its own native runner)

**Fix 2 — vcpkg binary cache:**
- Added `actions/cache@v4` step to restore/save `~/.cache/vcpkg/archives` for all 6 Linux jobs (keyed by `pkg-type + arch + vcpkg.json hash`)
- Added the same for macOS (`~/Library/Caches/vcpkg/archives`)
- Fixed Docker GHA layer cache to use per-job `scope` to avoid the 6 matrix jobs thrashing each other's cache

### 2. All 6 `docker-build-{type}-{arch}.sh` scripts

- Added `mkdir -p $HOME/.cache/vcpkg/archives` before `docker run`
- Added `-v $HOME/.cache/vcpkg/archives:/root/.cache/vcpkg/archives` volume mount so vcpkg inside the container reads/writes the cache restored by `actions/cache` on the runner host

**Expected result:** On the next tag push, `protobuf:arm64-linux` should build in minutes on the native arm64 runner (vs 3.2 hours under QEMU), and subsequent runs will skip rebuilding already-cached packages entirely.