### PR TITLE
Fix flaky ConnectionFailTest: restore fd limit in SetUp

### DIFF
--- a/tests/unix/ConnectionFailTest.cc
+++ b/tests/unix/ConnectionFailTest.cc
@@ -31,6 +31,10 @@ class ConnectionFailTest : public ::testing::TestWithParam<int> {
         struct rlimit limit;
         ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &limit), 0);
         maxFdCount_ = limit.rlim_max;
+        // The previous test leaves the soft fd limit lowered, which could make the HTTP request below fail
+        // to open a socket. Restore it before creating the topic.
+        limit.rlim_cur = limit.rlim_max;
+        ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &limit), 0);
         int numPartitions = GetParam();
         topic_ = "test-connection-fail-" + std::to_string(numPartitions) + std::to_string(time(nullptr));
         if (numPartitions > 0) {


### PR DESCRIPTION
### Motivation

`ConnectionFailTest` fails intermittently in CI, e.g. https://github.com/apache/pulsar-client-cpp/actions/runs/33217535403/job/99014404956:

```
[ RUN      ] Unix/ConnectionFailTest.test/1
tests/unix/ConnectionFailTest.cc:40: Failure
Value of: res == 204 || res == 409
  Actual: false
Expected: true
res: -1
```

The test lowers the process soft fd limit (`RLIMIT_NOFILE`) in a loop and never restores it, so a test leaves the limit as low as ~8 for the next one (the failing run's `test/0` ended with `Updated fd limit to 8`). The next test's `SetUp()` then makes an HTTP request to create the partitioned topic, and curl can intermittently fail to open a socket (`res: -1`) when the previous client's async connection teardown still holds file descriptors. Since `run-unit-tests.sh` runs this suite with `--gtest_repeat=20` and no retry, a single flake fails the job.

### Modifications

Restore the soft fd limit to the hard limit in `SetUp()` before making the HTTP request.