### PR TITLE
Use C++20-capable toolchains in the deb/rpm package build images

### DIFF
--- a/pkg/deb/Dockerfile
+++ b/pkg/deb/Dockerfile
@@ -19,7 +19,7 @@
 
 # Build pulsar client library in Centos with tools to
 
-FROM debian:11
+FROM debian:12
 
 ARG PLATFORM
 

--- a/pkg/rpm/Dockerfile
+++ b/pkg/rpm/Dockerfile
@@ -23,9 +23,14 @@ FROM rockylinux:8
 
 ARG PLATFORM
 
+# gcc-toolset-12 supplies GCC 12 for the C++20 scalable-topics code (concepts,
+# coroutines, `using enum`) while keeping the el8 / glibc 2.28 ABI, so the produced
+# RPM still runs on RHEL/Rocky/CentOS 8. It is enabled in the spec %build via
+# `source /opt/rh/gcc-toolset-12/enable`.
 RUN yum update -y && \
     yum install -y \
         gcc-c++ \
+        gcc-toolset-12 \
         make \
         rpm-build \
         which \

--- a/pkg/rpm/SPECS/pulsar-client.spec
+++ b/pkg/rpm/SPECS/pulsar-client.spec
@@ -53,6 +53,10 @@ static library.
 %setup -q -n apache-pulsar-client-cpp-%{pom_version}
 
 %build
+# Build with GCC 12 from gcc-toolset-12 (installed in the build image) for C++20
+# support, while keeping the el8 ABI. Sets PATH/LD_LIBRARY_PATH to the toolset for
+# the cmake build below.
+source /opt/rh/gcc-toolset-12/enable
 git clone https://github.com/microsoft/vcpkg.git
 cmake -B build -DINTEGRATE_VCPKG=ON -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_TESTS=OFF -DBUILD_DYNAMIC_LIB=ON -DBUILD_STATIC_LIB=ON


### PR DESCRIPTION
### Why

The scalable-topics SDK (`pulsar::st`, [#598](https://github.com/apache/pulsar-client-cpp/pull/598)) targets **C++20** — it uses concepts, coroutine-awaitable `Future<T>`, and `using enum`. The last of these needs **GCC 11+**. The package-build images shipped older compilers, so two package jobs failed compiling the C++20 examples:

- **RPM** — `rockylinux:8` ships **GCC 8.5**, which has no `-std=c++20` (CMake falls back to `-std=c++2a`, `__cplusplus=201709`), so the `Cxx20.h` guard `#error`s.
- **Deb** — `debian:11` ships **GCC 10**, which clears the guard but lacks `using enum` (a GCC 11 feature), so it fails to compile `Error.h`.

This bumps the package-build toolchains to GCC 11+ while preserving distro compatibility where it matters.

### What changed

| Image | Before | After | Min OS for the artifact |
|---|---|---|---|
| **deb** | `debian:11` (GCC 10) | **`debian:12`** (GCC 12) | Debian 12 / glibc 2.36 |
| **rpm** | `rockylinux:8` (GCC 8.5) | **`rockylinux:8` + `gcc-toolset-12`** (GCC 12) | **unchanged — RHEL/Rocky/CentOS 8** |
| **apk** | `alpine:3.19` (GCC 13) | unchanged | — |

For the **RPM** I deliberately kept the el8 base so the published RPM still runs on RHEL/Rocky/CentOS 8 (glibc 2.28). `gcc-toolset-12` provides GCC 12 against the el8 ABI; it's enabled in the spec `%build` with `source /opt/rh/gcc-toolset-12/enable`, and ships its own static `libstdc++` for the static `libpulsar.a`. The Debian image had no equivalent (bullseye can't install GCC 11+ from its repos), so it moves to `debian:12` — i.e. the **deb artifact now requires Debian 12+**, while the **RPM keeps el8 support**.

### Verification

Done locally against the real toolchains, not just a syntax check:

- Built **both** images from the updated Dockerfiles — all packages resolve on the new bases; `gcc-toolset-12` installs alongside the el8 `powertools`/`devel` repos.
- Compiled all four `pulsar::st` examples with `-std=c++20 -Wextra -Werror` under **debian:12 (GCC 12.2.0)** and **gcc-toolset-12 on rockylinux:8 (GCC 12.2.1)** — all pass.
- Confirmed `. /opt/rh/gcc-toolset-12/enable` works under `/bin/sh` (what rpmbuild's `%build` uses) and that the toolset provides a static `libstdc++.a` for `-static-libstdc++`.

### Notes

- This is the prerequisite that unblocks the package-build jobs on [#598](https://github.com/apache/pulsar-client-cpp/pull/598). The library itself remains C++17; only the new `pulsar::st` code requires C++20.
- `apk`/Alpine already ships GCC 13, so it needed no change.
