### PR TITLE
[fix][ci] Update docker/build-push-action to ASF allowlisted version

### DIFF
--- a/.github/workflows/ci-build-binary-artifacts.yaml
+++ b/.github/workflows/ci-build-binary-artifacts.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Build dependencies Docker image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./pkg/${{matrix.pkg.type}}
           load: true

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -403,7 +403,7 @@ jobs:
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Build dependencies Docker image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./pkg/${{matrix.pkg.type}}
           load: true


### PR DESCRIPTION

Related: https://github.com/apache/infrastructure-actions/commit/062f6aa187bf0f80dbd7fd98772a6c726b1fd214
Related: https://github.com/apache/infrastructure-actions/pull/994
Related: https://github.com/apache/spark/pull/54935

### Motivation

The `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` (v7.0.0) used in our CI workflows was removed from the ASF GitHub Actions allowlist on 2026-07-07 by the automated `remove_expired.yml` workflow ([commit](https://github.com/apache/infrastructure-actions/commit/062f6aa187bf0f80dbd7fd98772a6c726b1fd214)), causing all Docker-related CI jobs to fail with:

> The action docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 is not allowed in apache/pulsar-client-cpp because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns...

This is the same class of issue that Apache Spark encountered and fixed in https://github.com/apache/spark/pull/54935.

### Modifications

Updated `docker/build-push-action` in:
- `.github/workflows/ci-pr-validation.yaml`
- `.github/workflows/ci-build-binary-artifacts.yaml`

**Version mapping (SHA → tag):**

| SHA | Tag | Status |
|-----|-----|--------|
| `d08e5c354a6adb9ed34480a06d141179aa583294` (old) | v7.0.0 | ❌ expired from allowlist on 2026-07-07 |
| `bcafcacb16a39f128d818304e6c9c0c18556b85f` | v7.1.0 | ✅ in allowlist (used by Apache Spark) |
| `ca052bb54ab0790a636c9b5f226502c73d547a25` | v7.2.0 | ✅ in allowlist |
| `f9f3042f7e2789586610d6e8b85c8f03e5195baf` | v7.2.0 | ✅ in allowlist |
| `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` (new) | **v7.3.0** | ✅ in allowlist ([PR #994](https://github.com/apache/infrastructure-actions/pull/994)) |

**Why v7.3.0 instead of v7.1.0 (Spark's choice)?**

Apache Spark updated to v7.1.0 (`bcafcacb...`) back in March 2026. Since then, the ASF `approved_patterns.yml` has added newer versions. We chose v7.3.0 (`53b7df96...`) because:
1. It is the latest version in the [ASF approved patterns](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml) allowlist.
2. It is also the current `v7` floating tag target in the `docker/build-push-action` repository, meaning it includes the latest bug fixes and dependency updates.
3. Using the newest allowlisted version reduces the chance of needing another update soon if older SHAs are pruned from the allowlist.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `doc-not-needed`
(CI infrastructure fix only, no user-facing changes.)
