### PR TITLE
[improve][ci] Upgrade GitHub Actions to latest and ASF-approved revisions

### DIFF
--- a/.github/workflows/ci-build-binary-artifacts.yaml
+++ b/.github/workflows/ci-build-binary-artifacts.yaml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Restore vcpkg binary cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/vcpkg/archives
           key: vcpkg-linux-${{matrix.pkg.type}}-${{matrix.cpu.platform}}-${{hashFiles('vcpkg.json')}}
@@ -60,10 +60,10 @@ jobs:
       - name: Package Pulsar source
         run: build-support/generate-source-archive.sh
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build dependencies Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./pkg/${{matrix.pkg.type}}
           load: true
@@ -80,7 +80,7 @@ jobs:
         run: zip -r ${{matrix.pkg.type}}-${{matrix.cpu.platform}}.zip ${{matrix.pkg.path}}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.pkg.type}}-${{matrix.cpu.platform}}
           path: ${{matrix.pkg.path}}
@@ -111,10 +111,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         id: vcpkg-cache
         with:
           path: |
@@ -166,7 +166,7 @@ jobs:
         run: 7z a -tzip pulsar-client-cpp-${{ matrix.triplet }}.zip ${{ env.INSTALL_DIR }}/*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.triplet }}
           path: ${{ env.INSTALL_DIR }}
@@ -194,7 +194,7 @@ jobs:
         run: 7z a -tzip pulsar-client-cpp-${{ matrix.triplet }}-Debug.zip ${{ env.INSTALL_DIR }}-Debug/*
 
       - name: Upload artifacts (Debug)
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.triplet }}-Debug
           path: ${{ env.INSTALL_DIR }}-Debug
@@ -211,13 +211,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Restore vcpkg binary cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/Library/Caches/vcpkg/archives
           key: vcpkg-macos-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
@@ -236,7 +236,7 @@ jobs:
           cp macos-${{ matrix.arch }}.zip ../../../
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v7
         with:
           name: macos-${{ matrix.arch }}.zip
           path: macos-${{ matrix.arch }}.zip

--- a/.github/workflows/ci-pr-validation.yaml
+++ b/.github/workflows/ci-pr-validation.yaml
@@ -33,9 +33,9 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.11.0
+      uses: jidicula/clang-format-action@v4.18.0
       with:
         clang-format-version: '11'
         exclude-regex: '.*\.(proto|hpp)'
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Install deps (Ubuntu)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -85,13 +85,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Restore vcpkg installed cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: vcpkg-cache
         if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'
         with:
@@ -100,7 +100,7 @@ jobs:
           restore-keys: vcpkg-${{ runner.os }}-
 
       - name: Restore vcpkg downloads cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: vcpkg/downloads
           key: vcpkg-downloads-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
@@ -136,13 +136,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Restore vcpkg installed cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: vcpkg-cache
         if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'
         with:
@@ -153,7 +153,7 @@ jobs:
           restore-keys: vcpkg-${{ runner.os }}-
 
       - name: Restore vcpkg downloads cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: vcpkg/downloads
           key: vcpkg-downloads-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
@@ -218,7 +218,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Install deps
         run: |
           sudo apt-get update -y
@@ -259,12 +259,12 @@ jobs:
             arch: '-A Win32'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: vcpkg-cache
         if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'
         with:
@@ -392,18 +392,18 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Package Pulsar source
         run: build-support/generate-source-archive.sh
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build dependencies Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./pkg/${{matrix.pkg.type}}
           load: true
@@ -425,13 +425,13 @@ jobs:
     needs: lint
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Restore vcpkg installed cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: vcpkg-cache
         if: always() && steps.vcpkg-cache.outputs.cache-hit != 'true'
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,14 +43,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         submodules: recursive
 
       # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
@@ -68,6 +68,6 @@ jobs:
         cmake --build . -j8
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
### Motivation

Two Docker actions in our workflows are pinned to SHAs that are **not on the ASF org-wide allowlist**:

| action | pinned SHA | on allowlist? |
|---|---|---|
| `docker/setup-buildx-action` | `4d04d5d9` | ❌ no |
| `docker/setup-qemu-action` | `ce360397` | ❌ no |
| `docker/build-push-action` | `53b7df96` | ✅ yes (v7.3.0, current) |

When a workflow references an action that is not allowlisted, the run fails with a bare **"Startup failure"** — [per ASF infra](https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md): *"no logs, no notifications, and the PR may appear green because no checks ran."*

That is not hypothetical. #605 hit it: its `PR validation` run never started, so the build and unit tests did not execute on that head, while `CodeQL` and `Analyze (cpp)` still reported success — the PR looked green with its actual test suite never having run.

### Modifications

**ASF-allowlisted third-party actions** — bumped to the latest approved revisions from [`apache/infrastructure-actions/actions.yml`](https://github.com/apache/infrastructure-actions/blob/main/actions.yml), with the tag in a trailing comment so Dependabot can track them (the [recommended, Zizmor-friendly form](https://github.com/apache/infrastructure-actions#versioning-and-pinning-actions)):

- `docker/setup-buildx-action` → `37fe6310` &nbsp;`# v4.3.0`
- `docker/setup-qemu-action` → `96fe6ef7` &nbsp;`# v4.2.0`
- `docker/build-push-action` → unchanged SHA, comment added `# v7.3.0`
- `jidicula/clang-format-action` `v4.11.0` → `v4.18.0` (allowlisted via a `@*` wildcard)

**GitHub-owned actions** — the allowlist [implicitly trusts](https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md) `actions/*` and `github/*`, so these move to their latest majors:

- `actions/checkout` `v3`, `v4` → `v7` (12 call sites)
- `actions/cache` `v3`, `v4` → `v6` (9 call sites)
- `actions/upload-artifact` `master` → `v7` (4 call sites)
- `github/codeql-action/{init,analyze}` `v3` → `v4`

`actions/upload-artifact` was tracking `@master` — an unpinned moving target that could change under us at any time.

### Verifying this change

The diff touches only `uses:` lines; no workflow logic changed. Verified locally:

- every non-GitHub-owned `uses:` ref now matches an entry in [`approved_patterns.yml`](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml), applying the same rules as `apache/infrastructure-actions/allowlist-check`
- all three workflow files still parse as YAML
- all four `upload-artifact` call sites already use unique, matrix-derived artifact names, so the v4+ "one upload per artifact name" restriction is satisfied

The real verification is this PR's own CI: if `PR validation` starts and runs to completion, the allowlist problem is fixed.

### Follow-up worth considering

Adding the [`apache/infrastructure-actions/allowlist-check`](https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md) job to CI would catch this class of breakage at PR time instead of letting it surface as a silent startup failure. Left out here to keep this change to version bumps.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): **yes** (CI actions only; no change to the shipped client library)

### Documentation
- [x] `doc-not-needed`